### PR TITLE
fix: make order number generation concurrency-safe

### DIFF
--- a/src/routes/orders/orders.service.spec.ts
+++ b/src/routes/orders/orders.service.spec.ts
@@ -283,6 +283,53 @@ describe('OrdersService', () => {
         'Product product-001 not found',
       );
     });
+
+    it('should retry on duplicate order number and succeed', async () => {
+      const duplicateError = Object.assign(new Error('duplicate key'), {
+        code: '23505',
+      });
+      clientsService.existsById.mockResolvedValue(true);
+      productsService.existsById.mockResolvedValue(true);
+      orderRepository.countByPrefix.mockResolvedValue(0);
+      orderRepository.create
+        .mockRejectedValueOnce(duplicateError)
+        .mockResolvedValueOnce({ ...mockOrder, id: 'new-order' });
+      orderItemRepository.createMany.mockResolvedValue([mockOrderItem]);
+      orderRepository.findById.mockResolvedValue(mockOrderWithItems);
+
+      const result = await service.create(createDto, 'user-001');
+
+      expect(result.id).toBe('order-001');
+      expect(orderRepository.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw after exhausting retries on duplicate order number', async () => {
+      const duplicateError = Object.assign(new Error('duplicate key'), {
+        code: '23505',
+      });
+      clientsService.existsById.mockResolvedValue(true);
+      productsService.existsById.mockResolvedValue(true);
+      orderRepository.countByPrefix.mockResolvedValue(0);
+      orderRepository.create.mockRejectedValue(duplicateError);
+
+      await expect(service.create(createDto, 'user-001')).rejects.toThrow(
+        duplicateError,
+      );
+      expect(orderRepository.create).toHaveBeenCalledTimes(4);
+    });
+
+    it('should not retry on non-duplicate errors', async () => {
+      const otherError = new Error('connection lost');
+      clientsService.existsById.mockResolvedValue(true);
+      productsService.existsById.mockResolvedValue(true);
+      orderRepository.countByPrefix.mockResolvedValue(0);
+      orderRepository.create.mockRejectedValue(otherError);
+
+      await expect(service.create(createDto, 'user-001')).rejects.toThrow(
+        'connection lost',
+      );
+      expect(orderRepository.create).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('updateStatus', () => {

--- a/src/routes/orders/orders.service.ts
+++ b/src/routes/orders/orders.service.ts
@@ -81,10 +81,7 @@ export class OrdersService {
       0,
     );
 
-    const order_number = await this.generateOrderNumber();
-
-    const order = await this.orderRepository.create({
-      order_number,
+    const order = await this.createOrderWithUniqueNumber({
       client_id: dto.client_id,
       delivery_address: dto.delivery_address,
       delivery_deadline: dto.delivery_deadline
@@ -109,6 +106,27 @@ export class OrdersService {
 
     const orderWithRelations = await this.orderRepository.findById(order.id);
     return this.toResponseDto(orderWithRelations!);
+  }
+
+  private async createOrderWithUniqueNumber(
+    data: Partial<Order>,
+    maxRetries = 3,
+  ): Promise<Order> {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const order_number = await this.generateOrderNumber();
+      try {
+        return await this.orderRepository.create({ ...data, order_number });
+      } catch (error: unknown) {
+        const isUniqueViolation =
+          error instanceof Error &&
+          'code' in error &&
+          (error as { code: string }).code === '23505';
+        if (!isUniqueViolation || attempt === maxRetries) {
+          throw error;
+        }
+      }
+    }
+    throw new BadRequestException('Failed to generate unique order number');
   }
 
   async update(


### PR DESCRIPTION
## Summary

- The `generateOrderNumber()` method existed (issue #1 described it as missing — that was stale), but had a **race condition**: concurrent requests could generate duplicate order numbers via non-atomic `countByPrefix()` + increment
- Extracted order creation into `createOrderWithUniqueNumber()` which retries on PostgreSQL unique constraint violations (`23505`), up to 3 retries
- Non-duplicate DB errors propagate immediately without retry

## Test plan

- [x] Existing 24 order service tests still pass
- [x] New test: retry succeeds on second attempt after duplicate key
- [x] New test: throws after exhausting all retries (4 total attempts)
- [x] New test: non-duplicate errors are not retried

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)