### PR TITLE
feat(tenancy): require explicit platform host config

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,7 +1,8 @@
 DATABASE_URL=""
 NODE_ENV="development"
 PORT=8080
-TENANT_BASE_DOMAIN=librestock.maximilian.pw
+TENANT_BASE_DOMAIN=stocket.fr
+PLATFORM_HOST=app.stocket.fr
 CORS_ORIGIN=http://localhost:3000
 BETTER_AUTH_SECRET=""
 BETTER_AUTH_URL=http://localhost:8080

--- a/src/effect/http/tenant.spec.ts
+++ b/src/effect/http/tenant.spec.ts
@@ -13,7 +13,7 @@ import { tenantContextMiddleware } from './tenant';
 
 const TEST_USER_ID = '00000000-0000-4000-a000-000000000001';
 const TENANT_HOST = 'stocket.stocket.fr';
-const PLATFORM_HOST = 'default.stocket.fr';
+const PLATFORM_HOST = 'app.stocket.fr';
 const tenantUrl = (path: string) => `http://${TENANT_HOST}${path}`;
 const platformUrl = (path: string) => `http://${PLATFORM_HOST}${path}`;
 

--- a/src/effect/platform/tenancy/host.ts
+++ b/src/effect/platform/tenancy/host.ts
@@ -4,12 +4,13 @@ import { isValidTenantSlug } from '@stocket/types/common';
 
 export { isValidTenantSlug } from '@stocket/types/common';
 
-const DEFAULT_PRODUCTION_TENANT_BASE_DOMAIN = 'librestock.maximilian.pw';
-const PRODUCTION_PLATFORM_SUBDOMAIN = 'default';
+const DEFAULT_TENANT_BASE_DOMAIN = 'stocket.fr';
+const DEFAULT_PLATFORM_SUBDOMAIN = 'app';
 const LOCAL_PLATFORM_HOST = 'localhost';
 const LOCAL_TENANT_BASE_DOMAIN = 'localhost';
 const LOCAL_TENANT_PORT = '3000';
 const DEFAULT_RESERVED_TENANT_SLUGS = [
+  'app',
   'default',
   'api',
   'deploy',
@@ -38,7 +39,10 @@ const stripPort = (host: string) => {
 
 const parseReservedTenantSlugs = () =>
   new Set(
-    (process.env.RESERVED_TENANT_SLUGS ?? DEFAULT_RESERVED_TENANT_SLUGS.join(','))
+    (
+      process.env.RESERVED_TENANT_SLUGS ??
+      DEFAULT_RESERVED_TENANT_SLUGS.join(',')
+    )
       .split(',')
       .map((slug) => slug.trim().toLowerCase())
       .filter(Boolean),
@@ -52,30 +56,43 @@ export const normalizeHost = (value: string | null | undefined) => {
   return normalized.length > 0 ? normalized : null;
 };
 
-const isProductionRuntime = () => process.env.NODE_ENV === 'production';
+const isLocalRuntime = () =>
+  process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'staging';
 
-export const getProductionTenantBaseDomain = () =>
-  normalizeHost(process.env.TENANT_BASE_DOMAIN) ??
-  DEFAULT_PRODUCTION_TENANT_BASE_DOMAIN;
+const requireHostConfig = (name: string) => {
+  const value = normalizeHost(process.env[name]);
+  if (!value && !isLocalRuntime()) {
+    throw new Error(
+      `${name} is required when NODE_ENV=${process.env.NODE_ENV}`,
+    );
+  }
+  return value;
+};
 
-export const getProductionPlatformHost = () =>
-  `${PRODUCTION_PLATFORM_SUBDOMAIN}.${getProductionTenantBaseDomain()}`;
+export const getTenantBaseDomain = () =>
+  requireHostConfig('TENANT_BASE_DOMAIN') ?? DEFAULT_TENANT_BASE_DOMAIN;
+
+export const getPlatformHost = () =>
+  requireHostConfig('PLATFORM_HOST') ??
+  `${DEFAULT_PLATFORM_SUBDOMAIN}.${getTenantBaseDomain()}`;
+
+// Backwards-compatible exports for callers/tests that still use the old names.
+export const getProductionTenantBaseDomain = getTenantBaseDomain;
+export const getProductionPlatformHost = getPlatformHost;
 
 const getPlatformHosts = () =>
   new Set([
-    getProductionPlatformHost(),
-    ...(isProductionRuntime() ? [] : [LOCAL_PLATFORM_HOST]),
+    getPlatformHost(),
+    ...(isLocalRuntime() ? [LOCAL_PLATFORM_HOST] : []),
   ]);
 
 const getPrimaryTenantBaseDomain = () =>
-  isProductionRuntime()
-    ? getProductionTenantBaseDomain()
-    : LOCAL_TENANT_BASE_DOMAIN;
+  isLocalRuntime() ? LOCAL_TENANT_BASE_DOMAIN : getTenantBaseDomain();
 
 const getTenantBaseDomains = () =>
   new Set([
-    getProductionTenantBaseDomain(),
-    ...(isProductionRuntime() ? [] : [LOCAL_TENANT_BASE_DOMAIN]),
+    getTenantBaseDomain(),
+    ...(isLocalRuntime() ? [LOCAL_TENANT_BASE_DOMAIN] : []),
   ]);
 
 const getReservedTenantSlugs = () => parseReservedTenantSlugs();
@@ -121,7 +138,9 @@ export const resolveRequestHost = (
     if (normalizedForwardedHost) return normalizedForwardedHost;
   }
 
-  return normalizeHost(request.headers.host ?? hostFromUrl(request.originalUrl));
+  return normalizeHost(
+    request.headers.host ?? hostFromUrl(request.originalUrl),
+  );
 };
 
 export const isPlatformHost = (host: string | null | undefined) => {
@@ -152,9 +171,9 @@ export const isTenantSubdomain = (host: string | null | undefined) =>
   getTenantSlugFromHost(host) !== null;
 
 export const hostnameForTenantSlug = (slug: string) =>
-  isProductionRuntime()
-    ? `${slug.toLowerCase()}.${getPrimaryTenantBaseDomain()}`
-    : `${slug.toLowerCase()}.${getPrimaryTenantBaseDomain()}:${LOCAL_TENANT_PORT}`;
+  isLocalRuntime()
+    ? `${slug.toLowerCase()}.${getPrimaryTenantBaseDomain()}:${LOCAL_TENANT_PORT}`
+    : `${slug.toLowerCase()}.${getPrimaryTenantBaseDomain()}`;
 
 export const isAllowedPlatformOrTenantHost = (
   host: string | null | undefined,

--- a/src/effect/platform/tenancy/tenant-constants.ts
+++ b/src/effect/platform/tenancy/tenant-constants.ts
@@ -1,3 +1,3 @@
 export const DEFAULT_TENANT_ID = '00000000-0000-4000-8000-000000000001';
-export const DEFAULT_TENANT_NAME = 'LibreStock';
-export const DEFAULT_TENANT_SLUG = 'librestock';
+export const DEFAULT_TENANT_NAME = 'Stocket';
+export const DEFAULT_TENANT_SLUG = 'stocket';

--- a/src/effect/platform/testing/authorization.spec.ts
+++ b/src/effect/platform/testing/authorization.spec.ts
@@ -186,7 +186,7 @@ describe('requireSuperAdmin', () => {
     await expect(
       fail(
         requireSuperAdmin.pipe(
-          Effect.provide(makeRequestLayer('tenant.librestock.maximilian.pw')),
+          Effect.provide(makeRequestLayer('tenant.stocket.fr')),
           Effect.provide(makeDbLayer([{ user_id: 'user-1' }])),
         ),
       ),
@@ -203,7 +203,7 @@ describe('requireSuperAdmin', () => {
       fail(
         requireSuperAdmin.pipe(
           Effect.provide(
-            makeRequestLayer('default.librestock.maximilian.pw'),
+            makeRequestLayer('app.stocket.fr'),
           ),
           Effect.provide(makeDbLayer([])),
         ),
@@ -220,7 +220,7 @@ describe('requireSuperAdmin', () => {
       fail(
         requireSuperAdmin.pipe(
           Effect.provide(
-            makeRequestLayer('default.librestock.maximilian.pw'),
+            makeRequestLayer('app.stocket.fr'),
           ),
           Effect.provide(makeFailingDbLayer()),
         ),
@@ -237,7 +237,7 @@ describe('requireSuperAdmin', () => {
       run(
         requireSuperAdmin.pipe(
           Effect.provide(
-            makeRequestLayer('default.librestock.maximilian.pw'),
+            makeRequestLayer('app.stocket.fr'),
           ),
           Effect.provide(makeDbLayer([{ user_id: 'user-1' }])),
         ),

--- a/src/effect/platform/testing/host.spec.ts
+++ b/src/effect/platform/testing/host.spec.ts
@@ -10,133 +10,152 @@ import {
   resolveRequestHost,
 } from '../host';
 
+const withEnv = <A>(
+  values: Record<string, string | undefined>,
+  run: () => A,
+): A => {
+  const previous = Object.fromEntries(
+    Object.keys(values).map((key) => [key, process.env[key]]),
+  );
+
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  try {
+    return run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+};
+
 describe('platform host helpers', () => {
   it('normalizes host casing, ports, lists, and trailing dots', () => {
-    expect(normalizeHost(' Default.LibreStock.Maximilian.PW:443. ')).toBe(
-      'default.librestock.maximilian.pw',
-    );
-    expect(normalizeHost('Tenant.Librestock.Maximilian.PW, proxy.local')).toBe(
-      'tenant.librestock.maximilian.pw',
+    expect(normalizeHost(' App.Stocket.FR:443. ')).toBe('app.stocket.fr');
+    expect(normalizeHost('Tenant.Stocket.FR, proxy.local')).toBe(
+      'tenant.stocket.fr',
     );
   });
 
   it('recognizes platform hosts separately from tenant hosts', () => {
-    expect(isPlatformHost('default.librestock.maximilian.pw')).toBe(true);
+    expect(isPlatformHost('app.stocket.fr')).toBe(true);
     expect(isPlatformHost('localhost:3000')).toBe(true);
-    expect(isTenantSubdomain('default.librestock.maximilian.pw')).toBe(false);
+    expect(isTenantSubdomain('app.stocket.fr')).toBe(false);
     expect(isTenantSubdomain('localhost:3000')).toBe(false);
   });
 
   it('accepts exactly one DNS-safe tenant label under the base domain', () => {
-    expect(getTenantSlugFromHost('tenant-1.librestock.maximilian.pw')).toBe(
-      'tenant-1',
-    );
+    expect(getTenantSlugFromHost('tenant-1.stocket.fr')).toBe('tenant-1');
     expect(getTenantSlugFromHost('tenant-1.localhost:3000')).toBe('tenant-1');
     expect(getTenantSlugFromHost('tenant-1:3000')).toBeNull();
-    expect(isTenantSubdomain('nested.tenant.librestock.maximilian.pw')).toBe(
-      false,
-    );
-    expect(isTenantSubdomain('librestock.maximilian.pw')).toBe(false);
-    expect(isTenantSubdomain('Tenant.librestock.maximilian.pw')).toBe(true);
+    expect(isTenantSubdomain('nested.tenant.stocket.fr')).toBe(false);
+    expect(isTenantSubdomain('stocket.fr')).toBe(false);
+    expect(isTenantSubdomain('Tenant.stocket.fr')).toBe(true);
   });
 
   it('rejects reserved tenant slugs', () => {
-    expect(getTenantSlugFromHost('admin.librestock.maximilian.pw')).toBeNull();
-    expect(
-      getTenantSlugFromHost('superadmin.librestock.maximilian.pw'),
-    ).toBeNull();
+    expect(getTenantSlugFromHost('admin.stocket.fr')).toBeNull();
+    expect(getTenantSlugFromHost('app.stocket.fr')).toBeNull();
+    expect(getTenantSlugFromHost('superadmin.stocket.fr')).toBeNull();
   });
 
   it('builds tenant.localhost:3000 hostnames in local development', () => {
     expect(hostnameForTenantSlug('tenant-1')).toBe('tenant-1.localhost:3000');
   });
 
-  it('builds tenant.librestock.maximilian.pw hostnames in production by default', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    const originalTenantBaseDomain = process.env.TENANT_BASE_DOMAIN;
-    process.env.NODE_ENV = 'production';
-    delete process.env.TENANT_BASE_DOMAIN;
-    try {
-      expect(hostnameForTenantSlug('tenant-1')).toBe(
-        'tenant-1.librestock.maximilian.pw',
-      );
-    } finally {
-      if (originalNodeEnv === undefined) {
-        delete process.env.NODE_ENV;
-      } else {
-        process.env.NODE_ENV = originalNodeEnv;
-      }
-      if (originalTenantBaseDomain === undefined) {
-        delete process.env.TENANT_BASE_DOMAIN;
-      } else {
-        process.env.TENANT_BASE_DOMAIN = originalTenantBaseDomain;
-      }
-    }
+  it('requires TENANT_BASE_DOMAIN outside local runtimes', () => {
+    withEnv(
+      {
+        NODE_ENV: 'production',
+        TENANT_BASE_DOMAIN: undefined,
+        PLATFORM_HOST: 'app.stocket.fr',
+      },
+      () => {
+        expect(() => hostnameForTenantSlug('tenant-1')).toThrow(
+          'TENANT_BASE_DOMAIN is required',
+        );
+      },
+    );
+  });
+
+  it('requires PLATFORM_HOST outside local runtimes', () => {
+    withEnv(
+      {
+        NODE_ENV: 'production',
+        TENANT_BASE_DOMAIN: 'stocket.fr',
+        PLATFORM_HOST: undefined,
+      },
+      () => {
+        expect(() => isPlatformHost('app.stocket.fr')).toThrow(
+          'PLATFORM_HOST is required',
+        );
+      },
+    );
   });
 
   it('builds production tenant hostnames from TENANT_BASE_DOMAIN', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    const originalTenantBaseDomain = process.env.TENANT_BASE_DOMAIN;
-    process.env.NODE_ENV = 'production';
-    process.env.TENANT_BASE_DOMAIN = 'stock.example.com';
-    try {
-      expect(hostnameForTenantSlug('tenant-1')).toBe('tenant-1.stock.example.com');
-      expect(getTenantSlugFromHost('tenant-1.stock.example.com')).toBe('tenant-1');
-    } finally {
-      if (originalNodeEnv === undefined) {
-        delete process.env.NODE_ENV;
-      } else {
-        process.env.NODE_ENV = originalNodeEnv;
-      }
-      if (originalTenantBaseDomain === undefined) {
-        delete process.env.TENANT_BASE_DOMAIN;
-      } else {
-        process.env.TENANT_BASE_DOMAIN = originalTenantBaseDomain;
-      }
-    }
+    withEnv(
+      {
+        NODE_ENV: 'production',
+        TENANT_BASE_DOMAIN: 'stock.example.com',
+        PLATFORM_HOST: 'app.stock.example.com',
+      },
+      () => {
+        expect(hostnameForTenantSlug('tenant-1')).toBe(
+          'tenant-1.stock.example.com',
+        );
+        expect(getTenantSlugFromHost('tenant-1.stock.example.com')).toBe(
+          'tenant-1',
+        );
+      },
+    );
   });
 
   it('falls back to the original request URL host when no Host header is present', () => {
     const request = HttpServerRequest.fromWeb(
-      new Request('https://tenant.librestock.maximilian.pw/api/v1/branding'),
+      new Request('https://tenant.stocket.fr/api/v1/branding'),
     );
 
-    expect(resolveRequestHost(request)).toBe('tenant.librestock.maximilian.pw');
+    expect(resolveRequestHost(request)).toBe('tenant.stocket.fr');
   });
 
   it('prefers the Host header over the original request URL host', () => {
     const request = HttpServerRequest.fromWeb(
       new Request('https://ignored.example.com/api/v1/branding', {
-        headers: { host: 'tenant.librestock.maximilian.pw' },
+        headers: { host: 'tenant.stocket.fr' },
       }),
     );
 
-    expect(resolveRequestHost(request)).toBe('tenant.librestock.maximilian.pw');
+    expect(resolveRequestHost(request)).toBe('tenant.stocket.fr');
   });
 
   it('trusts x-forwarded-host only from trusted remote addresses', () => {
     const request = HttpServerRequest.fromWeb(
       new Request('https://ignored.example.com/api/v1/branding', {
         headers: {
-          host: 'tenant.librestock.maximilian.pw',
-          'x-forwarded-host': 'forwarded.librestock.maximilian.pw',
+          host: 'tenant.stocket.fr',
+          'x-forwarded-host': 'forwarded.stocket.fr',
         },
       }),
     );
 
     expect(
       resolveRequestHost(request.modify({ remoteAddress: '127.0.0.1' })),
-    ).toBe('forwarded.librestock.maximilian.pw');
+    ).toBe('forwarded.stocket.fr');
     expect(
       resolveRequestHost(request.modify({ remoteAddress: '203.0.113.10' })),
-    ).toBe('tenant.librestock.maximilian.pw');
+    ).toBe('tenant.stocket.fr');
   });
 
   it('falls back to Host when a trusted forwarded host is invalid', () => {
     const request = HttpServerRequest.fromWeb(
       new Request('https://ignored.example.com/api/v1/branding', {
         headers: {
-          host: 'tenant.librestock.maximilian.pw',
+          host: 'tenant.stocket.fr',
           'x-forwarded-host': '',
         },
       }),
@@ -144,18 +163,16 @@ describe('platform host helpers', () => {
 
     expect(
       resolveRequestHost(request.modify({ remoteAddress: '127.0.0.1' })),
-    ).toBe('tenant.librestock.maximilian.pw');
+    ).toBe('tenant.stocket.fr');
   });
 
   it('validates same-origin platform and tenant origins', () => {
-    expect(
-      isAllowedPlatformOrTenantOrigin(
-        'https://default.librestock.maximilian.pw',
-      ),
-    ).toBe(true);
-    expect(
-      isAllowedPlatformOrTenantOrigin('https://tenant.librestock.maximilian.pw'),
-    ).toBe(true);
+    expect(isAllowedPlatformOrTenantOrigin('https://app.stocket.fr')).toBe(
+      true,
+    );
+    expect(isAllowedPlatformOrTenantOrigin('https://tenant.stocket.fr')).toBe(
+      true,
+    );
     expect(isAllowedPlatformOrTenantOrigin('https://example.com')).toBe(false);
   });
 });


### PR DESCRIPTION
Move production/staging tenancy from legacy/default host assumptions to explicit `stocket.fr` + `app.stocket.fr`, while retaining local `localhost` behavior. Reserves the `app` subdomain and requires host config outside the local runtime.

**Stack:** ⬇ bottom (base `main`). Next in stack: #87 (`fix(tenancy): harden cross-tenant isolation…`), which targets this branch.

Closes STC-186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform host configuration from `librestock.maximilian.pw` to `stocket.fr`
  * Updated default tenant name and identifier to Stocket
  * Enhanced host and tenant resolution configuration handling

* **Tests**
  * Updated test fixtures to reflect new configuration and domain names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->