### PR TITLE
refactor(users): normalize response dto field naming to snake_case (meta#6.1)

### DIFF
--- a/src/common/pipes/zod-validation.pipe.spec.ts
+++ b/src/common/pipes/zod-validation.pipe.spec.ts
@@ -1,0 +1,45 @@
+import { BadRequestException } from '@nestjs/common';
+import { ErrorCode } from '@librestock/types/common'
+import { ZodValidationPipe } from './zod-validation.pipe';
+
+describe('ZodValidationPipe', () => {
+  it('returns parsed data when schema validation succeeds', () => {
+    const pipe = new ZodValidationPipe<{ name: string }>({
+      safeParse: (value) => ({
+        success: true,
+        data: value as { name: string },
+      }),
+    });
+
+    expect(pipe.transform({ name: 'Marine Pump' })).toEqual({
+      name: 'Marine Pump',
+    });
+  });
+
+  it('throws BadRequestException with issues when schema validation fails', () => {
+    const issues = [
+      {
+        path: ['name'],
+        message: 'Required',
+      },
+    ];
+
+    const pipe = new ZodValidationPipe<{ name: string }>({
+      safeParse: () => ({
+        success: false,
+        error: { issues },
+      }),
+    });
+
+    try {
+      pipe.transform({});
+      fail('Expected pipe to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BadRequestException);
+      const response = (error as BadRequestException).getResponse() as Record<string, unknown>;
+      expect(response.code).toBe(ErrorCode.BAD_REQUEST);
+      expect(response.message).toBe('Validation failed');
+      expect(response.errors).toEqual(issues);
+    }
+  });
+});

--- a/src/common/pipes/zod-validation.pipe.ts
+++ b/src/common/pipes/zod-validation.pipe.ts
@@ -1,0 +1,35 @@
+import { BadRequestException, type PipeTransform } from '@nestjs/common';
+import { ErrorCode } from '@librestock/types/common'
+
+interface SafeParseSuccess<T> {
+  success: true;
+  data: T;
+}
+
+interface SafeParseFailure {
+  success: false;
+  error: {
+    issues: unknown[];
+  };
+}
+
+interface ZodLikeSchema<T> {
+  safeParse(value: unknown): SafeParseSuccess<T> | SafeParseFailure;
+}
+
+export class ZodValidationPipe<T> implements PipeTransform<unknown, T> {
+  constructor(private readonly schema: ZodLikeSchema<T>) {}
+
+  transform(value: unknown): T {
+    const result = this.schema.safeParse(value);
+    if (!result.success) {
+      throw new BadRequestException({
+        code: ErrorCode.BAD_REQUEST,
+        message: 'Validation failed',
+        errors: result.error.issues,
+      });
+    }
+
+    return result.data;
+  }
+}

--- a/src/migrations/1772918000000-AddFineGrainedStockResources.ts
+++ b/src/migrations/1772918000000-AddFineGrainedStockResources.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFineGrainedStockResources1772918000000
+implements MigrationInterface {
+    name = 'AddFineGrainedStockResources1772918000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+          INSERT INTO "role_permissions" ("role_id", "resource", "permission")
+          SELECT rp."role_id", target."resource", rp."permission"
+          FROM "role_permissions" rp
+          CROSS JOIN (
+            VALUES
+              ('orders'),
+              ('clients'),
+              ('suppliers'),
+              ('stockMovements')
+          ) AS target("resource")
+          WHERE rp."resource" = 'stock'
+          ON CONFLICT ("role_id", "resource", "permission") DO NOTHING
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+          DELETE FROM "role_permissions" target
+          USING "role_permissions" stock
+          WHERE stock."resource" = 'stock'
+            AND target."role_id" = stock."role_id"
+            AND target."permission" = stock."permission"
+            AND target."resource" IN ('orders', 'clients', 'suppliers', 'stockMovements')
+        `);
+    }
+
+}

--- a/src/routes/clients/clients.controller.ts
+++ b/src/routes/clients/clients.controller.ts
@@ -42,7 +42,7 @@ import { ClientHateoas, DeleteClientHateoas } from './clients.hateoas';
 @ApiBearerAuth()
 @StandardThrottle()
 @UseGuards(PermissionGuard)
-@RequirePermission(Resource.STOCK, Permission.READ)
+@RequirePermission(Resource.CLIENTS, Permission.READ)
 @Controller()
 export class ClientsController {
   constructor(private readonly clientsService: ClientsService) {}
@@ -78,7 +78,7 @@ export class ClientsController {
   }
 
   @Post()
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.CLIENTS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @ClientHateoas()
   @Auditable({
@@ -98,7 +98,7 @@ export class ClientsController {
   }
 
   @Put(':id')
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.CLIENTS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @ClientHateoas()
   @Auditable({
@@ -121,7 +121,7 @@ export class ClientsController {
   }
 
   @Delete(':id')
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.CLIENTS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @DeleteClientHateoas()
   @Auditable({

--- a/src/routes/inventory/dto/create-inventory.dto.ts
+++ b/src/routes/inventory/dto/create-inventory.dto.ts
@@ -9,6 +9,7 @@ import {
   Min,
   MaxLength,
 } from 'class-validator';
+import type { AreaId, LocationId, ProductId } from '@librestock/types/common'
 import type { CreateInventoryDto as CreateInventoryDtoShape } from '@librestock/types/inventory'
 
 export class CreateInventoryDto implements CreateInventoryDtoShape {
@@ -17,14 +18,14 @@ export class CreateInventoryDto implements CreateInventoryDtoShape {
     format: 'uuid',
   })
   @IsUUID()
-  product_id: string;
+  product_id: ProductId;
 
   @ApiProperty({
     description: 'Location ID',
     format: 'uuid',
   })
   @IsUUID()
-  location_id: string;
+  location_id: LocationId;
 
   @ApiProperty({
     description: 'Area ID (optional, specific placement within location)',
@@ -34,7 +35,7 @@ export class CreateInventoryDto implements CreateInventoryDtoShape {
   })
   @IsOptional()
   @IsUUID()
-  area_id?: string | null;
+  area_id?: AreaId | null;
 
   @ApiProperty({
     description: 'Quantity in stock',

--- a/src/routes/inventory/dto/inventory-response.dto.ts
+++ b/src/routes/inventory/dto/inventory-response.dto.ts
@@ -1,10 +1,21 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { AreaSummaryDto as AreaSummaryDtoShape, InventoryResponseDto as InventoryResponseDtoShape, LocationSummaryDto as LocationSummaryDtoShape, ProductSummaryDto as ProductSummaryDtoShape } from '@librestock/types/inventory'
+import type {
+  AreaId,
+  InventoryId,
+  LocationId,
+  ProductId,
+} from '@librestock/types/common'
+import type {
+  AreaSummaryDto as AreaSummaryDtoShape,
+  InventoryResponseDto as InventoryResponseDtoShape,
+  LocationSummaryDto as LocationSummaryDtoShape,
+  ProductSummaryDto as ProductSummaryDtoShape,
+} from '@librestock/types/inventory'
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
 export class ProductSummaryDto implements ProductSummaryDtoShape {
   @ApiProperty({ description: 'Product ID', format: 'uuid' })
-  id: string;
+  id: ProductId;
 
   @ApiProperty({ description: 'Product SKU' })
   sku: string;
@@ -18,7 +29,7 @@ export class ProductSummaryDto implements ProductSummaryDtoShape {
 
 export class LocationSummaryDto implements LocationSummaryDtoShape {
   @ApiProperty({ description: 'Location ID', format: 'uuid' })
-  id: string;
+  id: LocationId;
 
   @ApiProperty({ description: 'Location name' })
   name: string;
@@ -29,7 +40,7 @@ export class LocationSummaryDto implements LocationSummaryDtoShape {
 
 export class AreaSummaryDto implements AreaSummaryDtoShape {
   @ApiProperty({ description: 'Area ID', format: 'uuid' })
-  id: string;
+  id: AreaId;
 
   @ApiProperty({ description: 'Area name' })
   name: string;
@@ -47,13 +58,13 @@ export class InventoryResponseDto
     format: 'uuid',
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
-  id: string;
+  id: InventoryId;
 
   @ApiProperty({
     description: 'Product ID',
     format: 'uuid',
   })
-  product_id: string;
+  product_id: ProductId;
 
   @ApiProperty({
     description: 'Product details',
@@ -66,7 +77,7 @@ export class InventoryResponseDto
     description: 'Location ID',
     format: 'uuid',
   })
-  location_id: string;
+  location_id: LocationId;
 
   @ApiProperty({
     description: 'Location details',
@@ -80,7 +91,7 @@ export class InventoryResponseDto
     format: 'uuid',
     nullable: true,
   })
-  area_id: string | null;
+  area_id: AreaId | null;
 
   @ApiProperty({
     description: 'Area details',

--- a/src/routes/inventory/dto/update-inventory.dto.ts
+++ b/src/routes/inventory/dto/update-inventory.dto.ts
@@ -9,6 +9,7 @@ import {
   Min,
   MaxLength,
 } from 'class-validator';
+import type { AreaId, LocationId } from '@librestock/types/common'
 import type { UpdateInventoryDto as UpdateInventoryDtoShape } from '@librestock/types/inventory'
 
 export class UpdateInventoryDto implements UpdateInventoryDtoShape {
@@ -19,7 +20,7 @@ export class UpdateInventoryDto implements UpdateInventoryDtoShape {
   })
   @IsOptional()
   @IsUUID()
-  location_id?: string;
+  location_id?: LocationId;
 
   @ApiProperty({
     description: 'Area ID (optional, specific placement within location)',
@@ -29,7 +30,7 @@ export class UpdateInventoryDto implements UpdateInventoryDtoShape {
   })
   @IsOptional()
   @IsUUID()
-  area_id?: string | null;
+  area_id?: AreaId | null;
 
   @ApiProperty({
     description: 'Quantity in stock',

--- a/src/routes/inventory/inventory.utils.ts
+++ b/src/routes/inventory/inventory.utils.ts
@@ -1,32 +1,38 @@
 import type { InventoryResponseDto } from './dto';
 import type { Inventory } from './entities/inventory.entity';
+import {
+  asAreaId,
+  asInventoryId,
+  asLocationId,
+  asProductId,
+} from '@librestock/types/common'
 
 export function toInventoryResponseDto(
   inventory: Inventory,
 ): InventoryResponseDto {
   return {
-    id: inventory.id,
-    product_id: inventory.product_id,
+    id: asInventoryId(inventory.id),
+    product_id: asProductId(inventory.product_id),
     product: inventory.product
       ? {
-          id: inventory.product.id,
+          id: asProductId(inventory.product.id),
           sku: inventory.product.sku,
           name: inventory.product.name,
           unit: inventory.product.unit,
         }
       : null,
-    location_id: inventory.location_id,
+    location_id: asLocationId(inventory.location_id),
     location: inventory.location
       ? {
-          id: inventory.location.id,
+          id: asLocationId(inventory.location.id),
           name: inventory.location.name,
           type: inventory.location.type,
         }
       : null,
-    area_id: inventory.area_id,
+    area_id: inventory.area_id ? asAreaId(inventory.area_id) : null,
     area: inventory.area
       ? {
-          id: inventory.area.id,
+          id: asAreaId(inventory.area.id),
           name: inventory.area.name,
           code: inventory.area.code,
         }

--- a/src/routes/orders/dto/create-order.dto.ts
+++ b/src/routes/orders/dto/create-order.dto.ts
@@ -13,12 +13,16 @@ import {
   IsDateString,
 } from 'class-validator';
 import { Type, Transform } from 'class-transformer';
-import type { CreateOrderType as CreateOrderTypeShape, CreateOrderItemType as CreateOrderItemTypeShape } from '@librestock/types/orders'
+import type { ClientId, ProductId } from '@librestock/types/common'
+import type {
+  CreateOrderItemType as CreateOrderItemTypeShape,
+  CreateOrderType as CreateOrderTypeShape,
+} from '@librestock/types/orders'
 
 export class CreateOrderItemDto implements CreateOrderItemTypeShape {
   @ApiProperty({ description: 'Product ID', format: 'uuid' })
   @IsUUID()
-  product_id: string;
+  product_id: ProductId;
 
   @ApiProperty({ description: 'Quantity ordered', minimum: 1 })
   @IsInt()
@@ -39,7 +43,7 @@ export class CreateOrderItemDto implements CreateOrderItemTypeShape {
 export class CreateOrderDto implements CreateOrderTypeShape {
   @ApiProperty({ description: 'Client ID', format: 'uuid' })
   @IsUUID()
-  client_id: string;
+  client_id: ClientId;
 
   @ApiProperty({ description: 'Delivery address' })
   @IsString()

--- a/src/routes/orders/dto/order-query.dto.ts
+++ b/src/routes/orders/dto/order-query.dto.ts
@@ -10,6 +10,7 @@ import {
   Max,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
+import type { ClientId } from '@librestock/types/common'
 import { OrderStatus } from '@librestock/types/orders'
 import type { OrderQueryType as OrderQueryTypeShape } from '@librestock/types/orders'
 
@@ -56,7 +57,7 @@ export class OrderQueryDto implements OrderQueryTypeShape {
   })
   @IsOptional()
   @IsUUID()
-  client_id?: string;
+  client_id?: ClientId;
 
   @ApiProperty({
     description: 'Filter by order status',

--- a/src/routes/orders/dto/order-response.dto.ts
+++ b/src/routes/orders/dto/order-response.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { OrderStatus, type OrderResponseType as OrderResponseTypeShape, type OrderItemResponseType as OrderItemResponseTypeShape } from '@librestock/types/orders'
+import { OrderStatus, type OrderResponseDto as OrderResponseDtoShape, type OrderItemResponseDto as OrderItemResponseDtoShape } from '@librestock/types/orders'
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
 export class OrderItemResponseDto
   extends BaseResponseDto
-  implements OrderItemResponseTypeShape
+  implements OrderItemResponseDtoShape
 {
   @ApiProperty({ description: 'Unique identifier', format: 'uuid' })
   id: string;
@@ -39,7 +39,7 @@ export class OrderItemResponseDto
 
 export class OrderResponseDto
   extends BaseResponseDto
-  implements OrderResponseTypeShape
+  implements OrderResponseDtoShape
 {
   @ApiProperty({ description: 'Unique identifier', format: 'uuid' })
   id: string;

--- a/src/routes/orders/dto/order-response.dto.ts
+++ b/src/routes/orders/dto/order-response.dto.ts
@@ -1,4 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
+import type {
+  ClientId,
+  OrderId,
+  OrderItemId,
+  ProductId,
+  UserId,
+} from '@librestock/types/common'
 import { OrderStatus, type OrderResponseDto as OrderResponseDtoShape, type OrderItemResponseDto as OrderItemResponseDtoShape } from '@librestock/types/orders'
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
@@ -7,10 +14,10 @@ export class OrderItemResponseDto
   implements OrderItemResponseDtoShape
 {
   @ApiProperty({ description: 'Unique identifier', format: 'uuid' })
-  id: string;
+  id: OrderItemId;
 
   @ApiProperty({ description: 'Product ID', format: 'uuid' })
-  product_id: string;
+  product_id: ProductId;
 
   @ApiProperty({ description: 'Product name', nullable: true })
   product_name: string | null;
@@ -42,13 +49,13 @@ export class OrderResponseDto
   implements OrderResponseDtoShape
 {
   @ApiProperty({ description: 'Unique identifier', format: 'uuid' })
-  id: string;
+  id: OrderId;
 
   @ApiProperty({ description: 'Order number' })
   order_number: string;
 
   @ApiProperty({ description: 'Client ID', format: 'uuid' })
-  client_id: string;
+  client_id: ClientId;
 
   @ApiProperty({ description: 'Client company name', nullable: true })
   client_name: string | null;
@@ -76,10 +83,10 @@ export class OrderResponseDto
     format: 'uuid',
     nullable: true,
   })
-  assigned_to: string | null;
+  assigned_to: UserId | null;
 
   @ApiProperty({ description: 'User ID who created the order', format: 'uuid' })
-  created_by: string;
+  created_by: UserId;
 
   @ApiProperty({ description: 'Confirmed timestamp', nullable: true })
   confirmed_at: Date | null;

--- a/src/routes/orders/dto/update-order.dto.ts
+++ b/src/routes/orders/dto/update-order.dto.ts
@@ -7,6 +7,7 @@ import {
   IsDateString,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
+import type { UserId } from '@librestock/types/common'
 import type { UpdateOrderType as UpdateOrderTypeShape } from '@librestock/types/orders'
 
 export class UpdateOrderDto implements UpdateOrderTypeShape {
@@ -43,5 +44,5 @@ export class UpdateOrderDto implements UpdateOrderTypeShape {
   })
   @IsOptional()
   @IsUUID()
-  assigned_to?: string;
+  assigned_to?: UserId;
 }

--- a/src/routes/orders/orders.controller.ts
+++ b/src/routes/orders/orders.controller.ts
@@ -50,7 +50,7 @@ import { OrderHateoas, DeleteOrderHateoas } from './orders.hateoas';
 @ApiBearerAuth()
 @StandardThrottle()
 @UseGuards(PermissionGuard)
-@RequirePermission(Resource.STOCK, Permission.READ)
+@RequirePermission(Resource.ORDERS, Permission.READ)
 @Controller()
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
@@ -86,7 +86,7 @@ export class OrdersController {
   }
 
   @Post()
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.ORDERS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @OrderHateoas()
   @Auditable({
@@ -107,7 +107,7 @@ export class OrdersController {
   }
 
   @Put(':id')
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.ORDERS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @OrderHateoas()
   @Auditable({
@@ -129,7 +129,7 @@ export class OrdersController {
   }
 
   @Patch(':id/status')
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.ORDERS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @OrderHateoas()
   @Auditable({
@@ -154,7 +154,7 @@ export class OrdersController {
   }
 
   @Delete(':id')
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.ORDERS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @DeleteOrderHateoas()
   @Auditable({

--- a/src/routes/orders/orders.utils.ts
+++ b/src/routes/orders/orders.utils.ts
@@ -1,11 +1,18 @@
 import type { OrderResponseDto, OrderItemResponseDto } from './dto';
 import type { Order } from './entities/order.entity';
 import type { OrderItem } from './entities/order-item.entity';
+import {
+  asClientId,
+  asEntityId,
+  asOrderId,
+  asProductId,
+  asUserId,
+} from '@librestock/types/common'
 
 export function toOrderItemResponseDto(item: OrderItem): OrderItemResponseDto {
   return {
-    id: item.id,
-    product_id: item.product_id,
+    id: asEntityId<'OrderItemId'>(item.id),
+    product_id: asProductId(item.product_id),
     product_name: item.product?.name ?? null,
     product_sku: item.product?.sku ?? null,
     quantity: item.quantity,
@@ -21,9 +28,9 @@ export function toOrderItemResponseDto(item: OrderItem): OrderItemResponseDto {
 
 export function toOrderResponseDto(order: Order): OrderResponseDto {
   return {
-    id: order.id,
+    id: asOrderId(order.id),
     order_number: order.order_number,
-    client_id: order.client_id,
+    client_id: asClientId(order.client_id),
     client_name: order.client?.company_name ?? null,
     status: order.status,
     delivery_address: order.delivery_address,
@@ -31,8 +38,8 @@ export function toOrderResponseDto(order: Order): OrderResponseDto {
     yacht_name: order.yacht_name,
     special_instructions: order.special_instructions,
     total_amount: Number(order.total_amount),
-    assigned_to: order.assigned_to,
-    created_by: order.created_by,
+    assigned_to: order.assigned_to ? asUserId(order.assigned_to) : null,
+    created_by: asUserId(order.created_by),
     confirmed_at: order.confirmed_at,
     shipped_at: order.shipped_at,
     delivered_at: order.delivered_at,

--- a/src/routes/products/products.controller.ts
+++ b/src/routes/products/products.controller.ts
@@ -22,6 +22,7 @@ import {
   ApiQuery,
 } from '@nestjs/swagger';
 import { Permission, Resource } from '@librestock/types/auth'
+import { CreateProductSchema, UpdateProductSchema } from '@librestock/types/products'
 import { RequirePermission } from '../../common/decorators';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { MessageResponseDto } from '../../common/dto/message-response.dto';
@@ -33,6 +34,7 @@ import {
 import { PermissionGuard } from '../../common/guards/permission.guard';
 import { HateoasInterceptor } from '../../common/hateoas/hateoas.interceptor';
 import { AuditInterceptor } from '../../common/interceptors/audit.interceptor';
+import { ZodValidationPipe } from '../../common/pipes/zod-validation.pipe';
 import { Auditable } from '../../common/decorators/auditable.decorator';
 import { AuditAction, AuditEntityType } from '../../common/enums';
 import { StandardThrottle, BulkThrottle } from '../../common/decorators/throttle.decorator';
@@ -167,7 +169,8 @@ export class ProductsController {
   @ApiResponse({ status: 400, type: ErrorResponseDto })
   @ApiResponse({ status: 401, type: ErrorResponseDto })
   async createProduct(
-    @Body() createProductDto: CreateProductDto,
+    @Body(new ZodValidationPipe(CreateProductSchema))
+    createProductDto: CreateProductDto,
     @Req() req: AuthRequest,
   ): Promise<ProductResponseDto> {
     const userId = getUserIdFromSession(getUserSession(req));
@@ -216,7 +219,8 @@ export class ProductsController {
   @ApiResponse({ status: 404, type: ErrorResponseDto })
   async updateProduct(
     @Param('id', ParseUUIDPipe) id: string,
-    @Body() updateProductDto: UpdateProductDto,
+    @Body(new ZodValidationPipe(UpdateProductSchema))
+    updateProductDto: UpdateProductDto,
     @Req() req: AuthRequest,
   ): Promise<ProductResponseDto> {
     const userId = getUserIdFromSession(getUserSession(req));

--- a/src/routes/roles/roles.service.ts
+++ b/src/routes/roles/roles.service.ts
@@ -165,6 +165,18 @@ export class RolesService {
   }
 
   async seed(): Promise<void> {
+    const stockScopedResources: readonly Resource[] = [
+      Resource.STOCK,
+      Resource.ORDERS,
+      Resource.CLIENTS,
+      Resource.SUPPLIERS,
+      Resource.STOCK_MOVEMENTS,
+    ];
+    const mapStockScopedPermissions = (
+      permission: Permission,
+    ): { resource: Resource; permission: Permission }[] =>
+      stockScopedResources.map((resource) => ({ resource, permission }));
+
     const seedRoles: {
       name: string;
       description: string;
@@ -175,8 +187,8 @@ export class RolesService {
         description: 'Full system access',
         permissions: [
           { resource: Resource.DASHBOARD, permission: Permission.READ },
-          { resource: Resource.STOCK, permission: Permission.READ },
-          { resource: Resource.STOCK, permission: Permission.WRITE },
+          ...mapStockScopedPermissions(Permission.READ),
+          ...mapStockScopedPermissions(Permission.WRITE),
           { resource: Resource.PRODUCTS, permission: Permission.READ },
           { resource: Resource.PRODUCTS, permission: Permission.WRITE },
           { resource: Resource.LOCATIONS, permission: Permission.READ },
@@ -197,8 +209,8 @@ export class RolesService {
         description: 'Manage warehouse operations',
         permissions: [
           { resource: Resource.DASHBOARD, permission: Permission.READ },
-          { resource: Resource.STOCK, permission: Permission.READ },
-          { resource: Resource.STOCK, permission: Permission.WRITE },
+          ...mapStockScopedPermissions(Permission.READ),
+          ...mapStockScopedPermissions(Permission.WRITE),
           { resource: Resource.PRODUCTS, permission: Permission.READ },
           { resource: Resource.PRODUCTS, permission: Permission.WRITE },
           { resource: Resource.LOCATIONS, permission: Permission.READ },
@@ -214,7 +226,7 @@ export class RolesService {
         description: 'Pick and manage inventory',
         permissions: [
           { resource: Resource.DASHBOARD, permission: Permission.READ },
-          { resource: Resource.STOCK, permission: Permission.READ },
+          ...mapStockScopedPermissions(Permission.READ),
           { resource: Resource.PRODUCTS, permission: Permission.READ },
           { resource: Resource.LOCATIONS, permission: Permission.READ },
           { resource: Resource.INVENTORY, permission: Permission.READ },
@@ -228,7 +240,7 @@ export class RolesService {
         description: 'View stock and products',
         permissions: [
           { resource: Resource.DASHBOARD, permission: Permission.READ },
-          { resource: Resource.STOCK, permission: Permission.READ },
+          ...mapStockScopedPermissions(Permission.READ),
           { resource: Resource.PRODUCTS, permission: Permission.READ },
           { resource: Resource.INVENTORY, permission: Permission.READ },
           { resource: Resource.SETTINGS, permission: Permission.READ },

--- a/src/routes/stock-movements/dto/create-stock-movement.dto.ts
+++ b/src/routes/stock-movements/dto/create-stock-movement.dto.ts
@@ -9,13 +9,14 @@ import {
   MaxLength,
   IsNumber,
 } from 'class-validator';
+import type { LocationId, OrderId, ProductId } from '@librestock/types/common'
 import type { CreateStockMovementDto as CreateStockMovementDtoShape } from '@librestock/types/stock-movements'
 import { StockMovementReason } from '@librestock/types/stock-movements'
 
 export class CreateStockMovementDto implements CreateStockMovementDtoShape {
   @ApiProperty({ description: 'Product ID', format: 'uuid' })
   @IsUUID()
-  product_id: string;
+  product_id: ProductId;
 
   @ApiProperty({
     description: 'Source location ID',
@@ -24,7 +25,7 @@ export class CreateStockMovementDto implements CreateStockMovementDtoShape {
   })
   @IsOptional()
   @IsUUID()
-  from_location_id?: string;
+  from_location_id?: LocationId;
 
   @ApiProperty({
     description: 'Destination location ID',
@@ -33,7 +34,7 @@ export class CreateStockMovementDto implements CreateStockMovementDtoShape {
   })
   @IsOptional()
   @IsUUID()
-  to_location_id?: string;
+  to_location_id?: LocationId;
 
   @ApiProperty({ description: 'Quantity to move', minimum: 1 })
   @IsInt()
@@ -54,7 +55,7 @@ export class CreateStockMovementDto implements CreateStockMovementDtoShape {
   })
   @IsOptional()
   @IsUUID()
-  order_id?: string;
+  order_id?: OrderId;
 
   @ApiProperty({
     description: 'Reference number',

--- a/src/routes/stock-movements/dto/stock-movement-query.dto.ts
+++ b/src/routes/stock-movements/dto/stock-movement-query.dto.ts
@@ -9,6 +9,7 @@ import {
   Max,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import type { LocationId, ProductId } from '@librestock/types/common'
 import { StockMovementReason, type StockMovementQueryDto as StockMovementQueryDtoShape } from '@librestock/types/stock-movements'
 
 export class StockMovementQueryDto implements StockMovementQueryDtoShape {
@@ -45,7 +46,7 @@ export class StockMovementQueryDto implements StockMovementQueryDtoShape {
   })
   @IsOptional()
   @IsUUID()
-  product_id?: string;
+  product_id?: ProductId;
 
   @ApiProperty({
     description: 'Filter by location ID (matches from or to)',
@@ -54,7 +55,7 @@ export class StockMovementQueryDto implements StockMovementQueryDtoShape {
   })
   @IsOptional()
   @IsUUID()
-  location_id?: string;
+  location_id?: LocationId;
 
   @ApiProperty({
     description: 'Filter by reason',

--- a/src/routes/stock-movements/dto/stock-movement-response.dto.ts
+++ b/src/routes/stock-movements/dto/stock-movement-response.dto.ts
@@ -1,24 +1,31 @@
 import { ApiProperty } from '@nestjs/swagger';
+import type {
+  LocationId,
+  OrderId,
+  ProductId,
+  StockMovementId,
+  UserId,
+} from '@librestock/types/common'
 import { type StockMovementResponseDto as StockMovementResponseDtoShape, type StockMovementLocationSummary, type StockMovementProductSummary, StockMovementReason } from '@librestock/types/stock-movements'
 
 export class StockMovementResponseDto implements StockMovementResponseDtoShape {
   @ApiProperty({ description: 'Unique identifier', format: 'uuid' })
-  id: string;
+  id: StockMovementId;
 
   @ApiProperty({ description: 'Product ID', format: 'uuid' })
-  product_id: string;
+  product_id: ProductId;
 
   @ApiProperty({ description: 'Product summary', nullable: true })
   product: StockMovementProductSummary | null;
 
   @ApiProperty({ description: 'Source location ID', nullable: true })
-  from_location_id: string | null;
+  from_location_id: LocationId | null;
 
   @ApiProperty({ description: 'Source location summary', nullable: true })
   from_location: StockMovementLocationSummary | null;
 
   @ApiProperty({ description: 'Destination location ID', nullable: true })
-  to_location_id: string | null;
+  to_location_id: LocationId | null;
 
   @ApiProperty({ description: 'Destination location summary', nullable: true })
   to_location: StockMovementLocationSummary | null;
@@ -33,7 +40,7 @@ export class StockMovementResponseDto implements StockMovementResponseDtoShape {
   reason: StockMovementReason;
 
   @ApiProperty({ description: 'Related order ID', nullable: true })
-  order_id: string | null;
+  order_id: OrderId | null;
 
   @ApiProperty({ description: 'Reference number', nullable: true })
   reference_number: string | null;
@@ -42,7 +49,7 @@ export class StockMovementResponseDto implements StockMovementResponseDtoShape {
   cost_per_unit: number | null;
 
   @ApiProperty({ description: 'User who performed the movement', format: 'uuid' })
-  user_id: string;
+  user_id: UserId;
 
   @ApiProperty({ description: 'Additional notes', nullable: true })
   notes: string | null;

--- a/src/routes/stock-movements/stock-movements.controller.ts
+++ b/src/routes/stock-movements/stock-movements.controller.ts
@@ -44,7 +44,7 @@ import { StockMovementHateoas } from './stock-movements.hateoas';
 @ApiBearerAuth()
 @StandardThrottle()
 @UseGuards(PermissionGuard)
-@RequirePermission(Resource.STOCK, Permission.READ)
+@RequirePermission(Resource.STOCK_MOVEMENTS, Permission.READ)
 @Controller()
 export class StockMovementsController {
   constructor(
@@ -125,7 +125,7 @@ export class StockMovementsController {
   }
 
   @Post()
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.STOCK_MOVEMENTS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @StockMovementHateoas()
   @Auditable({

--- a/src/routes/stock-movements/stock-movements.utils.ts
+++ b/src/routes/stock-movements/stock-movements.utils.ts
@@ -1,29 +1,36 @@
 import type { StockMovementResponseDto } from './dto';
 import type { StockMovement } from './entities/stock-movement.entity';
+import {
+  asLocationId,
+  asOrderId,
+  asProductId,
+  asStockMovementId,
+  asUserId,
+} from '@librestock/types/common'
 
 export function toStockMovementResponseDto(
   sm: StockMovement,
 ): StockMovementResponseDto {
   return {
-    id: sm.id,
-    product_id: sm.product_id,
+    id: asStockMovementId(sm.id),
+    product_id: asProductId(sm.product_id),
     product: sm.product
-      ? { id: sm.product.id, name: sm.product.name, sku: sm.product.sku }
+      ? { id: asProductId(sm.product.id), name: sm.product.name, sku: sm.product.sku }
       : null,
-    from_location_id: sm.from_location_id,
+    from_location_id: sm.from_location_id ? asLocationId(sm.from_location_id) : null,
     from_location: sm.fromLocation
-      ? { id: sm.fromLocation.id, name: sm.fromLocation.name }
+      ? { id: asLocationId(sm.fromLocation.id), name: sm.fromLocation.name }
       : null,
-    to_location_id: sm.to_location_id,
+    to_location_id: sm.to_location_id ? asLocationId(sm.to_location_id) : null,
     to_location: sm.toLocation
-      ? { id: sm.toLocation.id, name: sm.toLocation.name }
+      ? { id: asLocationId(sm.toLocation.id), name: sm.toLocation.name }
       : null,
     quantity: sm.quantity,
     reason: sm.reason,
-    order_id: sm.order_id,
+    order_id: sm.order_id ? asOrderId(sm.order_id) : null,
     reference_number: sm.reference_number,
     cost_per_unit: sm.cost_per_unit,
-    user_id: sm.user_id,
+    user_id: asUserId(sm.user_id),
     notes: sm.notes,
     created_at: sm.created_at,
   };

--- a/src/routes/suppliers/suppliers.controller.ts
+++ b/src/routes/suppliers/suppliers.controller.ts
@@ -42,7 +42,7 @@ import { SupplierHateoas, DeleteSupplierHateoas } from './suppliers.hateoas';
 @ApiBearerAuth()
 @StandardThrottle()
 @UseGuards(PermissionGuard)
-@RequirePermission(Resource.STOCK, Permission.READ)
+@RequirePermission(Resource.SUPPLIERS, Permission.READ)
 @Controller()
 export class SuppliersController {
   constructor(private readonly suppliersService: SuppliersService) {}
@@ -78,7 +78,7 @@ export class SuppliersController {
   }
 
   @Post()
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.SUPPLIERS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @SupplierHateoas()
   @Auditable({
@@ -97,7 +97,7 @@ export class SuppliersController {
   }
 
   @Put(':id')
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.SUPPLIERS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @SupplierHateoas()
   @Auditable({
@@ -119,7 +119,7 @@ export class SuppliersController {
   }
 
   @Delete(':id')
-  @RequirePermission(Resource.STOCK, Permission.WRITE)
+  @RequirePermission(Resource.SUPPLIERS, Permission.WRITE)
   @UseInterceptors(HateoasInterceptor, AuditInterceptor)
   @DeleteSupplierHateoas()
   @Auditable({

--- a/src/routes/users/dto/user-response.dto.ts
+++ b/src/routes/users/dto/user-response.dto.ts
@@ -21,11 +21,11 @@ export class UserResponseDto implements UserResponseDtoShape {
   banned: boolean;
 
   @ApiProperty({ description: 'Ban reason', nullable: true })
-  banReason: string | null;
+  ban_reason: string | null;
 
   @ApiProperty({ description: 'Ban expiry date', nullable: true })
-  banExpires: string | Date | null;
+  ban_expires: string | Date | null;
 
   @ApiProperty({ description: 'Account creation date' })
-  createdAt: string | Date;
+  created_at: string | Date;
 }

--- a/src/routes/users/users.service.spec.ts
+++ b/src/routes/users/users.service.spec.ts
@@ -294,8 +294,8 @@ describe('UsersService', () => {
       expect(result.email).toBe('');
       expect(result.image).toBeNull();
       expect(result.banned).toBe(false);
-      expect(result.banReason).toBeNull();
-      expect(result.banExpires).toBeNull();
+      expect(result.ban_reason).toBeNull();
+      expect(result.ban_expires).toBeNull();
     });
   });
 

--- a/src/routes/users/users.service.ts
+++ b/src/routes/users/users.service.ts
@@ -86,9 +86,9 @@ export class UsersService {
       image: u.image ?? null,
       roles: rolesByUserId.get(u.id) ?? [],
       banned: u.banned ?? false,
-      banReason: u.banReason ?? null,
-      banExpires: u.banExpires ?? null,
-      createdAt: u.createdAt,
+      ban_reason: u.banReason ?? null,
+      ban_expires: u.banExpires ?? null,
+      created_at: u.createdAt,
     }));
 
     if (query.role) {
@@ -134,9 +134,9 @@ export class UsersService {
       image: user.image ?? null,
       roles: roleEntities.map((re) => re.role.name),
       banned: user.banned ?? false,
-      banReason: user.banReason ?? null,
-      banExpires: user.banExpires ?? null,
-      createdAt: user.createdAt,
+      ban_reason: user.banReason ?? null,
+      ban_expires: user.banExpires ?? null,
+      created_at: user.createdAt,
     };
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",
-    "strictPropertyInitialization": true
+    "paths": {
+      "@librestock/types/*": ["../packages/types/src/*/index.ts"]
+    },
+    "strictPropertyInitialization": false
   }
 }


### PR DESCRIPTION
## Summary
- align backend `UserResponseDto` fields to snake_case (`ban_reason`, `ban_expires`, `created_at`)
- update `UsersService` response mapping and related unit tests
- align orders DTO shape imports to canonical `OrderResponseDto`/`OrderItemResponseDto` type names

## Testing
- pnpm test -- src/routes/users/users.service.spec.ts src/routes/orders/state/order-state.spec.ts