### PR TITLE
fix: update types package and refactor error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/config/typeorm-cli.config.ts"
   },
   "dependencies": {
-    "@librestock/types": "1.1.6",
+    "@librestock/types": "1.2.0",
     "@nestjs/common": "^11.1.10",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@librestock/types': link:../packages/types
-
 importers:
 
   .:
     dependencies:
       '@librestock/types':
-        specifier: link:../packages/types
-        version: link:../packages/types
+        specifier: 1.2.0
+        version: 1.2.0(effect@3.19.19)
       '@nestjs/common':
         specifier: ^11.1.10
         version: 11.1.13(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -733,6 +730,11 @@ packages:
 
   '@librestock/tsconfig@1.1.5':
     resolution: {integrity: sha512-lN8mFJWG/2hTtTuiK4/yWSEWtwviLsQhC6uW71tSllHbvMk/S0gk5DLmrehrNrEsmql8YybThVXdEjdFNl+VhQ==}
+
+  '@librestock/types@1.2.0':
+    resolution: {integrity: sha512-YtvzbUpxv6oAZlpejNdz2gJ/u/VthRwAsY81PhuOy+ZJGN0CYO1u3pO5vyq5hFb15bBe6fb7RbO0u3MRyt6EJA==}
+    peerDependencies:
+      effect: ^3.19.0
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -4484,6 +4486,11 @@ snapshots:
       - supports-color
 
   '@librestock/tsconfig@1.1.5': {}
+
+  '@librestock/types@1.2.0(effect@3.19.19)':
+    dependencies:
+      effect: 3.19.19
+      zod: 4.3.6
 
   '@lukeed/csprng@1.1.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,3 @@ onlyBuiltDependencies:
   - '@parcel/watcher'
   - msgpackr-extract
 
-overrides:
-  '@librestock/types': link:../packages/types

--- a/src/common/decorators/require-permission.decorator.ts
+++ b/src/common/decorators/require-permission.decorator.ts
@@ -1,5 +1,5 @@
 import { SetMetadata } from '@nestjs/common';
-import type { Resource, Permission } from '@librestock/types';
+import type { Resource, Permission } from '@librestock/types/auth';
 
 export const PERMISSION_KEY = 'required_permission';
 

--- a/src/common/dto/error-response.dto.ts
+++ b/src/common/dto/error-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { ErrorType, type ErrorResponseDto as ErrorResponseDtoShape } from '@librestock/types';
+import { ErrorType, type ErrorResponseDto as ErrorResponseDtoShape } from '@librestock/types/common';
 
 export { ErrorType };
 

--- a/src/common/dto/message-response.dto.ts
+++ b/src/common/dto/message-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { MessageResponseDto as MessageResponseDtoShape } from '@librestock/types';
+import type { MessageResponseDto as MessageResponseDtoShape } from '@librestock/types/common';
 
 export class MessageResponseDto implements MessageResponseDtoShape {
   @ApiProperty({ example: 'Operation completed successfully' })

--- a/src/common/effect/errors.spec.ts
+++ b/src/common/effect/errors.spec.ts
@@ -10,6 +10,9 @@ import {
 
 describe('Effect domain errors', () => {
   class ProductNotFound extends NotFoundError('ProductNotFound') {}
+  class ProductNotFoundWithId extends NotFoundError(
+    'ProductNotFoundWithId',
+  )<{ readonly id: string }> {}
   class DuplicateSku extends BadRequestError('DuplicateSku') {}
   class SkuConflict extends ConflictError('SkuConflict') {}
   class AccessDenied extends ForbiddenError('AccessDenied') {}
@@ -30,6 +33,17 @@ describe('Effect domain errors', () => {
     expect(error.statusCode).toBe(status);
   });
 
+  it('allows subclasses to add typed payload fields without redefining message', () => {
+    const error = new ProductNotFoundWithId({
+      id: 'product-1',
+      message: 'Product not found',
+    });
+
+    expect(error.id).toBe('product-1');
+    expect(error.message).toBe('Product not found');
+    expect(error.statusCode).toBe(404);
+  });
+
   describe('isAppError', () => {
     it('returns true for domain errors', () => {
       expect(isAppError(new ProductNotFound({ message: 'x' }))).toBe(true);
@@ -37,6 +51,12 @@ describe('Effect domain errors', () => {
 
     it('returns false for plain objects missing fields', () => {
       expect(isAppError({ _tag: 'Foo', message: 'x' })).toBe(false);
+      expect(isAppError({ _tag: 123, message: 'x', statusCode: 400 })).toBe(
+        false,
+      );
+      expect(isAppError({ _tag: 'Foo', message: 123, statusCode: 400 })).toBe(
+        false,
+      );
       expect(isAppError(null)).toBe(false);
       expect(isAppError('string')).toBe(false);
     });

--- a/src/common/effect/errors.ts
+++ b/src/common/effect/errors.ts
@@ -1,5 +1,23 @@
 import { Data } from 'effect';
 
+type AppErrorFields = {
+  readonly message: string;
+};
+
+type AppErrorInstance<
+  Tag extends string,
+  StatusCode extends number,
+  Fields extends object = {},
+> = AppError<Tag, StatusCode> & Readonly<Fields>;
+
+type AppErrorConstructor<
+  Tag extends string,
+  StatusCode extends number,
+  BaseFields extends object = AppErrorFields,
+> = new <Fields extends object = {}>(
+  args: Readonly<Fields & BaseFields>,
+) => AppErrorInstance<Tag, StatusCode, Fields & BaseFields>;
+
 /**
  * Convention for Effect domain errors in this codebase:
  *
@@ -8,62 +26,64 @@ import { Data } from 'effect';
  * - The `runEffect` bridge reads these to produce the correct NestJS HttpException
  *
  * Usage:
- *   class ProductNotFound extends NotFoundError("ProductNotFound")<{ id: string }> {}
+ *   class ProductNotFound extends NotFoundError("ProductNotFound")<{ readonly id: string }> {}
  *   yield* new ProductNotFound({ id, message: "Product not found" })
  */
-
-// ---------------------------------------------------------------------------
-// Branded factory helpers — produce a TaggedError subclass pre-wired with
-// the correct HTTP status code. Domain modules extend these.
-// ---------------------------------------------------------------------------
-
-export const NotFoundError = <Tag extends string>(tag: Tag) =>
-  class extends Data.TaggedError(tag)<{ readonly message: string }> {
-    readonly statusCode = 404 as const;
-  };
-
-export const BadRequestError = <Tag extends string>(tag: Tag) =>
-  class extends Data.TaggedError(tag)<{ readonly message: string }> {
-    readonly statusCode = 400 as const;
-  };
-
-export const ConflictError = <Tag extends string>(tag: Tag) =>
-  class extends Data.TaggedError(tag)<{ readonly message: string }> {
-    readonly statusCode = 409 as const;
-  };
-
-export const ForbiddenError = <Tag extends string>(tag: Tag) =>
-  class extends Data.TaggedError(tag)<{ readonly message: string }> {
-    readonly statusCode = 403 as const;
-  };
-
-export const UnauthorizedError = <Tag extends string>(tag: Tag) =>
-  class extends Data.TaggedError(tag)<{ readonly message: string }> {
-    readonly statusCode = 401 as const;
-  };
-
-export const InternalError = <Tag extends string>(tag: Tag) =>
-  class extends Data.TaggedError(tag)<{
-    readonly message: string;
-    readonly cause?: unknown;
-  }> {
-    readonly statusCode = 500 as const;
-  };
 
 // ---------------------------------------------------------------------------
 // Type guard used by runEffect to detect our domain errors
 // ---------------------------------------------------------------------------
 
-export interface AppError {
-  readonly _tag: string;
+export interface AppError<
+  Tag extends string = string,
+  StatusCode extends number = number,
+> extends Error {
+  readonly _tag: Tag;
   readonly message: string;
-  readonly statusCode: number;
+  readonly statusCode: StatusCode;
 }
 
-export const isAppError = (u: unknown): u is AppError =>
-  u !== null &&
-  typeof u === 'object' &&
-  '_tag' in u &&
-  'message' in u &&
-  'statusCode' in u &&
-  typeof (u as AppError).statusCode === 'number';
+const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
+  value !== null && typeof value === 'object';
+
+export const isAppError = (value: unknown): value is AppError =>
+  isRecord(value) &&
+  typeof value._tag === 'string' &&
+  typeof value.message === 'string' &&
+  typeof value.statusCode === 'number';
+
+// ---------------------------------------------------------------------------
+// Branded factory helpers — produce a TaggedError subclass pre-wired with
+// the correct HTTP status code. Domain modules extend these.
+//
+// The returned constructor stays generic over extra payload fields while still
+// enforcing that every instance has a message and statusCode.
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a factory that produces TaggedError subclasses with a fixed statusCode.
+ * Extra payload fields are carried by the generic constructor signature, so
+ * subclasses can add domain-specific context without re-declaring `message`.
+ */
+function makeErrorFactory<StatusCode extends number>(statusCode: StatusCode) {
+  return <Tag extends string>(
+    tag: Tag,
+  ): AppErrorConstructor<Tag, StatusCode> => {
+    class EffectError extends Data.TaggedError(tag)<AppErrorFields> {
+      readonly statusCode: StatusCode = statusCode;
+
+      constructor(args: Readonly<object & AppErrorFields>) {
+        super(args);
+      }
+    }
+
+    return EffectError as AppErrorConstructor<Tag, StatusCode>;
+  };
+}
+
+export const NotFoundError = makeErrorFactory(404);
+export const BadRequestError = makeErrorFactory(400);
+export const ConflictError = makeErrorFactory(409);
+export const ForbiddenError = makeErrorFactory(403);
+export const UnauthorizedError = makeErrorFactory(401);
+export const InternalError = makeErrorFactory(500);

--- a/src/common/effect/errors.ts
+++ b/src/common/effect/errors.ts
@@ -1,20 +1,20 @@
 import { Data } from 'effect';
 
-type AppErrorFields = {
+interface AppErrorFields {
   readonly message: string;
-};
+}
 
 type AppErrorInstance<
   Tag extends string,
   StatusCode extends number,
-  Fields extends object = {},
+  Fields extends object = object,
 > = AppError<Tag, StatusCode> & Readonly<Fields>;
 
 type AppErrorConstructor<
   Tag extends string,
   StatusCode extends number,
   BaseFields extends object = AppErrorFields,
-> = new <Fields extends object = {}>(
+> = new <Fields extends object = object>(
   args: Readonly<Fields & BaseFields>,
 ) => AppErrorInstance<Tag, StatusCode, Fields & BaseFields>;
 

--- a/src/common/effect/run-effect.ts
+++ b/src/common/effect/run-effect.ts
@@ -7,6 +7,13 @@ const FiberFailureCauseSymbol = Symbol.for(
   'effect/Runtime/FiberFailure/Cause',
 );
 
+type FiberFailure = {
+  readonly [FiberFailureCauseSymbol]: Cause.Cause<unknown>;
+};
+
+const hasFiberFailureCause = (value: object): value is FiberFailure =>
+  FiberFailureCauseSymbol in value;
+
 /**
  * Extract the original error from an Effect FiberFailure wrapper.
  *
@@ -16,23 +23,24 @@ const FiberFailureCauseSymbol = Symbol.for(
  */
 function unwrapFiberFailure(thrown: unknown): unknown {
   if (
-    thrown !== null &&
-    typeof thrown === 'object' &&
-    FiberFailureCauseSymbol in thrown
+    thrown === null ||
+    typeof thrown !== 'object' ||
+    !hasFiberFailureCause(thrown)
   ) {
-    const cause = (thrown as Record<symbol, unknown>)[
-      FiberFailureCauseSymbol
-    ] as Cause.Cause<unknown>;
-
-    // Expected failure → extract the error value
-    if (cause._tag === 'Fail') {
-      return cause.error;
-    }
-    // Defect → extract the defect value
-    if (cause._tag === 'Die') {
-      return cause.defect;
-    }
+    return thrown;
   }
+
+  const cause = thrown[FiberFailureCauseSymbol];
+
+  // Expected failure → extract the error value
+  if (cause._tag === 'Fail') {
+    return cause.error;
+  }
+  // Defect → extract the defect value
+  if (cause._tag === 'Die') {
+    return cause.defect;
+  }
+
   return thrown;
 }
 

--- a/src/common/effect/run-effect.ts
+++ b/src/common/effect/run-effect.ts
@@ -7,9 +7,9 @@ const FiberFailureCauseSymbol = Symbol.for(
   'effect/Runtime/FiberFailure/Cause',
 );
 
-type FiberFailure = {
+interface FiberFailure {
   readonly [FiberFailureCauseSymbol]: Cause.Cause<unknown>;
-};
+}
 
 const hasFiberFailureCause = (value: object): value is FiberFailure =>
   FiberFailureCauseSymbol in value;

--- a/src/common/effect/swagger.ts
+++ b/src/common/effect/swagger.ts
@@ -1,6 +1,6 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiBody, ApiQuery } from '@nestjs/swagger';
-import { JSONSchema, Schema } from 'effect';
+import { JSONSchema, type Schema } from 'effect';
 
 type JsonSchemaObj = Record<string, unknown>;
 
@@ -20,8 +20,8 @@ function resolveRefs(
   const obj = node as JsonSchemaObj;
 
   // Resolve $ref pointers
-  if (typeof obj['$ref'] === 'string') {
-    const refPath = obj['$ref'] as string;
+  if (typeof obj.$ref === 'string') {
+    const refPath = obj.$ref;
     const defName = refPath.replace('#/$defs/', '');
     const resolved = defs[defName];
     if (resolved) {
@@ -52,7 +52,7 @@ export function effectSchemaToOpenApi<A, I, R>(
   const jsonSchema: JsonSchemaObj = JSON.parse(
     JSON.stringify(JSONSchema.make(schema)),
   );
-  const defs = (jsonSchema['$defs'] as Record<string, JsonSchemaObj>) ?? {};
+  const defs = (jsonSchema.$defs as Record<string, JsonSchemaObj>) ?? {};
   return resolveRefs(jsonSchema, defs) as JsonSchemaObj;
 }
 
@@ -86,12 +86,12 @@ export function ApiEffectQuery<A, I, R>(
   schema: Schema.Schema<A, I, R>,
 ): MethodDecorator {
   const openApi = effectSchemaToOpenApi(schema);
-  const properties = (openApi['properties'] ?? {}) as Record<
+  const properties = (openApi.properties ?? {}) as Record<
     string,
     JsonSchemaObj
   >;
   const required = new Set(
-    (openApi['required'] as string[] | undefined) ?? [],
+    (openApi.required as string[] | undefined) ?? [],
   );
 
   const decorators = Object.entries(properties).map(([name, propSchema]) =>

--- a/src/common/enums/audit-action.enum.ts
+++ b/src/common/enums/audit-action.enum.ts
@@ -1,1 +1,1 @@
-export { AuditAction } from '@librestock/types';
+export { AuditAction } from '@librestock/types/audit-logs';

--- a/src/common/enums/audit-entity-type.enum.ts
+++ b/src/common/enums/audit-entity-type.enum.ts
@@ -1,1 +1,1 @@
-export { AuditEntityType } from '@librestock/types';
+export { AuditEntityType } from '@librestock/types/audit-logs';

--- a/src/common/enums/client-status.enum.ts
+++ b/src/common/enums/client-status.enum.ts
@@ -1,1 +1,1 @@
-export { ClientStatus } from '@librestock/types';
+export { ClientStatus } from '@librestock/types/clients';

--- a/src/common/enums/location-type.enum.ts
+++ b/src/common/enums/location-type.enum.ts
@@ -1,1 +1,1 @@
-export { LocationType } from '@librestock/types';
+export { LocationType } from '@librestock/types/locations';

--- a/src/common/enums/order-status.enum.ts
+++ b/src/common/enums/order-status.enum.ts
@@ -1,1 +1,1 @@
-export { OrderStatus } from '@librestock/types';
+export { OrderStatus } from '@librestock/types/orders';

--- a/src/common/enums/stock-movement-reason.enum.ts
+++ b/src/common/enums/stock-movement-reason.enum.ts
@@ -1,1 +1,1 @@
-export { StockMovementReason } from '@librestock/types';
+export { StockMovementReason } from '@librestock/types/stock-movements';

--- a/src/common/guards/permission.guard.spec.ts
+++ b/src/common/guards/permission.guard.spec.ts
@@ -4,7 +4,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { RolesService, type UserPermissions } from '../../routes/roles/roles.service';
 import {
   type MockRequest,

--- a/src/common/hateoas/hateoas-link.dto.ts
+++ b/src/common/hateoas/hateoas-link.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { HateoasLink as HateoasLinkShape } from '@librestock/types';
+import type { HateoasLink as HateoasLinkShape } from '@librestock/types/common';
 
 export class HateoasLink implements HateoasLinkShape {
   @ApiProperty({ description: 'The URL of the linked resource' })

--- a/src/migrations/1772917000000-AddOrderNumberSequence.ts
+++ b/src/migrations/1772917000000-AddOrderNumberSequence.ts
@@ -1,4 +1,4 @@
-import { MigrationInterface, QueryRunner } from 'typeorm';
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
 
 export class AddOrderNumberSequence1772917000000 implements MigrationInterface {
   name = 'AddOrderNumberSequence1772917000000';

--- a/src/routes/areas/areas.controller.ts
+++ b/src/routes/areas/areas.controller.ts
@@ -18,7 +18,7 @@ import {
   ApiBearerAuth,
   ApiParam,
 } from '@nestjs/swagger';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { HateoasInterceptor } from '../../common/hateoas/hateoas.interceptor';
 import { AuditInterceptor } from '../../common/interceptors/audit.interceptor';
 import { Auditable } from '../../common/decorators/auditable.decorator';

--- a/src/routes/areas/areas.service.spec.ts
+++ b/src/routes/areas/areas.service.spec.ts
@@ -179,7 +179,7 @@ describe('AreasService', () => {
       const result = await service.findAll({});
 
       expect(result).toHaveLength(1);
-      expect(result[0].name).toBe('Zone A');
+      expect(result[0]!.name).toBe('Zone A');
     });
 
     it('should return hierarchical areas when include_children and location_id are provided', async () => {

--- a/src/routes/areas/dto/area-query.dto.ts
+++ b/src/routes/areas/dto/area-query.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsUUID, IsBoolean } from 'class-validator';
 import { Transform } from 'class-transformer';
-import type { AreaQueryDto as AreaQueryDtoShape } from '@librestock/types';
+import type { AreaQueryDto as AreaQueryDtoShape } from '@librestock/types/areas';
 
 export class AreaQueryDto implements AreaQueryDtoShape {
   @ApiProperty({

--- a/src/routes/areas/dto/area-response.dto.ts
+++ b/src/routes/areas/dto/area-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { AreaResponseDto as AreaResponseDtoShape } from '@librestock/types';
+import type { AreaResponseDto as AreaResponseDtoShape } from '@librestock/types/areas';
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
 export class AreaResponseDto

--- a/src/routes/areas/dto/create-area.dto.ts
+++ b/src/routes/areas/dto/create-area.dto.ts
@@ -6,7 +6,7 @@ import {
   IsBoolean,
   MaxLength,
 } from 'class-validator';
-import type { CreateAreaDto as CreateAreaDtoShape } from '@librestock/types';
+import type { CreateAreaDto as CreateAreaDtoShape } from '@librestock/types/areas';
 
 export class CreateAreaDto implements CreateAreaDtoShape {
   @ApiProperty({ description: 'Location ID', format: 'uuid' })

--- a/src/routes/areas/dto/update-area.dto.ts
+++ b/src/routes/areas/dto/update-area.dto.ts
@@ -6,7 +6,7 @@ import {
   IsBoolean,
   MaxLength,
 } from 'class-validator';
-import type { UpdateAreaDto as UpdateAreaDtoShape } from '@librestock/types';
+import type { UpdateAreaDto as UpdateAreaDtoShape } from '@librestock/types/areas';
 
 export class UpdateAreaDto implements UpdateAreaDtoShape {
   @ApiProperty({

--- a/src/routes/audit-logs/audit-log.repository.spec.ts
+++ b/src/routes/audit-logs/audit-log.repository.spec.ts
@@ -6,7 +6,7 @@ import { AuditLogRepository } from './audit-log.repository';
 
 describe('AuditLogRepository', () => {
   let repository: AuditLogRepository;
-  let typeormRepository: Record<string, jest.Mock>;
+  let typeormRepository: Record<string, jest.Mock | undefined>;
 
   const mockAuditLog: AuditLog = {
     id: '550e8400-e29b-41d4-a716-446655440000',
@@ -56,7 +56,7 @@ describe('AuditLogRepository', () => {
     mockQueryBuilder.orderBy.mockReturnThis();
     mockQueryBuilder.skip.mockReturnThis();
     mockQueryBuilder.take.mockReturnThis();
-    typeormRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+    typeormRepository.createQueryBuilder!.mockReturnValue(mockQueryBuilder);
   });
 
   it('should be defined', () => {
@@ -65,8 +65,8 @@ describe('AuditLogRepository', () => {
 
   describe('create', () => {
     it('should create and save an audit log', async () => {
-      typeormRepository.create.mockReturnValue(mockAuditLog);
-      typeormRepository.save.mockResolvedValue(mockAuditLog);
+      typeormRepository.create!.mockReturnValue(mockAuditLog);
+      typeormRepository.save!.mockResolvedValue(mockAuditLog);
 
       const data = {
         user_id: 'user_123',
@@ -105,8 +105,8 @@ describe('AuditLogRepository', () => {
         ...d,
       }));
 
-      typeormRepository.create.mockReturnValue(mockLogs);
-      typeormRepository.save.mockResolvedValue(mockLogs);
+      typeormRepository.create!.mockReturnValue(mockLogs);
+      typeormRepository.save!.mockResolvedValue(mockLogs);
 
       const result = await repository.createMany(dataArray);
 
@@ -119,7 +119,7 @@ describe('AuditLogRepository', () => {
   describe('findByEntityId', () => {
     it('should find logs by entity type and id', async () => {
       const logs = [mockAuditLog];
-      typeormRepository.find.mockResolvedValue(logs);
+      typeormRepository.find!.mockResolvedValue(logs);
 
       const result = await repository.findByEntityId(
         AuditEntityType.PRODUCT,
@@ -140,7 +140,7 @@ describe('AuditLogRepository', () => {
   describe('findByUserId', () => {
     it('should find logs by user id', async () => {
       const logs = [mockAuditLog];
-      typeormRepository.find.mockResolvedValue(logs);
+      typeormRepository.find!.mockResolvedValue(logs);
 
       const result = await repository.findByUserId('user_123');
 
@@ -289,7 +289,7 @@ describe('AuditLogRepository', () => {
 
   describe('findById', () => {
     it('should find audit log by id', async () => {
-      typeormRepository.findOneBy.mockResolvedValue(mockAuditLog);
+      typeormRepository.findOneBy!.mockResolvedValue(mockAuditLog);
 
       const result = await repository.findById(mockAuditLog.id);
 
@@ -300,7 +300,7 @@ describe('AuditLogRepository', () => {
     });
 
     it('should return null when not found', async () => {
-      typeormRepository.findOneBy.mockResolvedValue(null);
+      typeormRepository.findOneBy!.mockResolvedValue(null);
 
       const result = await repository.findById('non-existent');
 

--- a/src/routes/audit-logs/audit-logs.controller.ts
+++ b/src/routes/audit-logs/audit-logs.controller.ts
@@ -15,7 +15,8 @@ import {
   ApiTags,
   ApiParam,
 } from '@nestjs/swagger';
-import { AuditEntityType, Resource, Permission } from '@librestock/types';
+import { AuditEntityType } from '@librestock/types/audit-logs';
+import { Resource, Permission } from '@librestock/types/auth';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { RequirePermission } from '../../common/decorators';
 import { PermissionGuard } from '../../common/guards/permission.guard';

--- a/src/routes/audit-logs/dto/audit-log-query.dto.ts
+++ b/src/routes/audit-logs/dto/audit-log-query.dto.ts
@@ -13,7 +13,7 @@ import {
   AuditAction,
   AuditEntityType,
   type AuditLogQueryDto as AuditLogQueryDtoShape,
-} from '@librestock/types';
+} from '@librestock/types/audit-logs';
 
 export class AuditLogQueryDto implements AuditLogQueryDtoShape {
   @ApiProperty({

--- a/src/routes/audit-logs/dto/audit-log-response.dto.ts
+++ b/src/routes/audit-logs/dto/audit-log-response.dto.ts
@@ -4,7 +4,7 @@ import {
   AuditEntityType,
   type AuditChanges,
   type AuditLogResponseDto as AuditLogResponseDtoShape,
-} from '@librestock/types';
+} from '@librestock/types/audit-logs';
 
 export class AuditLogResponseDto implements AuditLogResponseDtoShape {
   @ApiProperty({

--- a/src/routes/audit-logs/dto/paginated-audit-logs-response.dto.ts
+++ b/src/routes/audit-logs/dto/paginated-audit-logs-response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type {
-  PaginatedAuditLogsResponseDto as PaginatedAuditLogsResponseDtoShape,
-  PaginationMeta as PaginationMetaShape,
-} from '@librestock/types';
+import type { PaginatedAuditLogsResponseDto as PaginatedAuditLogsResponseDtoShape } from '@librestock/types/audit-logs';
+import type { PaginationMeta as PaginationMetaShape } from '@librestock/types/common';
 import { AuditLogResponseDto } from './audit-log-response.dto';
 
 export class PaginationMetaDto implements PaginationMetaShape {

--- a/src/routes/auth/dto/current-user-response.dto.ts
+++ b/src/routes/auth/dto/current-user-response.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Permission, Resource } from '@librestock/types';
-import type { CurrentUserResponseDto as CurrentUserResponseDtoShape } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
+import type { CurrentUserResponseDto as CurrentUserResponseDtoShape } from '@librestock/types/auth';
 
 export class CurrentUserResponseDto implements CurrentUserResponseDtoShape {
   @ApiProperty({ description: 'User ID' })

--- a/src/routes/auth/dto/profile-response.dto.ts
+++ b/src/routes/auth/dto/profile-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import type { ProfileResponseDto as ProfileResponseDtoShape } from '@librestock/types';
+import type { ProfileResponseDto as ProfileResponseDtoShape } from '@librestock/types/auth';
 
 export class ProfileResponseDto implements ProfileResponseDtoShape {
   @ApiProperty({ description: 'User ID' })

--- a/src/routes/auth/dto/session-claims-response.dto.ts
+++ b/src/routes/auth/dto/session-claims-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { SessionClaimsResponseDto as SessionClaimsResponseDtoShape } from '@librestock/types';
+import type { SessionClaimsResponseDto as SessionClaimsResponseDtoShape } from '@librestock/types/auth';
 
 export class SessionClaimsResponseDto implements SessionClaimsResponseDtoShape {
   @ApiProperty()

--- a/src/routes/branding/branding.controller.ts
+++ b/src/routes/branding/branding.controller.ts
@@ -17,7 +17,7 @@ import {
   Session,
   UserSession,
 } from '@thallesp/nestjs-better-auth';
-import { Resource, Permission } from '@librestock/types';
+import { Resource, Permission } from '@librestock/types/auth';
 import { StandardThrottle } from 'src/common/decorators/throttle.decorator';
 import { RequirePermission } from 'src/common/decorators';
 import { PermissionGuard } from 'src/common/guards/permission.guard';

--- a/src/routes/branding/dto/branding-response.dto.ts
+++ b/src/routes/branding/dto/branding-response.dto.ts
@@ -1,8 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type {
-  BrandingResponseDto as BrandingResponseDtoShape,
-  PoweredByDto as PoweredByDtoShape,
-} from '@librestock/types';
+import type { BrandingResponseDto as BrandingResponseDtoShape, PoweredByDto as PoweredByDtoShape } from '@librestock/types/branding';
 
 class PoweredByDto implements PoweredByDtoShape {
   @ApiProperty({ description: 'Product name', example: 'LibreStock' })

--- a/src/routes/branding/dto/update-branding.dto.ts
+++ b/src/routes/branding/dto/update-branding.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional, MaxLength, Matches, IsUrl, ValidateIf } from 'class-validator';
-import type { UpdateBrandingDto as UpdateBrandingDtoShape } from '@librestock/types';
+import type { UpdateBrandingDto as UpdateBrandingDtoShape } from '@librestock/types/branding';
 
 export class UpdateBrandingDto implements UpdateBrandingDtoShape {
   @ApiPropertyOptional({ description: 'Application name', maxLength: 100 })

--- a/src/routes/categories/categories.controller.ts
+++ b/src/routes/categories/categories.controller.ts
@@ -17,7 +17,7 @@ import {
   ApiTags,
   ApiParam,
 } from '@nestjs/swagger';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { RequirePermission } from '../../common/decorators';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { MessageResponseDto } from '../../common/dto/message-response.dto';

--- a/src/routes/categories/categories.service.spec.ts
+++ b/src/routes/categories/categories.service.spec.ts
@@ -84,9 +84,9 @@ describe('CategoriesService', () => {
 
       expect(categoryRepository.findAll).toHaveBeenCalled();
       expect(result).toHaveLength(1);
-      expect(result[0].name).toBe('Electronics');
-      expect(result[0].children).toHaveLength(1);
-      expect(result[0].children[0].name).toBe('Smartphones');
+      expect(result[0]!.name).toBe('Electronics');
+      expect(result[0]!.children).toHaveLength(1);
+      expect(result[0]!.children![0]!.name).toBe('Smartphones');
     });
 
     it('should return empty array when no categories exist', async () => {

--- a/src/routes/categories/dto/category-response.dto.ts
+++ b/src/routes/categories/dto/category-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { CategoryResponseDto as CategoryResponseDtoShape } from '@librestock/types';
+import type { CategoryResponseDto as CategoryResponseDtoShape } from '@librestock/types/categories';
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
 export class CategoryResponseDto

--- a/src/routes/categories/dto/category-with-children-response.dto.ts
+++ b/src/routes/categories/dto/category-with-children-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { CategoryWithChildrenResponseDto as CategoryWithChildrenResponseDtoShape } from '@librestock/types';
+import type { CategoryWithChildrenResponseDto as CategoryWithChildrenResponseDtoShape } from '@librestock/types/categories';
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
 export class CategoryWithChildrenResponseDto

--- a/src/routes/categories/dto/create-category.dto.ts
+++ b/src/routes/categories/dto/create-category.dto.ts
@@ -6,7 +6,7 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
-import type { CreateCategoryDto as CreateCategoryDtoShape } from '@librestock/types';
+import type { CreateCategoryDto as CreateCategoryDtoShape } from '@librestock/types/categories';
 
 export class CreateCategoryDto implements CreateCategoryDtoShape {
   @ApiProperty({

--- a/src/routes/categories/dto/update-category.dto.ts
+++ b/src/routes/categories/dto/update-category.dto.ts
@@ -6,7 +6,7 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
-import type { UpdateCategoryDto as UpdateCategoryDtoShape } from '@librestock/types';
+import type { UpdateCategoryDto as UpdateCategoryDtoShape } from '@librestock/types/categories';
 
 export class UpdateCategoryDto implements UpdateCategoryDtoShape {
   @ApiProperty({

--- a/src/routes/clients/clients.controller.ts
+++ b/src/routes/clients/clients.controller.ts
@@ -18,7 +18,7 @@ import {
   ApiTags,
   ApiParam,
 } from '@nestjs/swagger';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { RequirePermission } from '../../common/decorators';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { MessageResponseDto } from '../../common/dto/message-response.dto';

--- a/src/routes/clients/clients.service.spec.ts
+++ b/src/routes/clients/clients.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 import { NotFoundException, ConflictException } from '@nestjs/common';
-import { ClientStatus } from '@librestock/types';
+import { ClientStatus } from '@librestock/types/clients';
 import { ClientsService } from './clients.service';
 import { ClientRepository, type PaginatedResult } from './client.repository';
 import { type Client } from './entities/client.entity';

--- a/src/routes/clients/dto/client-query.dto.ts
+++ b/src/routes/clients/dto/client-query.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString, IsEnum, IsNumber, Min, Max } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
-import { ClientStatus } from '@librestock/types';
-import type { ClientQueryDto as ClientQueryDtoShape } from '@librestock/types';
+import { ClientStatus } from '@librestock/types/clients';
+import type { ClientQueryDto as ClientQueryDtoShape } from '@librestock/types/clients';
 
 export class ClientQueryDto implements ClientQueryDtoShape {
   @ApiProperty({

--- a/src/routes/clients/dto/client-response.dto.ts
+++ b/src/routes/clients/dto/client-response.dto.ts
@@ -1,8 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  type ClientResponseDto as ClientResponseDtoShape,
-  ClientStatus,
-} from '@librestock/types';
+import { type ClientResponseDto as ClientResponseDtoShape, ClientStatus } from '@librestock/types/clients';
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
 export class ClientResponseDto

--- a/src/routes/clients/dto/create-client.dto.ts
+++ b/src/routes/clients/dto/create-client.dto.ts
@@ -9,8 +9,8 @@ import {
   MaxLength,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
-import { ClientStatus } from '@librestock/types';
-import type { CreateClientDto as CreateClientDtoShape } from '@librestock/types';
+import { ClientStatus } from '@librestock/types/clients';
+import type { CreateClientDto as CreateClientDtoShape } from '@librestock/types/clients';
 
 export class CreateClientDto implements CreateClientDtoShape {
   @ApiProperty({ description: 'Company name', maxLength: 200 })

--- a/src/routes/clients/dto/paginated-clients-response.dto.ts
+++ b/src/routes/clients/dto/paginated-clients-response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type {
-  PaginatedClientsResponseDto as PaginatedClientsResponseDtoShape,
-  PaginationMeta as PaginationMetaShape,
-} from '@librestock/types';
+import type { PaginatedClientsResponseDto as PaginatedClientsResponseDtoShape } from '@librestock/types/clients';
+import type { PaginationMeta as PaginationMetaShape } from '@librestock/types/common';
 import { ClientResponseDto } from './client-response.dto';
 
 export class PaginationMeta implements PaginationMetaShape {

--- a/src/routes/clients/dto/update-client.dto.ts
+++ b/src/routes/clients/dto/update-client.dto.ts
@@ -9,8 +9,8 @@ import {
   MaxLength,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
-import { ClientStatus } from '@librestock/types';
-import type { UpdateClientDto as UpdateClientDtoShape } from '@librestock/types';
+import { ClientStatus } from '@librestock/types/clients';
+import type { UpdateClientDto as UpdateClientDtoShape } from '@librestock/types/clients';
 
 export class UpdateClientDto implements UpdateClientDtoShape {
   @ApiProperty({

--- a/src/routes/clients/entities/client.entity.ts
+++ b/src/routes/clients/entities/client.entity.ts
@@ -5,7 +5,7 @@ import {
   Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
-import { ClientStatus } from '@librestock/types';
+import { ClientStatus } from '@librestock/types/clients';
 import { BaseEntity } from '../../../common/entities/base.entity';
 
 @Entity('clients')

--- a/src/routes/inventory/dto/adjust-inventory.dto.ts
+++ b/src/routes/inventory/dto/adjust-inventory.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt } from 'class-validator';
-import type { AdjustInventoryDto as AdjustInventoryDtoShape } from '@librestock/types';
+import type { AdjustInventoryDto as AdjustInventoryDtoShape } from '@librestock/types/inventory';
 
 export class AdjustInventoryDto implements AdjustInventoryDtoShape {
   @ApiProperty({

--- a/src/routes/inventory/dto/create-inventory.dto.ts
+++ b/src/routes/inventory/dto/create-inventory.dto.ts
@@ -9,7 +9,7 @@ import {
   Min,
   MaxLength,
 } from 'class-validator';
-import type { CreateInventoryDto as CreateInventoryDtoShape } from '@librestock/types';
+import type { CreateInventoryDto as CreateInventoryDtoShape } from '@librestock/types/inventory';
 
 export class CreateInventoryDto implements CreateInventoryDtoShape {
   @ApiProperty({

--- a/src/routes/inventory/dto/inventory-query.dto.ts
+++ b/src/routes/inventory/dto/inventory-query.dto.ts
@@ -10,11 +10,8 @@ import {
   Max,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
-import {
-  InventorySortField,
-  SortOrder,
-  type InventoryQueryDto as InventoryQueryDtoShape,
-} from '@librestock/types';
+import { SortOrder } from '@librestock/types/common';
+import { InventorySortField, type InventoryQueryDto as InventoryQueryDtoShape } from '@librestock/types/inventory';
 
 export { InventorySortField, SortOrder };
 

--- a/src/routes/inventory/dto/inventory-response.dto.ts
+++ b/src/routes/inventory/dto/inventory-response.dto.ts
@@ -4,7 +4,7 @@ import type {
   InventoryResponseDto as InventoryResponseDtoShape,
   LocationSummaryDto as LocationSummaryDtoShape,
   ProductSummaryDto as ProductSummaryDtoShape,
-} from '@librestock/types';
+} from '@librestock/types/inventory';
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
 export class ProductSummaryDto implements ProductSummaryDtoShape {

--- a/src/routes/inventory/dto/paginated-inventory-response.dto.ts
+++ b/src/routes/inventory/dto/paginated-inventory-response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type {
-  PaginatedInventoryResponseDto as PaginatedInventoryResponseDtoShape,
-  PaginationMeta as PaginationMetaShape,
-} from '@librestock/types';
+import type { PaginationMeta as PaginationMetaShape } from '@librestock/types/common';
+import type { PaginatedInventoryResponseDto as PaginatedInventoryResponseDtoShape } from '@librestock/types/inventory';
 import { InventoryResponseDto } from './inventory-response.dto';
 
 export class PaginationMeta implements PaginationMetaShape {

--- a/src/routes/inventory/dto/update-inventory.dto.ts
+++ b/src/routes/inventory/dto/update-inventory.dto.ts
@@ -9,7 +9,7 @@ import {
   Min,
   MaxLength,
 } from 'class-validator';
-import type { UpdateInventoryDto as UpdateInventoryDtoShape } from '@librestock/types';
+import type { UpdateInventoryDto as UpdateInventoryDtoShape } from '@librestock/types/inventory';
 
 export class UpdateInventoryDto implements UpdateInventoryDtoShape {
   @ApiProperty({

--- a/src/routes/inventory/inventory.controller.ts
+++ b/src/routes/inventory/inventory.controller.ts
@@ -19,7 +19,7 @@ import {
   ApiTags,
   ApiParam,
 } from '@nestjs/swagger';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { RequirePermission } from '../../common/decorators';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { MessageResponseDto } from '../../common/dto/message-response.dto';

--- a/src/routes/inventory/inventory.service.spec.ts
+++ b/src/routes/inventory/inventory.service.spec.ts
@@ -184,7 +184,7 @@ describe('InventoryService', () => {
       const result = await service.findAll();
 
       expect(result).toHaveLength(1);
-      expect(result[0].product_id).toBe('product-001');
+      expect(result[0]!.product_id).toBe('product-001');
     });
   });
 

--- a/src/routes/locations/dto/create-location.dto.ts
+++ b/src/routes/locations/dto/create-location.dto.ts
@@ -7,8 +7,8 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
-import type { CreateLocationDto as CreateLocationDtoShape } from '@librestock/types';
-import { LocationType } from '@librestock/types';
+import type { CreateLocationDto as CreateLocationDtoShape } from '@librestock/types/locations';
+import { LocationType } from '@librestock/types/locations';
 
 export class CreateLocationDto implements CreateLocationDtoShape {
   @ApiProperty({

--- a/src/routes/locations/dto/location-query.dto.ts
+++ b/src/routes/locations/dto/location-query.dto.ts
@@ -9,12 +9,12 @@ import {
   Max,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
+import { SortOrder } from '@librestock/types/common';
 import {
   LocationType,
   LocationSortField,
-  SortOrder,
   type LocationQueryDto as LocationQueryDtoShape,
-} from '@librestock/types';
+} from '@librestock/types/locations';
 
 export { LocationSortField, SortOrder };
 

--- a/src/routes/locations/dto/location-response.dto.ts
+++ b/src/routes/locations/dto/location-response.dto.ts
@@ -1,8 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {
-  type LocationResponseDto as LocationResponseDtoShape,
-  LocationType,
-} from '@librestock/types';
+import { type LocationResponseDto as LocationResponseDtoShape, LocationType } from '@librestock/types/locations';
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
 export class LocationResponseDto

--- a/src/routes/locations/dto/paginated-locations-response.dto.ts
+++ b/src/routes/locations/dto/paginated-locations-response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type {
-  PaginatedLocationsResponseDto as PaginatedLocationsResponseDtoShape,
-  PaginationMeta as PaginationMetaShape,
-} from '@librestock/types';
+import type { PaginationMeta as PaginationMetaShape } from '@librestock/types/common';
+import type { PaginatedLocationsResponseDto as PaginatedLocationsResponseDtoShape } from '@librestock/types/locations';
 import { LocationResponseDto } from './location-response.dto';
 
 export class PaginationMeta implements PaginationMetaShape {

--- a/src/routes/locations/dto/update-location.dto.ts
+++ b/src/routes/locations/dto/update-location.dto.ts
@@ -7,8 +7,8 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
-import type { UpdateLocationDto as UpdateLocationDtoShape } from '@librestock/types';
-import { LocationType } from '@librestock/types';
+import type { UpdateLocationDto as UpdateLocationDtoShape } from '@librestock/types/locations';
+import { LocationType } from '@librestock/types/locations';
 
 export class UpdateLocationDto implements UpdateLocationDtoShape {
   @ApiProperty({

--- a/src/routes/locations/locations.controller.ts
+++ b/src/routes/locations/locations.controller.ts
@@ -18,7 +18,7 @@ import {
   ApiTags,
   ApiParam,
 } from '@nestjs/swagger';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { RequirePermission } from '../../common/decorators';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { MessageResponseDto } from '../../common/dto/message-response.dto';

--- a/src/routes/locations/locations.service.spec.ts
+++ b/src/routes/locations/locations.service.spec.ts
@@ -98,7 +98,7 @@ describe('LocationsService', () => {
       const result = await service.findAll();
 
       expect(result).toHaveLength(1);
-      expect(result[0].name).toBe('Main Warehouse');
+      expect(result[0]!.name).toBe('Main Warehouse');
     });
 
     it('should return empty array when no locations exist', async () => {

--- a/src/routes/orders/dto/order-response.dto.ts
+++ b/src/routes/orders/dto/order-response.dto.ts
@@ -3,7 +3,7 @@ import {
   OrderStatus,
   type OrderResponseType as OrderResponseTypeShape,
   type OrderItemResponseType as OrderItemResponseTypeShape,
-} from '@librestock/types';
+} from '@librestock/types/orders';
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
 export class OrderItemResponseDto

--- a/src/routes/orders/dto/paginated-orders-response.dto.ts
+++ b/src/routes/orders/dto/paginated-orders-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { PaginationMeta as PaginationMetaShape } from '@librestock/types';
+import type { PaginationMeta as PaginationMetaShape } from '@librestock/types/common';
 import { OrderResponseDto } from './order-response.dto';
 
 export class PaginationMeta implements PaginationMetaShape {

--- a/src/routes/orders/entities/order.entity.ts
+++ b/src/routes/orders/entities/order.entity.ts
@@ -10,7 +10,7 @@ import {
   Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
-import { OrderStatus } from '@librestock/types';
+import { OrderStatus } from '@librestock/types/orders';
 import { Client } from '../../clients/entities/client.entity';
 import { OrderItem } from './order-item.entity';
 

--- a/src/routes/orders/events/order-status-changed.event.ts
+++ b/src/routes/orders/events/order-status-changed.event.ts
@@ -1,4 +1,4 @@
-import { type OrderStatus } from '@librestock/types';
+import { type OrderStatus } from '@librestock/types/orders';
 import { type Order } from '../entities/order.entity';
 
 export const ORDER_STATUS_CHANGED = 'order.status.changed';

--- a/src/routes/orders/orders.controller.ts
+++ b/src/routes/orders/orders.controller.ts
@@ -24,15 +24,16 @@ import {
   CreateOrderSchema,
   OrderIdSchema,
   OrderQuerySchema,
-  Permission,
-  Resource,
   UpdateOrderSchema,
   UpdateOrderStatusSchema,
-  type CreateOrder,
-  type OrderQuery,
-  type UpdateOrder,
-  type UpdateOrderStatus,
 } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
+import {
+  type CreateOrderType as CreateOrder,
+  type OrderQueryType as OrderQuery,
+  type UpdateOrderType as UpdateOrder,
+  type UpdateOrderStatusType as UpdateOrderStatus,
+} from '@librestock/types/orders';
 import {
   getUserIdFromSession,
   getUserSession,

--- a/src/routes/orders/orders.errors.ts
+++ b/src/routes/orders/orders.errors.ts
@@ -1,5 +1,5 @@
 import { Data } from 'effect';
-import type { OrderStatus } from '@librestock/types';
+import type { OrderStatus } from '@librestock/types/orders';
 
 export class OrderNotFound extends Data.TaggedError('OrderNotFound')<{
   readonly id: string;

--- a/src/routes/orders/orders.repository.ts
+++ b/src/routes/orders/orders.repository.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { type OrderQueryType as OrderQuery } from '@librestock/types/orders';
 import { Order } from './entities/order.entity';
-import { type OrderQuery } from '@librestock/types';
 
 export interface PaginatedResult<T> {
   data: T[];

--- a/src/routes/orders/orders.service.spec.ts
+++ b/src/routes/orders/orders.service.spec.ts
@@ -1,8 +1,7 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Effect } from 'effect';
-// eslint-disable-next-line no-restricted-imports
-import { OrderStatus } from '@librestock/types';
+import { OrderStatus, type CreateOrderType as CreateOrder } from '@librestock/types/orders';
 import { ClientsService } from '../clients/clients.service';
 import { ProductsService } from '../products/products.service';
 import { type OrderItem } from './entities/order-item.entity';
@@ -10,7 +9,6 @@ import { type Order } from './entities/order.entity';
 import { ORDER_STATUS_CHANGED } from './events/order-status-changed.event';
 import { OrderItemRepository } from './order-items.repository';
 import { OrderRepository, type PaginatedResult } from './orders.repository';
-import { type CreateOrder } from '@librestock/types';
 import { OrdersService } from './orders.service';
 
 describe('OrdersService', () => {

--- a/src/routes/orders/orders.service.ts
+++ b/src/routes/orders/orders.service.ts
@@ -3,11 +3,11 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Effect } from 'effect';
 import {
   OrderStatus,
-  type CreateOrder,
-  type OrderQuery,
-  type UpdateOrder,
-  type UpdateOrderStatus,
-} from '@librestock/types';
+  type CreateOrderType as CreateOrder,
+  type OrderQueryType as OrderQuery,
+  type UpdateOrderType as UpdateOrder,
+  type UpdateOrderStatusType as UpdateOrderStatus,
+} from '@librestock/types/orders';
 import { toPaginatedResponse } from '../../common/utils/pagination.utils';
 import { ClientsService } from '../clients/clients.service';
 import { ProductsService } from '../products/products.service';
@@ -47,7 +47,7 @@ export class OrdersService {
       OrderUtils.tryAsync('list orders', () =>
         this.orderRepository.findAllPaginated(query),
       ),
-      (result) => toPaginatedResponse(result, OrderUtils.toOrderResponseDto),
+      (result) => toPaginatedResponse(result, (order) => OrderUtils.toOrderResponseDto(order)),
     );
   }
 
@@ -57,7 +57,7 @@ export class OrdersService {
     OrderResponseDto,
     OrderNotFound | OrdersInfrastructureError
   > {
-    return Effect.map(this.getOrderOrFail(id), OrderUtils.toOrderResponseDto);
+    return Effect.map(this.getOrderOrFail(id), (order) => OrderUtils.toOrderResponseDto(order));
   }
 
   public create(
@@ -109,7 +109,7 @@ export class OrdersService {
         this.orderRepository.create({
           client_id: dto.client_id,
           delivery_address: dto.delivery_address,
-          delivery_deadline: dto.delivery_deadline ?? null,
+          delivery_deadline: dto.delivery_deadline ? new Date(dto.delivery_deadline) : null,
           yacht_name: dto.yacht_name ?? null,
           special_instructions: dto.special_instructions ?? null,
           total_amount,
@@ -155,7 +155,7 @@ export class OrdersService {
         updateData.delivery_address = dto.delivery_address;
       }
       if (dto.delivery_deadline !== undefined) {
-        updateData.delivery_deadline = dto.delivery_deadline;
+        updateData.delivery_deadline = new Date(dto.delivery_deadline);
       }
       if (dto.yacht_name !== undefined) {
         updateData.yacht_name = dto.yacht_name;

--- a/src/routes/orders/orders.utils.ts
+++ b/src/routes/orders/orders.utils.ts
@@ -1,8 +1,8 @@
+import { Effect } from 'effect';
 import type { OrderResponseDto, OrderItemResponseDto } from './dto';
 import type { Order } from './entities/order.entity';
 import type { OrderItem } from './entities/order-item.entity';
 import { OrdersInfrastructureError } from './orders.errors';
-import { Effect } from 'effect';
 
 export class OrderUtils {
   public static toOrderItemResponseDto(item: OrderItem): OrderItemResponseDto {

--- a/src/routes/orders/state/order-state.spec.ts
+++ b/src/routes/orders/state/order-state.spec.ts
@@ -1,5 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
-import { OrderStatus } from '@librestock/types';
+import { OrderStatus } from '@librestock/types/orders';
 import { getOrderState } from './order-state';
 
 describe('OrderState', () => {

--- a/src/routes/orders/state/order-state.ts
+++ b/src/routes/orders/state/order-state.ts
@@ -1,5 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
-import { OrderStatus } from '@librestock/types';
+import { OrderStatus } from '@librestock/types/orders';
 import { type Order } from '../entities/order.entity';
 
 export abstract class OrderState {

--- a/src/routes/photos/dto/photo-response.dto.ts
+++ b/src/routes/photos/dto/photo-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { PhotoResponseDto as PhotoResponseDtoShape } from '@librestock/types';
+import type { PhotoResponseDto as PhotoResponseDtoShape } from '@librestock/types/photos';
 
 export class PhotoResponseDto implements PhotoResponseDtoShape {
   @ApiProperty({

--- a/src/routes/photos/photos.controller.ts
+++ b/src/routes/photos/photos.controller.ts
@@ -21,7 +21,7 @@ import {
   ApiTags,
   ApiBody,
 } from '@nestjs/swagger';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { type Response } from 'express';
 import { RequirePermission } from '../../common/decorators';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';

--- a/src/routes/photos/photos.service.spec.ts
+++ b/src/routes/photos/photos.service.spec.ts
@@ -99,8 +99,8 @@ describe('PhotosService', () => {
       expect(result.uploaded_by).toBe('user-001');
       expect(photoRepository.create).toHaveBeenCalledTimes(1);
 
-      const [createPayload] = photoRepository.create.mock.calls[0];
-      await expect(access(createPayload.storage_path)).resolves.toBeUndefined();
+      const [createPayload] = photoRepository.create.mock.calls[0]!;
+      await expect(access(createPayload.storage_path!)).resolves.toBeUndefined();
     });
 
     it('cleans up uploaded file when db create fails', async () => {

--- a/src/routes/photos/photos.service.spec.ts
+++ b/src/routes/photos/photos.service.spec.ts
@@ -74,8 +74,8 @@ describe('PhotosService', () => {
   describe('uploadPhoto', () => {
     it('writes file and persists photo metadata', async () => {
       photoRepository.countByProductId.mockResolvedValue(0);
-      photoRepository.create.mockImplementation(async (data) => {
-        return {
+      photoRepository.create.mockImplementation((data) => {
+        return Promise.resolve({
           id: 'photo-001',
           product_id: data.product_id!,
           filename: data.filename!,
@@ -86,7 +86,7 @@ describe('PhotosService', () => {
           uploaded_by: data.uploaded_by ?? null,
           created_at: new Date('2026-03-01T00:00:00.000Z'),
           product: null as never,
-        } satisfies Photo;
+        } satisfies Photo);
       });
 
       const result = await service.uploadPhoto(
@@ -100,7 +100,7 @@ describe('PhotosService', () => {
       expect(photoRepository.create).toHaveBeenCalledTimes(1);
 
       const [createPayload] = photoRepository.create.mock.calls[0];
-      await expect(access(createPayload.storage_path!)).resolves.toBeUndefined();
+      await expect(access(createPayload.storage_path)).resolves.toBeUndefined();
     });
 
     it('cleans up uploaded file when db create fails', async () => {

--- a/src/routes/products/dto/bulk-operations.dto.ts
+++ b/src/routes/products/dto/bulk-operations.dto.ts
@@ -15,7 +15,7 @@ import type {
   BulkDeleteDto as BulkDeleteDtoShape,
   BulkRestoreDto as BulkRestoreDtoShape,
   BulkOperationResultDto as BulkOperationResultDtoShape,
-} from '@librestock/types';
+} from '@librestock/types/products';
 import { CreateProductDto } from './create-product.dto';
 
 export class BulkCreateProductsDto implements BulkCreateProductsDtoShape {

--- a/src/routes/products/dto/create-product.dto.ts
+++ b/src/routes/products/dto/create-product.dto.ts
@@ -16,7 +16,7 @@ import {
   ValidationArguments,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
-import type { CreateProductDto as CreateProductDtoShape } from '@librestock/types';
+import type { CreateProductDto as CreateProductDtoShape } from '@librestock/types/products';
 import { Product } from '../entities/product.entity';
 
 @ValidatorConstraint({ name: 'priceGreaterThanCost', async: false })

--- a/src/routes/products/dto/paginated-products-response.dto.ts
+++ b/src/routes/products/dto/paginated-products-response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type {
-  PaginatedProductsResponseDto as PaginatedProductsResponseDtoShape,
-  PaginationMeta as PaginationMetaShape,
-} from '@librestock/types';
+import type { PaginationMeta as PaginationMetaShape } from '@librestock/types/common';
+import type { PaginatedProductsResponseDto as PaginatedProductsResponseDtoShape } from '@librestock/types/products';
 import { ProductResponseDto } from './product-response.dto';
 
 export class PaginationMeta implements PaginationMetaShape {

--- a/src/routes/products/dto/product-query.dto.ts
+++ b/src/routes/products/dto/product-query.dto.ts
@@ -10,11 +10,8 @@ import {
   Max,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
-import {
-  ProductSortField,
-  SortOrder,
-  type ProductQueryDto as ProductQueryDtoShape,
-} from '@librestock/types';
+import { SortOrder } from '@librestock/types/common';
+import { ProductSortField, type ProductQueryDto as ProductQueryDtoShape } from '@librestock/types/products';
 
 export { ProductSortField, SortOrder };
 

--- a/src/routes/products/dto/product-response.dto.ts
+++ b/src/routes/products/dto/product-response.dto.ts
@@ -4,7 +4,7 @@ import type {
   SupplierSummaryDto as SupplierSummaryDtoShape,
   ProductLinksDto as ProductLinksDtoShape,
   ProductResponseDto as ProductResponseDtoShape,
-} from '@librestock/types';
+} from '@librestock/types/products';
 import { HateoasLink } from '../../../common/hateoas/hateoas-link.dto';
 import { BaseAuditResponseDto } from '../../../common/dto/base-response.dto';
 

--- a/src/routes/products/dto/update-product.dto.ts
+++ b/src/routes/products/dto/update-product.dto.ts
@@ -16,7 +16,7 @@ import {
   ValidationArguments,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
-import type { UpdateProductDto as UpdateProductDtoShape } from '@librestock/types';
+import type { UpdateProductDto as UpdateProductDtoShape } from '@librestock/types/products';
 import { Product } from '../entities/product.entity';
 
 @ValidatorConstraint({ name: 'updatePriceGreaterThanCost', async: false })

--- a/src/routes/products/products.controller.ts
+++ b/src/routes/products/products.controller.ts
@@ -21,7 +21,7 @@ import {
   ApiParam,
   ApiQuery,
 } from '@nestjs/swagger';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { RequirePermission } from '../../common/decorators';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { MessageResponseDto } from '../../common/dto/message-response.dto';

--- a/src/routes/products/products.service.spec.ts
+++ b/src/routes/products/products.service.spec.ts
@@ -176,7 +176,7 @@ describe('ProductsService', () => {
       const result = await service.findAll();
 
       expect(result).toHaveLength(1);
-      expect(result[0].sku).toBe('PROD-001');
+      expect(result[0]!.sku).toBe('PROD-001');
     });
   });
 
@@ -220,7 +220,7 @@ describe('ProductsService', () => {
       const result = await service.findByCategory(mockCategory.id);
 
       expect(result).toHaveLength(1);
-      expect(result[0].category_id).toBe(mockCategory.id);
+      expect(result[0]!.category_id).toBe(mockCategory.id);
     });
 
     it('should throw NotFoundException when category does not exist', async () => {
@@ -381,8 +381,8 @@ describe('ProductsService', () => {
     it('should handle duplicate SKUs in request', async () => {
       const bulkDtoWithDuplicates = {
         products: [
-          { ...bulkDto.products[0], sku: 'DUPLICATE' },
-          { ...bulkDto.products[1], sku: 'DUPLICATE' },
+          { ...bulkDto.products[0]!, sku: 'DUPLICATE' },
+          { ...bulkDto.products[1]!, sku: 'DUPLICATE' },
         ],
       };
       categoriesService.existsById.mockResolvedValue(true);
@@ -527,7 +527,7 @@ describe('ProductsService', () => {
 
       expect(result.success_count).toBe(1);
       expect(result.failure_count).toBe(1);
-      expect(result.failures[0].id).toBe('non-existent');
+      expect(result.failures[0]!.id).toBe('non-existent');
     });
   });
 
@@ -674,7 +674,7 @@ describe('ProductsService', () => {
 
       expect(result.success_count).toBe(1);
       expect(result.failure_count).toBe(1);
-      expect(result.failures[0].error).toBe('Product not found or not deleted');
+      expect(result.failures[0]!.error).toBe('Product not found or not deleted');
     });
   });
 });

--- a/src/routes/roles/dto/create-role.dto.ts
+++ b/src/routes/roles/dto/create-role.dto.ts
@@ -8,7 +8,7 @@ import {
   MaxLength,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import type { CreateRoleDto as CreateRoleDtoShape } from '@librestock/types';
+import type { CreateRoleDto as CreateRoleDtoShape } from '@librestock/types/roles';
 import { RolePermissionDto } from './role-permission.dto';
 
 export class CreateRoleDto implements CreateRoleDtoShape {

--- a/src/routes/roles/dto/role-permission.dto.ts
+++ b/src/routes/roles/dto/role-permission.dto.ts
@@ -1,10 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum } from 'class-validator';
-import {
-  Resource,
-  Permission,
-  type RolePermissionDto as RolePermissionDtoShape,
-} from '@librestock/types';
+import { Resource, Permission } from '@librestock/types/auth';
+import { type RolePermissionDto as RolePermissionDtoShape } from '@librestock/types/roles';
 
 export class RolePermissionDto implements RolePermissionDtoShape {
   @ApiProperty({ description: 'Resource', enum: Resource })

--- a/src/routes/roles/dto/role-response.dto.ts
+++ b/src/routes/roles/dto/role-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import type { RoleResponseDto as RoleResponseDtoShape } from '@librestock/types';
+import type { RoleResponseDto as RoleResponseDtoShape } from '@librestock/types/roles';
 import { RolePermissionDto } from './role-permission.dto';
 
 export class RoleResponseDto implements RoleResponseDtoShape {

--- a/src/routes/roles/dto/update-role.dto.ts
+++ b/src/routes/roles/dto/update-role.dto.ts
@@ -7,7 +7,7 @@ import {
   MaxLength,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import type { UpdateRoleDto as UpdateRoleDtoShape } from '@librestock/types';
+import type { UpdateRoleDto as UpdateRoleDtoShape } from '@librestock/types/roles';
 import { RolePermissionDto } from './role-permission.dto';
 
 export class UpdateRoleDto implements UpdateRoleDtoShape {

--- a/src/routes/roles/roles.controller.ts
+++ b/src/routes/roles/roles.controller.ts
@@ -16,7 +16,8 @@ import {
   ApiTags,
   ApiParam,
 } from '@nestjs/swagger';
-import { Resource, Permission, AuditAction, AuditEntityType } from '@librestock/types';
+import { AuditAction, AuditEntityType } from '@librestock/types/audit-logs';
+import { Resource, Permission } from '@librestock/types/auth';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { RequirePermission } from '../../common/decorators/require-permission.decorator';
 import { Auditable } from '../../common/decorators/auditable.decorator';

--- a/src/routes/roles/roles.service.spec.ts
+++ b/src/routes/roles/roles.service.spec.ts
@@ -5,7 +5,7 @@ import {
   ConflictException,
 } from '@nestjs/common';
 import { DataSource } from 'typeorm';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { RolesService } from './roles.service';
 import { RolesRepository } from './roles.repository';
 import { type RoleEntity } from './entities/role.entity';

--- a/src/routes/roles/roles.service.spec.ts
+++ b/src/routes/roles/roles.service.spec.ts
@@ -95,11 +95,11 @@ describe('RolesService', () => {
       const result = await service.findAll();
 
       expect(result).toHaveLength(2);
-      expect(result[0].id).toBe('role-1');
-      expect(result[0].name).toBe('Admin');
-      expect(result[0].is_system).toBe(true);
-      expect(result[0].permissions).toHaveLength(2);
-      expect(result[1].id).toBe('role-2');
+      expect(result[0]!.id).toBe('role-1');
+      expect(result[0]!.name).toBe('Admin');
+      expect(result[0]!.is_system).toBe(true);
+      expect(result[0]!.permissions).toHaveLength(2);
+      expect(result[1]!.id).toBe('role-2');
     });
 
     it('should return empty array when no roles exist', async () => {
@@ -120,7 +120,7 @@ describe('RolesService', () => {
       expect(result.id).toBe('role-1');
       expect(result.name).toBe('Admin');
       expect(result.permissions).toHaveLength(2);
-      expect(result.permissions[0].resource).toBe(Resource.PRODUCTS);
+      expect(result.permissions[0]!.resource).toBe(Resource.PRODUCTS);
     });
 
     it('should throw NotFoundException when role does not exist', async () => {

--- a/src/routes/roles/roles.service.ts
+++ b/src/routes/roles/roles.service.ts
@@ -6,7 +6,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { DataSource } from 'typeorm';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { RolesRepository } from './roles.repository';
 import { RoleEntity } from './entities/role.entity';
 import type { CreateRoleDto } from './dto/create-role.dto';

--- a/src/routes/roles/roles.utils.ts
+++ b/src/routes/roles/roles.utils.ts
@@ -1,4 +1,4 @@
-import { type Permission, type Resource } from '@librestock/types';
+import { type Permission, type Resource } from '@librestock/types/auth';
 import type { RoleResponseDto } from './dto';
 import type { RoleEntity } from './entities/role.entity';
 

--- a/src/routes/stock-movements/dto/create-stock-movement.dto.ts
+++ b/src/routes/stock-movements/dto/create-stock-movement.dto.ts
@@ -9,8 +9,8 @@ import {
   MaxLength,
   IsNumber,
 } from 'class-validator';
-import type { CreateStockMovementDto as CreateStockMovementDtoShape } from '@librestock/types';
-import { StockMovementReason } from '@librestock/types';
+import type { CreateStockMovementDto as CreateStockMovementDtoShape } from '@librestock/types/stock-movements';
+import { StockMovementReason } from '@librestock/types/stock-movements';
 
 export class CreateStockMovementDto implements CreateStockMovementDtoShape {
   @ApiProperty({ description: 'Product ID', format: 'uuid' })

--- a/src/routes/stock-movements/dto/paginated-stock-movements-response.dto.ts
+++ b/src/routes/stock-movements/dto/paginated-stock-movements-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { PaginationMeta as PaginationMetaShape } from '@librestock/types';
+import type { PaginationMeta as PaginationMetaShape } from '@librestock/types/common';
 import { StockMovementResponseDto } from './stock-movement-response.dto';
 
 export class PaginationMeta implements PaginationMetaShape {

--- a/src/routes/stock-movements/dto/stock-movement-query.dto.ts
+++ b/src/routes/stock-movements/dto/stock-movement-query.dto.ts
@@ -9,10 +9,7 @@ import {
   Max,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import {
-  StockMovementReason,
-  type StockMovementQueryDto as StockMovementQueryDtoShape,
-} from '@librestock/types';
+import { StockMovementReason, type StockMovementQueryDto as StockMovementQueryDtoShape } from '@librestock/types/stock-movements';
 
 export class StockMovementQueryDto implements StockMovementQueryDtoShape {
   @ApiProperty({

--- a/src/routes/stock-movements/dto/stock-movement-response.dto.ts
+++ b/src/routes/stock-movements/dto/stock-movement-response.dto.ts
@@ -4,7 +4,7 @@ import {
   type StockMovementLocationSummary,
   type StockMovementProductSummary,
   StockMovementReason,
-} from '@librestock/types';
+} from '@librestock/types/stock-movements';
 
 export class StockMovementResponseDto implements StockMovementResponseDtoShape {
   @ApiProperty({ description: 'Unique identifier', format: 'uuid' })

--- a/src/routes/stock-movements/entities/stock-movement.entity.ts
+++ b/src/routes/stock-movements/entities/stock-movement.entity.ts
@@ -8,7 +8,7 @@ import {
   Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
-import { StockMovementReason } from '@librestock/types';
+import { StockMovementReason } from '@librestock/types/stock-movements';
 import { Product } from '../../products/entities/product.entity';
 import { Location } from '../../locations/entities/location.entity';
 import { Order } from '../../orders/entities/order.entity';

--- a/src/routes/stock-movements/stock-movements.controller.ts
+++ b/src/routes/stock-movements/stock-movements.controller.ts
@@ -17,7 +17,7 @@ import {
   ApiTags,
   ApiParam,
 } from '@nestjs/swagger';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { RequirePermission } from '../../common/decorators';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { PermissionGuard } from '../../common/guards/permission.guard';

--- a/src/routes/stock-movements/stock-movements.service.spec.ts
+++ b/src/routes/stock-movements/stock-movements.service.spec.ts
@@ -160,7 +160,7 @@ describe('StockMovementsService', () => {
       const result = await service.findByProduct('product-001');
 
       expect(result).toHaveLength(1);
-      expect(result[0].product_id).toBe('product-001');
+      expect(result[0]!.product_id).toBe('product-001');
     });
 
     it('should throw NotFoundException when product does not exist', async () => {

--- a/src/routes/stock-movements/stock-movements.service.spec.ts
+++ b/src/routes/stock-movements/stock-movements.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
-import { StockMovementReason } from '@librestock/types';
+import { StockMovementReason } from '@librestock/types/stock-movements';
 import { ProductsService } from '../products/products.service';
 import { LocationsService } from '../locations/locations.service';
 import { StockMovementsService } from './stock-movements.service';

--- a/src/routes/suppliers/dto/create-supplier.dto.ts
+++ b/src/routes/suppliers/dto/create-supplier.dto.ts
@@ -8,7 +8,7 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
-import type { CreateSupplierDto as CreateSupplierDtoShape } from '@librestock/types';
+import type { CreateSupplierDto as CreateSupplierDtoShape } from '@librestock/types/suppliers';
 
 export class CreateSupplierDto implements CreateSupplierDtoShape {
   @ApiProperty({

--- a/src/routes/suppliers/dto/paginated-suppliers-response.dto.ts
+++ b/src/routes/suppliers/dto/paginated-suppliers-response.dto.ts
@@ -1,8 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type {
-  PaginatedSuppliersResponseDto as PaginatedSuppliersResponseDtoShape,
-  PaginationMeta as PaginationMetaShape,
-} from '@librestock/types';
+import type { PaginationMeta as PaginationMetaShape } from '@librestock/types/common';
+import type { PaginatedSuppliersResponseDto as PaginatedSuppliersResponseDtoShape } from '@librestock/types/suppliers';
 import { SupplierResponseDto } from './supplier-response.dto';
 
 export class PaginationMeta implements PaginationMetaShape {

--- a/src/routes/suppliers/dto/supplier-query.dto.ts
+++ b/src/routes/suppliers/dto/supplier-query.dto.ts
@@ -8,7 +8,7 @@ import {
   Max,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
-import type { SupplierQueryDto as SupplierQueryDtoShape } from '@librestock/types';
+import type { SupplierQueryDto as SupplierQueryDtoShape } from '@librestock/types/suppliers';
 
 export class SupplierQueryDto implements SupplierQueryDtoShape {
   @ApiProperty({

--- a/src/routes/suppliers/dto/supplier-response.dto.ts
+++ b/src/routes/suppliers/dto/supplier-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { SupplierResponseDto as SupplierResponseDtoShape } from '@librestock/types';
+import type { SupplierResponseDto as SupplierResponseDtoShape } from '@librestock/types/suppliers';
 import { BaseResponseDto } from '../../../common/dto/base-response.dto';
 
 export class SupplierResponseDto

--- a/src/routes/suppliers/dto/update-supplier.dto.ts
+++ b/src/routes/suppliers/dto/update-supplier.dto.ts
@@ -8,7 +8,7 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
-import type { UpdateSupplierDto as UpdateSupplierDtoShape } from '@librestock/types';
+import type { UpdateSupplierDto as UpdateSupplierDtoShape } from '@librestock/types/suppliers';
 
 export class UpdateSupplierDto implements UpdateSupplierDtoShape {
   @ApiProperty({

--- a/src/routes/suppliers/suppliers.controller.ts
+++ b/src/routes/suppliers/suppliers.controller.ts
@@ -18,7 +18,7 @@ import {
   ApiTags,
   ApiParam,
 } from '@nestjs/swagger';
-import { Permission, Resource } from '@librestock/types';
+import { Permission, Resource } from '@librestock/types/auth';
 import { RequirePermission } from '../../common/decorators';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { MessageResponseDto } from '../../common/dto/message-response.dto';

--- a/src/routes/users/dto/ban-user.dto.ts
+++ b/src/routes/users/dto/ban-user.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString, IsDateString } from 'class-validator';
-import { type BanUserDto as BanUserDtoShape } from '@librestock/types';
+import { type BanUserDto as BanUserDtoShape } from '@librestock/types/users';
 
 export class BanUserDto implements BanUserDtoShape {
   @ApiProperty({ description: 'Reason for banning', required: false })

--- a/src/routes/users/dto/update-user-roles.dto.ts
+++ b/src/routes/users/dto/update-user-roles.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsArray, IsUUID } from 'class-validator';
-import type { UpdateUserRolesDto as UpdateUserRolesDtoShape } from '@librestock/types';
+import type { UpdateUserRolesDto as UpdateUserRolesDtoShape } from '@librestock/types/users';
 
 export class UpdateUserRolesDto implements UpdateUserRolesDtoShape {
   @ApiProperty({

--- a/src/routes/users/dto/user-query.dto.ts
+++ b/src/routes/users/dto/user-query.dto.ts
@@ -7,7 +7,7 @@ import {
   Max,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import type { UserQueryDto as UserQueryDtoShape } from '@librestock/types';
+import type { UserQueryDto as UserQueryDtoShape } from '@librestock/types/users';
 
 export class UserQueryDto implements UserQueryDtoShape {
   @ApiProperty({

--- a/src/routes/users/dto/user-response.dto.ts
+++ b/src/routes/users/dto/user-response.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import type { UserResponseDto as UserResponseDtoShape } from '@librestock/types';
+import type { UserResponseDto as UserResponseDtoShape } from '@librestock/types/users';
 
 export class UserResponseDto implements UserResponseDtoShape {
   @ApiProperty({ description: 'User ID', format: 'uuid' })

--- a/src/routes/users/users.controller.ts
+++ b/src/routes/users/users.controller.ts
@@ -20,7 +20,7 @@ import {
   ApiParam,
 } from '@nestjs/swagger';
 import type { Request } from 'express';
-import { Resource, Permission } from '@librestock/types';
+import { Resource, Permission } from '@librestock/types/auth';
 import { ErrorResponseDto } from '../../common/dto/error-response.dto';
 import { RequirePermission } from '../../common/decorators';
 import { PermissionGuard } from '../../common/guards/permission.guard';

--- a/src/routes/users/users.service.spec.ts
+++ b/src/routes/users/users.service.spec.ts
@@ -21,11 +21,11 @@ jest.mock('../../auth', () => ({
   },
 }));
 
-const mockListUsers = auth.api.listUsers as jest.Mock;
-const mockBanUser = auth.api.banUser as jest.Mock;
-const mockUnbanUser = auth.api.unbanUser as jest.Mock;
-const mockRemoveUser = auth.api.removeUser as jest.Mock;
-const mockRevokeUserSessions = auth.api.revokeUserSessions as jest.Mock;
+const mockListUsers = auth.api.listUsers as unknown as jest.Mock;
+const mockBanUser = auth.api.banUser as unknown as jest.Mock;
+const mockUnbanUser = auth.api.unbanUser as unknown as jest.Mock;
+const mockRemoveUser = auth.api.removeUser as unknown as jest.Mock;
+const mockRevokeUserSessions = auth.api.revokeUserSessions as unknown as jest.Mock;
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -124,9 +124,9 @@ describe('UsersService', () => {
       );
 
       expect(result.data).toHaveLength(1);
-      expect(result.data[0].id).toBe('user-1');
-      expect(result.data[0].name).toBe('John Doe');
-      expect(result.data[0].roles).toEqual(['Admin']);
+      expect(result.data[0]!.id).toBe('user-1');
+      expect(result.data[0]!.name).toBe('John Doe');
+      expect(result.data[0]!.roles).toEqual(['Admin']);
       expect(result.total).toBe(1);
       expect(result.page).toBe(1);
       expect(result.limit).toBe(20);
@@ -193,7 +193,7 @@ describe('UsersService', () => {
       );
 
       expect(result.data).toHaveLength(1);
-      expect(result.data[0].id).toBe('user-1');
+      expect(result.data[0]!.id).toBe('user-1');
       expect(result.total).toBe(1);
     });
 

--- a/src/scripts/seed/audit-logs.ts
+++ b/src/scripts/seed/audit-logs.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
-import { AuditAction, AuditEntityType, OrderStatus } from '@librestock/types';
+import { AuditAction, AuditEntityType } from '@librestock/types/audit-logs';
+import { OrderStatus } from '@librestock/types/orders';
 import { AuditLog } from '../../routes/audit-logs/entities/audit-log.entity';
 import { type Category } from '../../routes/categories/entities/category.entity';
 import { type Location } from '../../routes/locations/entities/location.entity';

--- a/src/scripts/seed/config.ts
+++ b/src/scripts/seed/config.ts
@@ -1,4 +1,4 @@
-import { LocationType } from '@librestock/types';
+import { LocationType } from '@librestock/types/locations';
 import { DataSource } from 'typeorm';
 import { Area } from '../../routes/areas/entities/area.entity';
 import { AuditLog } from '../../routes/audit-logs/entities/audit-log.entity';

--- a/src/scripts/seed/factories/index.ts
+++ b/src/scripts/seed/factories/index.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
-import { ClientStatus, type LocationType } from '@librestock/types';
+import { ClientStatus } from '@librestock/types/clients';
+import { type LocationType } from '@librestock/types/locations';
 import type { DeepPartial } from 'typeorm';
 import type { Client } from '../../../routes/clients/entities/client.entity';
 import type { Inventory } from '../../../routes/inventory/entities/inventory.entity';

--- a/src/scripts/seed/inventory.ts
+++ b/src/scripts/seed/inventory.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { LocationType } from '@librestock/types';
+import { LocationType } from '@librestock/types/locations';
 import { type Area } from '../../routes/areas/entities/area.entity';
 import { Inventory } from '../../routes/inventory/entities/inventory.entity';
 import { type Location } from '../../routes/locations/entities/location.entity';

--- a/src/scripts/seed/locations.ts
+++ b/src/scripts/seed/locations.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { LocationType } from '@librestock/types';
+import { LocationType } from '@librestock/types/locations';
 import { Area } from '../../routes/areas/entities/area.entity';
 import { Location } from '../../routes/locations/entities/location.entity';
 import { AREA_TEMPLATES, LOCATION_NAMES, SEED_CONFIG, SUB_AREA_TEMPLATES } from './config';

--- a/src/scripts/seed/orders.ts
+++ b/src/scripts/seed/orders.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
-import { ClientStatus, OrderStatus } from '@librestock/types';
+import { ClientStatus } from '@librestock/types/clients';
+import { OrderStatus } from '@librestock/types/orders';
 import { type Client } from '../../routes/clients/entities/client.entity';
 import { OrderItem } from '../../routes/orders/entities/order-item.entity';
 import { Order } from '../../routes/orders/entities/order.entity';

--- a/src/scripts/seed/stock-movements.ts
+++ b/src/scripts/seed/stock-movements.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
-import { LocationType, StockMovementReason } from '@librestock/types';
+import { LocationType } from '@librestock/types/locations';
+import { StockMovementReason } from '@librestock/types/stock-movements';
 import { type Location } from '../../routes/locations/entities/location.entity';
 import { type Order } from '../../routes/orders/entities/order.entity';
 import { type Product } from '../../routes/products/entities/product.entity';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,10 @@
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "effect": ["./node_modules/effect"],
+      "effect/*": ["./node_modules/effect/*"]
+    },
     "strictPropertyInitialization": false
   }
 }


### PR DESCRIPTION
\## Update types package and refactor error handling

Upgrades `@librestock/types` from 1.1.6 to 1.2.0 and updates all imports to use the new modular structure with specific subpaths (e.g., `@librestock/types/auth`, `@librestock/types/common`).

Refactors the Effect error handling system with improved type safety:

- Redesigns error factory functions to support generic payload fields while maintaining required base fields
- Enhances type guards with proper runtime validation for `AppError` instances
- Adds comprehensive test coverage for error subclasses with typed payload fields
- Improves `FiberFailure` unwrapping logic with better type safety

Updates Swagger utilities to use proper type imports and improves property access patterns. Adds TypeScript path mapping for Effect library imports.