### PR TITLE
fix(tenancy): harden cross-tenant isolation and route repos through TenantQuery

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,7 +1,8 @@
 DATABASE_URL=""
 NODE_ENV="development"
 PORT=8080
-TENANT_BASE_DOMAIN=librestock.maximilian.pw
+TENANT_BASE_DOMAIN=stocket.fr
+PLATFORM_HOST=app.stocket.fr
 CORS_ORIGIN=http://localhost:3000
 BETTER_AUTH_SECRET=""
 BETTER_AUTH_URL=http://localhost:8080

--- a/src/effect/http/tenant.spec.ts
+++ b/src/effect/http/tenant.spec.ts
@@ -13,7 +13,7 @@ import { tenantContextMiddleware } from './tenant';
 
 const TEST_USER_ID = '00000000-0000-4000-a000-000000000001';
 const TENANT_HOST = 'stocket.stocket.fr';
-const PLATFORM_HOST = 'default.stocket.fr';
+const PLATFORM_HOST = 'app.stocket.fr';
 const tenantUrl = (path: string) => `http://${TENANT_HOST}${path}`;
 const platformUrl = (path: string) => `http://${PLATFORM_HOST}${path}`;
 

--- a/src/effect/modules/areas/repository.ts
+++ b/src/effect/modules/areas/repository.ts
@@ -6,9 +6,9 @@ import type {
   AreaQueryDto,
 } from '@stocket/types/areas';
 import { makeTryAsync } from '../../platform/try-async';
+import { TenantQuery } from '../../platform/tenant-query';
 import { DrizzleDatabase } from '../../platform/drizzle';
 import { areas, locations } from '../../platform/db/schema';
-import { requireRequestTenantId } from '../../platform/tenant-context';
 import {
   AreaLocationNotFound,
   AreaParentLocationMismatch,
@@ -33,6 +33,7 @@ export class AreasRepository extends Effect.Service<AreasRepository>()(
   {
     effect: Effect.gen(function* () {
       const db = yield* DrizzleDatabase;
+      const tenantQuery = yield* TenantQuery;
 
       const loadChildrenRecursively = async (
         area: AreaWithChildren,
@@ -131,7 +132,7 @@ export class AreasRepository extends Effect.Service<AreasRepository>()(
 
       const create = (dto: CreateAreaDto) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           yield* validateAreaReferences(tenantId, dto);
           return yield* tryAsync('create area', async () => {
             const rows = await db
@@ -151,7 +152,7 @@ export class AreasRepository extends Effect.Service<AreasRepository>()(
 
       const findAll = (query: AreaQueryDto) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('list areas', async () => {
             const conditions: SQL[] = [eq(areas.tenant_id, tenantId)];
 
@@ -178,7 +179,7 @@ export class AreasRepository extends Effect.Service<AreasRepository>()(
 
       const findById = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('load area', async () => {
             const rows = await db
               .select({
@@ -203,7 +204,7 @@ export class AreasRepository extends Effect.Service<AreasRepository>()(
 
       const findByIdWithChildren = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('load area with children', async () => {
             const rows = await db
               .select({
@@ -240,7 +241,7 @@ export class AreasRepository extends Effect.Service<AreasRepository>()(
 
       const findHierarchyByLocationId = (locationId: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('load area hierarchy', async () => {
             const rootAreas: AreaWithChildren[] = await db
               .select()
@@ -264,23 +265,25 @@ export class AreasRepository extends Effect.Service<AreasRepository>()(
 
       const update = (id: string, dto: UpdateAreaDto) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
-          const existing = yield* tryAsync('load area before update', async () =>
-            db
-              .select({
-                area: areas,
-                location: locations,
-              })
-              .from(areas)
-              .leftJoin(
-                locations,
-                and(
-                  eq(areas.location_id, locations.id),
-                  eq(locations.tenant_id, tenantId),
-                ),
-              )
-              .where(and(eq(areas.tenant_id, tenantId), eq(areas.id, id)))
-              .limit(1),
+          const tenantId = yield* tenantQuery.tenantId;
+          const existing = yield* tryAsync(
+            'load area before update',
+            async () =>
+              db
+                .select({
+                  area: areas,
+                  location: locations,
+                })
+                .from(areas)
+                .leftJoin(
+                  locations,
+                  and(
+                    eq(areas.location_id, locations.id),
+                    eq(locations.tenant_id, tenantId),
+                  ),
+                )
+                .where(and(eq(areas.tenant_id, tenantId), eq(areas.id, id)))
+                .limit(1),
           );
 
           if (!existing[0]) return null;
@@ -321,7 +324,7 @@ export class AreasRepository extends Effect.Service<AreasRepository>()(
 
       const remove = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('delete area', async () => {
             const result = await db
               .delete(areas)
@@ -333,7 +336,7 @@ export class AreasRepository extends Effect.Service<AreasRepository>()(
 
       const existsById = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('check area existence', async () => {
             const rows = await db
               .select({ count: sql<number>`count(*)::int` })
@@ -354,5 +357,6 @@ export class AreasRepository extends Effect.Service<AreasRepository>()(
         existsById,
       };
     }),
+    dependencies: [TenantQuery.Default],
   },
 ) {}

--- a/src/effect/modules/audit-logs/repository.ts
+++ b/src/effect/modules/audit-logs/repository.ts
@@ -18,9 +18,9 @@ import {
   toRepositoryPaginatedResult,
 } from '@stocket/types/common';
 import { makeTryAsync } from '../../platform/try-async';
+import { TenantQuery } from '../../platform/tenant-query';
 import { DrizzleDatabase } from '../../platform/drizzle';
 import { auditLogs, betterAuthUsers } from '../../platform/db/schema';
-import { requireRequestTenantId } from '../../platform/tenant-context';
 import { AuditLogsInfrastructureError } from './audit-logs.errors';
 
 export interface AuditLogQueryOptions {
@@ -75,6 +75,7 @@ export class AuditLogsRepository extends Effect.Service<AuditLogsRepository>()(
   {
     effect: Effect.gen(function* () {
       const db = yield* DrizzleDatabase;
+      const tenantQuery = yield* TenantQuery;
       const auditLogSelect = {
         ...getTableColumns(auditLogs),
         user_name: betterAuthUsers.name,
@@ -82,7 +83,7 @@ export class AuditLogsRepository extends Effect.Service<AuditLogsRepository>()(
 
       const findPaginated = (options: AuditLogQueryOptions) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('query audit logs', async () => {
             const { page, limit, skip } = resolvePaginationWindow(
               options.page,
@@ -118,7 +119,7 @@ export class AuditLogsRepository extends Effect.Service<AuditLogsRepository>()(
 
       const findById = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('load audit log', async () => {
             const rows = await db
               .select(auditLogSelect)
@@ -128,10 +129,7 @@ export class AuditLogsRepository extends Effect.Service<AuditLogsRepository>()(
                 eq(auditLogs.user_id, betterAuthUsers.id),
               )
               .where(
-                and(
-                  eq(auditLogs.tenant_id, tenantId),
-                  eq(auditLogs.id, id),
-                ),
+                and(eq(auditLogs.tenant_id, tenantId), eq(auditLogs.id, id)),
               )
               .limit(1);
             return rows[0] ?? null;
@@ -140,7 +138,7 @@ export class AuditLogsRepository extends Effect.Service<AuditLogsRepository>()(
 
       const findByEntityId = (entityType: AuditEntityType, entityId: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('load entity audit history', () =>
             db
               .select(auditLogSelect)
@@ -162,7 +160,7 @@ export class AuditLogsRepository extends Effect.Service<AuditLogsRepository>()(
 
       const findByUserId = (userId: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('load user audit history', () =>
             db
               .select(auditLogSelect)
@@ -183,5 +181,6 @@ export class AuditLogsRepository extends Effect.Service<AuditLogsRepository>()(
 
       return { findPaginated, findById, findByEntityId, findByUserId };
     }),
+    dependencies: [TenantQuery.Default],
   },
 ) {}

--- a/src/effect/modules/inventory/repository.ts
+++ b/src/effect/modules/inventory/repository.ts
@@ -23,6 +23,7 @@ import {
   type RepositoryPaginatedResult,
 } from '@stocket/types/common';
 import { makeTryAsync } from '../../platform/try-async';
+import { TenantQuery } from '../../platform/tenant-query';
 import { DrizzleDatabase, type DrizzleDb } from '../../platform/drizzle';
 import {
   inventory,
@@ -30,10 +31,7 @@ import {
   locations,
   areas,
 } from '../../platform/db/schema';
-import {
-  requireRequestTenantId,
-  type TenantNotResolved,
-} from '../../platform/tenant-context';
+import type { TenantNotResolved } from '../../platform/tenant-context';
 import { InventoryInfrastructureError } from './inventory.errors';
 
 type InventoryRow = typeof inventory.$inferSelect;
@@ -145,6 +143,7 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
   {
     effect: Effect.gen(function* () {
       const db = yield* DrizzleDatabase;
+      const tenantQuery = yield* TenantQuery;
 
       const findAllPaginated = (
         query: InventoryQueryDto,
@@ -153,7 +152,7 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('list inventory paginated', async () => {
             const { page, limit, skip } = resolvePaginationWindow(
               query.page,
@@ -196,7 +195,7 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('list all inventory', async () => {
             const rows = await selectInventoryWithJoins(db)
               .where(eq(inventory.tenant_id, tenantId))
@@ -212,14 +211,11 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find inventory by id', async () => {
             const rows = await selectInventoryWithJoins(db)
               .where(
-                and(
-                  eq(inventory.tenant_id, tenantId),
-                  eq(inventory.id, id),
-                ),
+                and(eq(inventory.tenant_id, tenantId), eq(inventory.id, id)),
               )
               .limit(1);
             return rows[0] ? mapInventoryRow(rows[0]) : null;
@@ -233,7 +229,7 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find inventory by product', async () => {
             const rows = await selectInventoryWithJoins(db)
               .where(
@@ -254,7 +250,7 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find inventory by location', async () => {
             const rows = await selectInventoryWithJoins(db)
               .where(
@@ -277,7 +273,7 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync(
             'find inventory by product and location',
             async () => {
@@ -309,7 +305,7 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('create inventory', async () => {
             const rows = await db
               .insert(inventory)
@@ -327,16 +323,14 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('update inventory', async () => {
+            const { tenant_id: _tenantId, ...updateData } = data;
             const rows = await db
               .update(inventory)
-              .set({ ...data, updated_at: new Date() })
+              .set({ ...updateData, updated_at: new Date() })
               .where(
-                and(
-                  eq(inventory.tenant_id, tenantId),
-                  eq(inventory.id, id),
-                ),
+                and(eq(inventory.tenant_id, tenantId), eq(inventory.id, id)),
               )
               .returning({ id: inventory.id });
             return rows.length;
@@ -351,7 +345,7 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('adjust inventory quantity', async () => {
             const rows = await db
               .update(inventory)
@@ -378,15 +372,12 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('delete inventory', async () => {
             await db
               .delete(inventory)
               .where(
-                and(
-                  eq(inventory.tenant_id, tenantId),
-                  eq(inventory.id, id),
-                ),
+                and(eq(inventory.tenant_id, tenantId), eq(inventory.id, id)),
               );
           });
         });
@@ -396,7 +387,7 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         InventoryInfrastructureError | TenantNotResolved
       > =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync(
             'get inventory summary',
             async (): Promise<InventorySummaryDto> => {
@@ -430,5 +421,6 @@ export class InventoryRepository extends Effect.Service<InventoryRepository>()(
         findSummary,
       };
     }),
+    dependencies: [TenantQuery.Default],
   },
 ) {}

--- a/src/effect/modules/orders/repository.ts
+++ b/src/effect/modules/orders/repository.ts
@@ -18,6 +18,7 @@ import {
   toRepositoryPaginatedResult,
 } from '@stocket/types/common';
 import { makeTryAsync } from '../../platform/try-async';
+import { TenantQuery } from '../../platform/tenant-query';
 import { DrizzleDatabase } from '../../platform/drizzle';
 import {
   orders,
@@ -25,7 +26,6 @@ import {
   clients,
   products,
 } from '../../platform/db/schema';
-import { requireRequestTenantId } from '../../platform/tenant-context';
 import { OrdersInfrastructureError } from './orders.errors';
 
 type OrderQueryDto = Schema.Schema.Type<typeof OrderQuerySchema>;
@@ -44,10 +44,11 @@ export class OrdersRepository extends Effect.Service<OrdersRepository>()(
   {
     effect: Effect.gen(function* () {
       const db = yield* DrizzleDatabase;
+      const tenantQuery = yield* TenantQuery;
 
       const findAllPaginated = (query: OrderQueryDto) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('list orders paginated', async () => {
             const { page, limit, skip } = resolvePaginationWindow(
               query.page,
@@ -87,7 +88,13 @@ export class OrdersRepository extends Effect.Service<OrdersRepository>()(
               ? db
                   .select({ count: distinctCount })
                   .from(orders)
-                  .leftJoin(clients, eq(orders.client_id, clients.id))
+                  .leftJoin(
+                    clients,
+                    and(
+                      eq(orders.client_id, clients.id),
+                      eq(orders.tenant_id, clients.tenant_id),
+                    ),
+                  )
                   .where(where)
               : db.select({ count: totalCount }).from(orders).where(where);
 
@@ -98,7 +105,13 @@ export class OrdersRepository extends Effect.Service<OrdersRepository>()(
             const orderRows = await db
               .select()
               .from(orders)
-              .leftJoin(clients, eq(orders.client_id, clients.id))
+              .leftJoin(
+                clients,
+                and(
+                  eq(orders.client_id, clients.id),
+                  eq(orders.tenant_id, clients.tenant_id),
+                ),
+              )
               .where(where)
               .orderBy(desc(orders.created_at))
               .offset(skip)
@@ -131,12 +144,18 @@ export class OrdersRepository extends Effect.Service<OrdersRepository>()(
 
       const findById = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find order by id', async () => {
             const rows = await db
               .select()
               .from(orders)
-              .leftJoin(clients, eq(orders.client_id, clients.id))
+              .leftJoin(
+                clients,
+                and(
+                  eq(orders.client_id, clients.id),
+                  eq(orders.tenant_id, clients.tenant_id),
+                ),
+              )
               .where(and(eq(orders.tenant_id, tenantId), eq(orders.id, id)))
               .limit(1);
 
@@ -148,7 +167,13 @@ export class OrdersRepository extends Effect.Service<OrdersRepository>()(
                 product: products,
               })
               .from(orderItems)
-              .leftJoin(products, eq(orderItems.product_id, products.id))
+              .leftJoin(
+                products,
+                and(
+                  eq(orderItems.product_id, products.id),
+                  eq(products.tenant_id, tenantId),
+                ),
+              )
               .where(eq(orderItems.order_id, id));
 
             return {
@@ -161,7 +186,7 @@ export class OrdersRepository extends Effect.Service<OrdersRepository>()(
 
       const create = (data: typeof orders.$inferInsert) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('create order', async () => {
             const rows = await db
               .insert(orders)
@@ -173,11 +198,12 @@ export class OrdersRepository extends Effect.Service<OrdersRepository>()(
 
       const update = (id: string, data: Partial<typeof orders.$inferInsert>) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('update order', async () => {
+            const { tenant_id: _tenantId, ...updateData } = data;
             const rows = await db
               .update(orders)
-              .set({ ...data, updated_at: new Date() })
+              .set({ ...updateData, updated_at: new Date() })
               .where(and(eq(orders.tenant_id, tenantId), eq(orders.id, id)))
               .returning({ id: orders.id });
             return rows.length;
@@ -186,7 +212,7 @@ export class OrdersRepository extends Effect.Service<OrdersRepository>()(
 
       const remove = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('delete order', () =>
             db
               .delete(orders)
@@ -207,7 +233,7 @@ export class OrdersRepository extends Effect.Service<OrdersRepository>()(
 
       const existsById = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('check order existence', async () => {
             const rows = await db
               .select({ id: orders.id })
@@ -228,6 +254,7 @@ export class OrdersRepository extends Effect.Service<OrdersRepository>()(
         existsById,
       };
     }),
+    dependencies: [TenantQuery.Default],
   },
 ) {}
 
@@ -236,12 +263,13 @@ export class OrderItemsRepository extends Effect.Service<OrderItemsRepository>()
   {
     effect: Effect.gen(function* () {
       const db = yield* DrizzleDatabase;
+      const tenantQuery = yield* TenantQuery;
       const orderItemTenantFilter = (tenantId: string) =>
         sql`${orderItems.order_id} IN (SELECT id FROM orders WHERE tenant_id = ${tenantId})`;
 
       const findByIds = (ids: string[]) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find order items by ids', async () => {
             const rows = await db
               .select()
@@ -262,7 +290,7 @@ export class OrderItemsRepository extends Effect.Service<OrderItemsRepository>()
 
       const findByOrderId = (orderId: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find order items by order id', async () => {
             const items = await db
               .select({
@@ -270,7 +298,13 @@ export class OrderItemsRepository extends Effect.Service<OrderItemsRepository>()
                 product: products,
               })
               .from(orderItems)
-              .leftJoin(products, eq(orderItems.product_id, products.id))
+              .leftJoin(
+                products,
+                and(
+                  eq(orderItems.product_id, products.id),
+                  eq(products.tenant_id, tenantId),
+                ),
+              )
               .where(
                 and(
                   eq(orderItems.order_id, orderId),
@@ -284,13 +318,11 @@ export class OrderItemsRepository extends Effect.Service<OrderItemsRepository>()
 
       const createMany = (items: (typeof orderItems.$inferInsert)[]) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('create order items', async () => {
             if (items.length === 0) return [];
 
-            const orderIds = [
-              ...new Set(items.map((item) => item.order_id)),
-            ];
+            const orderIds = [...new Set(items.map((item) => item.order_id))];
             const tenantOrders = await db
               .select({ id: orders.id })
               .from(orders)
@@ -305,13 +337,30 @@ export class OrderItemsRepository extends Effect.Service<OrderItemsRepository>()
               throw new Error('Order item references an order outside tenant');
             }
 
+            const productIds = [
+              ...new Set(items.map((item) => item.product_id)),
+            ];
+            const tenantProducts = await db
+              .select({ id: products.id })
+              .from(products)
+              .where(
+                and(
+                  eq(products.tenant_id, tenantId),
+                  inArray(products.id, productIds),
+                ),
+              );
+
+            if (tenantProducts.length !== productIds.length) {
+              throw new Error('Order item references a product outside tenant');
+            }
+
             return db.insert(orderItems).values(items).returning();
           });
         });
 
       const incrementPicked = (orderItemId: string, quantity: number) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync(
             'increment order item quantity_picked',
             async () => {
@@ -336,7 +385,7 @@ export class OrderItemsRepository extends Effect.Service<OrderItemsRepository>()
 
       const deleteByOrderId = (orderId: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('delete order items by order id', () =>
             db
               .delete(orderItems)
@@ -357,5 +406,6 @@ export class OrderItemsRepository extends Effect.Service<OrderItemsRepository>()
         deleteByOrderId,
       };
     }),
+    dependencies: [TenantQuery.Default],
   },
 ) {}

--- a/src/effect/modules/photos/repository.ts
+++ b/src/effect/modules/photos/repository.ts
@@ -1,9 +1,9 @@
 import { Effect } from 'effect';
 import { eq, asc, sql, and } from 'drizzle-orm';
 import { makeTryAsync } from '../../platform/try-async';
+import { TenantQuery } from '../../platform/tenant-query';
 import { DrizzleDatabase } from '../../platform/drizzle';
 import { photos, products } from '../../platform/db/schema';
-import { requireRequestTenantId } from '../../platform/tenant-context';
 import { PhotosInfrastructureError } from './photos.errors';
 
 const tryAsync = makeTryAsync(
@@ -20,12 +20,13 @@ export class PhotosRepository extends Effect.Service<PhotosRepository>()(
   {
     effect: Effect.gen(function* () {
       const db = yield* DrizzleDatabase;
+      const tenantQuery = yield* TenantQuery;
       const tenantOwnsProduct = (tenantId: string) =>
         sql`${photos.product_id} IN (SELECT id FROM products WHERE tenant_id = ${tenantId})`;
 
       const findByProductId = (productId: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('list photos by product', () =>
             db
               .select()
@@ -42,7 +43,7 @@ export class PhotosRepository extends Effect.Service<PhotosRepository>()(
 
       const findById = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('load photo', async () => {
             const rows = await db
               .select()
@@ -55,7 +56,7 @@ export class PhotosRepository extends Effect.Service<PhotosRepository>()(
 
       const create = (data: typeof photos.$inferInsert) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('create photo', async () => {
             const productRows = await db
               .select({ id: products.id })
@@ -78,7 +79,7 @@ export class PhotosRepository extends Effect.Service<PhotosRepository>()(
 
       const remove = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('delete photo metadata', async () => {
             await db
               .delete(photos)
@@ -88,7 +89,7 @@ export class PhotosRepository extends Effect.Service<PhotosRepository>()(
 
       const countByProductId = (productId: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('count photos by product', async () => {
             const rows = await db
               .select({ count: sql<number>`count(*)::int` })
@@ -111,5 +112,6 @@ export class PhotosRepository extends Effect.Service<PhotosRepository>()(
         countByProductId,
       };
     }),
+    dependencies: [TenantQuery.Default],
   },
 ) {}

--- a/src/effect/modules/products/repository.ts
+++ b/src/effect/modules/products/repository.ts
@@ -20,9 +20,9 @@ import {
 } from '@stocket/types/common';
 import { buildOrderBy } from '../../platform/drizzle-sort.utils';
 import { makeTryAsync } from '../../platform/try-async';
+import { TenantQuery } from '../../platform/tenant-query';
 import { DrizzleDatabase, type DrizzleDb } from '../../platform/drizzle';
 import { products, categories, suppliers } from '../../platform/db/schema';
-import { requireRequestTenantId } from '../../platform/tenant-context';
 import type { ProductQuerySchema } from './products.schema';
 import { ProductsInfrastructureError } from './products.errors';
 
@@ -61,8 +61,20 @@ function selectProductWithJoins(db: DrizzleDb) {
       supplier: suppliers,
     })
     .from(products)
-    .leftJoin(categories, eq(products.category_id, categories.id))
-    .leftJoin(suppliers, eq(products.primary_supplier_id, suppliers.id));
+    .leftJoin(
+      categories,
+      and(
+        eq(products.category_id, categories.id),
+        eq(products.tenant_id, categories.tenant_id),
+      ),
+    )
+    .leftJoin(
+      suppliers,
+      and(
+        eq(products.primary_supplier_id, suppliers.id),
+        eq(products.tenant_id, suppliers.tenant_id),
+      ),
+    );
 }
 
 function mapProductRow(row: ProductJoinRow) {
@@ -78,10 +90,11 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
   {
     effect: Effect.gen(function* () {
       const db = yield* DrizzleDatabase;
+      const tenantQuery = yield* TenantQuery;
 
       const findAllPaginated = (query: ProductQueryDto) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('list products paginated', async () => {
             const { page, limit, skip } = resolvePaginationWindow(
               query.page,
@@ -159,7 +172,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const findAll = (includeDeleted = false) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('list all products', async () => {
             const conditions: SQL[] = [eq(products.tenant_id, tenantId)];
             if (!includeDeleted) conditions.push(isNull(products.deleted_at));
@@ -172,7 +185,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const findById = (id: string, includeDeleted = false) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find product by id', async () => {
             const conditions: SQL[] = [
               eq(products.tenant_id, tenantId),
@@ -190,7 +203,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const findBySku = (sku: string, includeDeleted = false) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find product by sku', async () => {
             const conditions: SQL[] = [
               eq(products.tenant_id, tenantId),
@@ -210,7 +223,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const findByCategoryId = (categoryId: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find products by category', async () => {
             const rows = await selectProductWithJoins(db)
               .where(
@@ -227,7 +240,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const findByCategoryIds = (categoryIds: string[]) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find products by categories', async () => {
             if (categoryIds.length === 0) return [];
 
@@ -246,7 +259,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const findByIds = (ids: string[], includeDeleted = false) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find products by ids', async () => {
             const conditions: SQL[] = [
               eq(products.tenant_id, tenantId),
@@ -264,7 +277,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const findDeletedByIds = (ids: string[]) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find deleted products by ids', () =>
             db
               .select()
@@ -281,7 +294,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const existsById = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('check product existence', async () => {
             const rows = await db
               .select({ id: products.id })
@@ -300,7 +313,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const create = (data: typeof products.$inferInsert) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('create product', async () => {
             const rows = await db
               .insert(products)
@@ -315,11 +328,12 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
         data: Partial<typeof products.$inferInsert>,
       ) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('update product', async () => {
+            const { tenant_id: _tenantId, ...updateData } = data;
             const rows = await db
               .update(products)
-              .set({ ...data, updated_at: new Date() })
+              .set({ ...updateData, updated_at: new Date() })
               .where(
                 and(
                   eq(products.tenant_id, tenantId),
@@ -337,11 +351,12 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
         data: Partial<typeof products.$inferInsert>,
       ) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('update multiple products', async () => {
+            const { tenant_id: _tenantId, ...updateData } = data;
             const rows = await db
               .update(products)
-              .set({ ...data, updated_at: new Date() })
+              .set({ ...updateData, updated_at: new Date() })
               .where(
                 and(
                   eq(products.tenant_id, tenantId),
@@ -356,7 +371,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const softDelete = (id: string, deletedBy?: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('soft delete product', async () => {
             await db
               .update(products)
@@ -377,7 +392,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const softDeleteMany = (ids: string[], deletedBy?: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('soft delete multiple products', async () => {
             const rows = await db
               .update(products)
@@ -400,7 +415,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const restore = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('restore product', async () => {
             await db
               .update(products)
@@ -421,7 +436,7 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const restoreMany = (ids: string[]) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('restore multiple products', async () => {
             const rows = await db
               .update(products)
@@ -444,22 +459,19 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
 
       const hardDelete = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('hard delete product', async () => {
             await db
               .delete(products)
               .where(
-                and(
-                  eq(products.tenant_id, tenantId),
-                  eq(products.id, id),
-                ),
+                and(eq(products.tenant_id, tenantId), eq(products.id, id)),
               );
           });
         });
 
       const hardDeleteMany = (ids: string[]) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('hard delete multiple products', async () => {
             const rows = await db
               .delete(products)
@@ -495,5 +507,6 @@ export class ProductsRepository extends Effect.Service<ProductsRepository>()(
         hardDeleteMany,
       };
     }),
+    dependencies: [TenantQuery.Default],
   },
 ) {}

--- a/src/effect/modules/products/service.effect.spec.ts
+++ b/src/effect/modules/products/service.effect.spec.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from '@effect/vitest';
 import { Effect, Layer } from 'effect';
 import { makeTestLayer } from '../../test/utils';
 import { CategoriesService } from '../categories/service';
+import { SuppliersService } from '../suppliers/service';
 import { ProductsRepository } from './repository';
 import { ProductsService } from './service';
 
@@ -106,6 +107,10 @@ const defaultCatMethods: Partial<CategoriesService> = {
   findAllDescendantIds: () => Effect.succeed(['child-1']),
 };
 
+const defaultSupplierMethods: Partial<SuppliersService> = {
+  existsById: () => Effect.succeed(true),
+};
+
 // ---------------------------------------------------------------------------
 // Layer helpers
 // ---------------------------------------------------------------------------
@@ -116,20 +121,35 @@ const repoLayer = (overrides: Partial<ProductsRepository> = {}) =>
 const catLayer = (overrides: Partial<CategoriesService> = {}) =>
   makeTestLayer(CategoriesService)({ ...defaultCatMethods, ...overrides });
 
-const serviceLayer = (repo = repoLayer(), cat = catLayer()) =>
+const supplierLayer = (overrides: Partial<SuppliersService> = {}) =>
+  makeTestLayer(SuppliersService)({
+    ...defaultSupplierMethods,
+    ...overrides,
+  });
+
+const serviceLayer = (
+  repo = repoLayer(),
+  cat = catLayer(),
+  suppliers = supplierLayer(),
+) =>
   ProductsService.DefaultWithoutDependencies.pipe(
-    Layer.provide(Layer.mergeAll(repo, cat)),
+    Layer.provide(Layer.mergeAll(repo, cat, suppliers)),
   );
 
 const withService = <A, E>(
   effect: (svc: ProductsService) => Effect.Effect<A, E>,
   repo?: Partial<ProductsRepository>,
   cat?: Partial<CategoriesService>,
+  suppliers?: Partial<SuppliersService>,
 ) =>
   Effect.gen(function* () {
     const svc = yield* ProductsService;
     return yield* effect(svc);
-  }).pipe(Effect.provide(serviceLayer(repoLayer(repo), catLayer(cat))));
+  }).pipe(
+    Effect.provide(
+      serviceLayer(repoLayer(repo), catLayer(cat), supplierLayer(suppliers)),
+    ),
+  );
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/src/effect/modules/products/service.ts
+++ b/src/effect/modules/products/service.ts
@@ -8,6 +8,8 @@ import {
   toPaginatedResponse,
 } from '@stocket/types/common';
 import { CategoriesService } from '../categories/service';
+import { SuppliersService } from '../suppliers/service';
+import { SupplierNotFound } from '../suppliers/suppliers.errors';
 import type {
   ProductQuerySchema,
   CreateProductSchema,
@@ -17,10 +19,7 @@ import type {
   BulkDeleteSchema,
   BulkRestoreSchema,
 } from './products.schema';
-import {
-  toCreateProductEntity,
-  toProductResponseDto,
-} from './products.utils';
+import { toCreateProductEntity, toProductResponseDto } from './products.utils';
 import {
   CategoryNotFound,
   PriceBelowCost,
@@ -48,10 +47,16 @@ export class ProductsService extends Effect.Service<ProductsService>()(
     effect: Effect.gen(function* () {
       const repository = yield* ProductsRepository;
       const categoriesService = yield* CategoriesService;
+      const suppliersService = yield* SuppliersService;
 
       const getProductOrFail = (id: string, includeDeleted = false) =>
-        fromNullOr(repository.findById(id, includeDeleted), () =>
-          new ProductNotFound({ productId: id, messageKey: 'products.notFound' }),
+        fromNullOr(
+          repository.findById(id, includeDeleted),
+          () =>
+            new ProductNotFound({
+              productId: id,
+              messageKey: 'products.notFound',
+            }),
         );
 
       const checkCategoryExists = (categoryId: string) =>
@@ -66,6 +71,35 @@ export class ProductsService extends Effect.Service<ProductsService>()(
           ),
           Effect.asVoid,
         );
+
+      const checkSupplierExists = (supplierId: string) =>
+        suppliersService.existsById(supplierId).pipe(
+          Effect.filterOrFail(
+            Boolean,
+            () =>
+              new SupplierNotFound({
+                id: supplierId,
+                messageKey: 'suppliers.notFound',
+              }),
+          ),
+          Effect.asVoid,
+        );
+
+      const validateProductTenantReferences = (
+        dto: Pick<
+          CreateProductDto | UpdateProductDto,
+          'category_id' | 'primary_supplier_id'
+        >,
+      ) =>
+        Effect.gen(function* () {
+          if (dto.category_id) {
+            yield* checkCategoryExists(dto.category_id);
+          }
+
+          if (dto.primary_supplier_id) {
+            yield* checkSupplierExists(dto.primary_supplier_id);
+          }
+        });
 
       const ensureSkuAvailable = (
         sku: string,
@@ -106,19 +140,20 @@ export class ProductsService extends Effect.Service<ProductsService>()(
       };
 
       const findAllPaginated = (query: ProductQueryDto) =>
-        Effect.map(
-          repository.findAllPaginated(query),
-          (result) => toPaginatedResponse(result, toProductResponseDto),
+        Effect.map(repository.findAllPaginated(query), (result) =>
+          toPaginatedResponse(result, toProductResponseDto),
         ).pipe(Effect.withSpan('ProductsService.findAllPaginated'));
 
       const findAll = () =>
-        Effect.map(
-          repository.findAll(),
-          (products) => products.map(toProductResponseDto),
+        Effect.map(repository.findAll(), (products) =>
+          products.map(toProductResponseDto),
         ).pipe(Effect.withSpan('ProductsService.findAll'));
 
       const findOne = (id: string, includeDeleted = false) =>
-        Effect.map(getProductOrFail(id, includeDeleted), toProductResponseDto).pipe(
+        Effect.map(
+          getProductOrFail(id, includeDeleted),
+          toProductResponseDto,
+        ).pipe(
           Effect.withSpan('ProductsService.findOne', { attributes: { id } }),
         );
 
@@ -127,22 +162,34 @@ export class ProductsService extends Effect.Service<ProductsService>()(
           yield* checkCategoryExists(categoryId);
           const products = yield* repository.findByCategoryId(categoryId);
           return products.map(toProductResponseDto);
-        }).pipe(Effect.withSpan('ProductsService.findByCategory', { attributes: { categoryId } }));
+        }).pipe(
+          Effect.withSpan('ProductsService.findByCategory', {
+            attributes: { categoryId },
+          }),
+        );
 
       const findByCategoryTree = (categoryId: string) =>
         Effect.gen(function* () {
           yield* checkCategoryExists(categoryId);
-          const descendantIds = yield* categoriesService.findAllDescendantIds(categoryId);
+          const descendantIds =
+            yield* categoriesService.findAllDescendantIds(categoryId);
           const categoryIds = [categoryId, ...descendantIds];
           const products = yield* repository.findByCategoryIds(categoryIds);
           return products.map(toProductResponseDto);
-        }).pipe(Effect.withSpan('ProductsService.findByCategoryTree', { attributes: { categoryId } }));
+        }).pipe(
+          Effect.withSpan('ProductsService.findByCategoryTree', {
+            attributes: { categoryId },
+          }),
+        );
 
       const create = (dto: CreateProductDto, userId?: string) =>
         Effect.gen(function* () {
-          yield* checkCategoryExists(dto.category_id);
+          yield* validateProductTenantReferences(dto);
           yield* ensureSkuAvailable(dto.sku);
-          yield* validatePriceNotBelowCost(dto.standard_price, dto.standard_cost);
+          yield* validatePriceNotBelowCost(
+            dto.standard_price,
+            dto.standard_cost,
+          );
 
           const entityData = toCreateProductEntity(dto, userId);
           const product = yield* repository.create(entityData);
@@ -174,6 +221,27 @@ export class ProductsService extends Effect.Service<ProductsService>()(
               for (const product of bulkDto.products) {
                 if (product.category_id === categoryId) {
                   result.addFailure(`Category ${categoryId} not found`, {
+                    sku: product.sku,
+                  });
+                }
+              }
+              return result.build();
+            }
+          }
+
+          const supplierIds = [
+            ...new Set(
+              bulkDto.products
+                .map((p) => p.primary_supplier_id)
+                .filter((id): id is string => Boolean(id)),
+            ),
+          ];
+          for (const supplierId of supplierIds) {
+            const exists = yield* suppliersService.existsById(supplierId);
+            if (!exists) {
+              for (const product of bulkDto.products) {
+                if (product.primary_supplier_id === supplierId) {
+                  result.addFailure(`Supplier ${supplierId} not found`, {
                     sku: product.sku,
                   });
                 }
@@ -218,9 +286,7 @@ export class ProductsService extends Effect.Service<ProductsService>()(
         Effect.gen(function* () {
           const product = yield* getProductOrFail(id);
 
-          if (dto.category_id) {
-            yield* checkCategoryExists(dto.category_id);
-          }
+          yield* validateProductTenantReferences(dto);
 
           if (dto.sku && dto.sku !== product.sku) {
             yield* ensureSkuAvailable(dto.sku);
@@ -239,9 +305,14 @@ export class ProductsService extends Effect.Service<ProductsService>()(
 
           const updated = yield* getProductOrFail(id);
           return toProductResponseDto(updated);
-        }).pipe(Effect.withSpan('ProductsService.update', { attributes: { id } }));
+        }).pipe(
+          Effect.withSpan('ProductsService.update', { attributes: { id } }),
+        );
 
-      const bulkUpdateStatus = (bulkDto: BulkUpdateStatusDto, userId?: string) =>
+      const bulkUpdateStatus = (
+        bulkDto: BulkUpdateStatusDto,
+        userId?: string,
+      ) =>
         Effect.gen(function* () {
           const result = createBulkResultBuilder();
 
@@ -277,7 +348,9 @@ export class ProductsService extends Effect.Service<ProductsService>()(
           } else {
             yield* repository.softDelete(id, userId);
           }
-        }).pipe(Effect.withSpan('ProductsService.delete', { attributes: { id } }));
+        }).pipe(
+          Effect.withSpan('ProductsService.delete', { attributes: { id } }),
+        );
 
       const bulkDelete = (bulkDto: BulkDeleteDto, userId?: string) =>
         Effect.gen(function* () {
@@ -322,7 +395,9 @@ export class ProductsService extends Effect.Service<ProductsService>()(
 
           const restored = yield* getProductOrFail(id);
           return toProductResponseDto(restored);
-        }).pipe(Effect.withSpan('ProductsService.restore', { attributes: { id } }));
+        }).pipe(
+          Effect.withSpan('ProductsService.restore', { attributes: { id } }),
+        );
 
       const bulkRestore = (bulkDto: BulkRestoreDto) =>
         Effect.gen(function* () {
@@ -352,9 +427,13 @@ export class ProductsService extends Effect.Service<ProductsService>()(
         }).pipe(Effect.withSpan('ProductsService.bulkRestore'));
 
       const existsById = (id: string) =>
-        repository.existsById(id).pipe(
-          Effect.withSpan('ProductsService.existsById', { attributes: { id } }),
-        );
+        repository
+          .existsById(id)
+          .pipe(
+            Effect.withSpan('ProductsService.existsById', {
+              attributes: { id },
+            }),
+          );
 
       return {
         findAllPaginated,
@@ -373,6 +452,10 @@ export class ProductsService extends Effect.Service<ProductsService>()(
         existsById,
       };
     }),
-    dependencies: [ProductsRepository.Default, CategoriesService.Default],
+    dependencies: [
+      ProductsRepository.Default,
+      CategoriesService.Default,
+      SuppliersService.Default,
+    ],
   },
 ) {}

--- a/src/effect/modules/roles/repository.ts
+++ b/src/effect/modules/roles/repository.ts
@@ -96,9 +96,10 @@ export class RolesRepository extends Effect.Service<RolesRepository>()(
         data: Partial<typeof roles.$inferInsert>,
       ) =>
         tryAsync('update role', async () => {
+          const { tenant_id: _tenantId, ...updateData } = data;
           await db
             .update(roles)
-            .set({ ...data, updated_at: new Date() })
+            .set({ ...updateData, updated_at: new Date() })
             .where(and(eq(roles.id, id), eq(roles.tenant_id, tenantId)));
         });
 

--- a/src/effect/modules/stock-movements/repository.ts
+++ b/src/effect/modules/stock-movements/repository.ts
@@ -6,9 +6,9 @@ import {
   toRepositoryPaginatedResult,
 } from '@stocket/types/common';
 import { makeTryAsync } from '../../platform/try-async';
+import { TenantQuery } from '../../platform/tenant-query';
 import { DrizzleDatabase } from '../../platform/drizzle';
-import { stockMovements } from '../../platform/db/schema';
-import { requireRequestTenantId } from '../../platform/tenant-context';
+import { orders, stockMovements } from '../../platform/db/schema';
 import { StockMovementsInfrastructureError } from './stock-movements.errors';
 
 const tryAsync = makeTryAsync(
@@ -56,10 +56,11 @@ export class StockMovementsRepository extends Effect.Service<StockMovementsRepos
   {
     effect: Effect.gen(function* () {
       const db = yield* DrizzleDatabase;
+      const tenantQuery = yield* TenantQuery;
 
       const findAllPaginated = (query: StockMovementQueryDto) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('list stock movements paginated', async () => {
             const { page, limit, skip } = resolvePaginationWindow(
               query.page,
@@ -91,7 +92,7 @@ export class StockMovementsRepository extends Effect.Service<StockMovementsRepos
 
       const findById = (id: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find stock movement by id', async () => {
             const row = await db.query.stockMovements.findFirst({
               where: and(
@@ -107,7 +108,7 @@ export class StockMovementsRepository extends Effect.Service<StockMovementsRepos
 
       const findByProductId = (productId: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find stock movements by product', () =>
             db.query.stockMovements.findMany({
               where: and(
@@ -122,7 +123,7 @@ export class StockMovementsRepository extends Effect.Service<StockMovementsRepos
 
       const findByLocationId = (locationId: string) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('find stock movements by location', () =>
             db.query.stockMovements.findMany({
               where: and(
@@ -140,7 +141,7 @@ export class StockMovementsRepository extends Effect.Service<StockMovementsRepos
 
       const create = (data: typeof stockMovements.$inferInsert) =>
         Effect.gen(function* () {
-          const tenantId = yield* requireRequestTenantId;
+          const tenantId = yield* tenantQuery.tenantId;
           return yield* tryAsync('create stock movement', async () => {
             const rows = await db
               .insert(stockMovements)
@@ -150,13 +151,33 @@ export class StockMovementsRepository extends Effect.Service<StockMovementsRepos
           });
         });
 
+      const orderExistsById = (orderId: string) =>
+        Effect.gen(function* () {
+          const tenantId = yield* tenantQuery.tenantId;
+          return yield* tryAsync(
+            'check stock movement order tenant',
+            async () => {
+              const rows = await db
+                .select({ id: orders.id })
+                .from(orders)
+                .where(
+                  and(eq(orders.tenant_id, tenantId), eq(orders.id, orderId)),
+                )
+                .limit(1);
+              return rows.length > 0;
+            },
+          );
+        });
+
       return {
         findAllPaginated,
         findById,
         findByProductId,
         findByLocationId,
         create,
+        orderExistsById,
       };
     }),
+    dependencies: [TenantQuery.Default],
   },
 ) {}

--- a/src/effect/modules/stock-movements/service.ts
+++ b/src/effect/modules/stock-movements/service.ts
@@ -12,6 +12,7 @@ import { StockMovementsRepository } from './repository';
 import {
   InvalidDestinationLocation,
   InvalidSourceLocation,
+  InvalidStockMovementOrder,
   InvalidStockMovementProduct,
   StockMovementLocationNotFound,
   StockMovementNotFound,
@@ -130,6 +131,20 @@ export class StockMovementsService extends Effect.Service<StockMovementsService>
                   new InvalidDestinationLocation({
                     locationId: toLocationId,
                     messageKey: 'stockMovements.destinationLocationNotFound',
+                  }),
+              ),
+            );
+          }
+
+          if (dto.order_id) {
+            const orderId = dto.order_id;
+            yield* repository.orderExistsById(orderId).pipe(
+              Effect.filterOrFail(
+                Boolean,
+                () =>
+                  new InvalidStockMovementOrder({
+                    orderId,
+                    messageKey: 'stockMovements.orderNotFound',
                   }),
               ),
             );

--- a/src/effect/modules/stock-movements/stock-movements.errors.ts
+++ b/src/effect/modules/stock-movements/stock-movements.errors.ts
@@ -40,6 +40,12 @@ export class InvalidDestinationLocation extends BadRequestError(
   readonly locationId: string;
 }> {}
 
+export class InvalidStockMovementOrder extends BadRequestError(
+  'InvalidStockMovementOrder',
+)<{
+  readonly orderId: string;
+}> {}
+
 export class StockMovementsInfrastructureError extends InternalError(
   'StockMovementsInfrastructureError',
 )<{

--- a/src/effect/platform/catalogs/de.ts
+++ b/src/effect/platform/catalogs/de.ts
@@ -151,6 +151,7 @@ export const deCatalog: Record<MessageKey, string> = {
     'Der Lagerbewegungsvorgang ist fehlgeschlagen.',
   'stockMovements.locationNotFound': 'Standort nicht gefunden.',
   'stockMovements.notFound': 'Lagerbewegung nicht gefunden.',
+  'stockMovements.orderNotFound': 'Bestellung nicht gefunden.',
   'stockMovements.productNotFound': 'Produkt nicht gefunden.',
   'stockMovements.repositoryFailed':
     'Der Lagerbewegungsvorgang ist fehlgeschlagen.',

--- a/src/effect/platform/catalogs/en.ts
+++ b/src/effect/platform/catalogs/en.ts
@@ -128,6 +128,7 @@ export const enCatalog = {
   'stockMovements.infrastructureFailed': 'Stock movement operation failed.',
   'stockMovements.locationNotFound': 'Location not found.',
   'stockMovements.notFound': 'Stock movement not found.',
+  'stockMovements.orderNotFound': 'Order not found.',
   'stockMovements.productNotFound': 'Product not found.',
   'stockMovements.repositoryFailed': 'Stock movement operation failed.',
   'stockMovements.sourceLocationNotFound': 'Source location not found.',

--- a/src/effect/platform/catalogs/fr.ts
+++ b/src/effect/platform/catalogs/fr.ts
@@ -108,8 +108,7 @@ export const frCatalog: Record<MessageKey, string> = {
   'photos.tooLarge':
     'Le fichier est trop volumineux. Taille maximale autorisee : {maxSize} octets.',
   'photos.writeFailed': "L'ecriture du fichier photo a echoue.",
-  'platform.hostRequired':
-    "La route plateforme est introuvable pour cet hote.",
+  'platform.hostRequired': 'La route plateforme est introuvable pour cet hote.',
   'products.categoryNotFound': 'Categorie introuvable.',
   'products.createdProductLoadFailed':
     'Le chargement du produit cree a echoue.',
@@ -145,6 +144,7 @@ export const frCatalog: Record<MessageKey, string> = {
     "L'operation sur le mouvement de stock a echoue.",
   'stockMovements.locationNotFound': 'Emplacement introuvable.',
   'stockMovements.notFound': 'Mouvement de stock introuvable.',
+  'stockMovements.orderNotFound': 'Commande introuvable.',
   'stockMovements.productNotFound': 'Produit introuvable.',
   'stockMovements.repositoryFailed':
     "L'operation sur le mouvement de stock a echoue.",

--- a/src/effect/platform/tenancy/host.ts
+++ b/src/effect/platform/tenancy/host.ts
@@ -4,12 +4,13 @@ import { isValidTenantSlug } from '@stocket/types/common';
 
 export { isValidTenantSlug } from '@stocket/types/common';
 
-const DEFAULT_PRODUCTION_TENANT_BASE_DOMAIN = 'librestock.maximilian.pw';
-const PRODUCTION_PLATFORM_SUBDOMAIN = 'default';
+const DEFAULT_TENANT_BASE_DOMAIN = 'stocket.fr';
+const DEFAULT_PLATFORM_SUBDOMAIN = 'app';
 const LOCAL_PLATFORM_HOST = 'localhost';
 const LOCAL_TENANT_BASE_DOMAIN = 'localhost';
 const LOCAL_TENANT_PORT = '3000';
 const DEFAULT_RESERVED_TENANT_SLUGS = [
+  'app',
   'default',
   'api',
   'deploy',
@@ -38,7 +39,10 @@ const stripPort = (host: string) => {
 
 const parseReservedTenantSlugs = () =>
   new Set(
-    (process.env.RESERVED_TENANT_SLUGS ?? DEFAULT_RESERVED_TENANT_SLUGS.join(','))
+    (
+      process.env.RESERVED_TENANT_SLUGS ??
+      DEFAULT_RESERVED_TENANT_SLUGS.join(',')
+    )
       .split(',')
       .map((slug) => slug.trim().toLowerCase())
       .filter(Boolean),
@@ -52,30 +56,43 @@ export const normalizeHost = (value: string | null | undefined) => {
   return normalized.length > 0 ? normalized : null;
 };
 
-const isProductionRuntime = () => process.env.NODE_ENV === 'production';
+const isLocalRuntime = () =>
+  process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'staging';
 
-export const getProductionTenantBaseDomain = () =>
-  normalizeHost(process.env.TENANT_BASE_DOMAIN) ??
-  DEFAULT_PRODUCTION_TENANT_BASE_DOMAIN;
+const requireHostConfig = (name: string) => {
+  const value = normalizeHost(process.env[name]);
+  if (!value && !isLocalRuntime()) {
+    throw new Error(
+      `${name} is required when NODE_ENV=${process.env.NODE_ENV}`,
+    );
+  }
+  return value;
+};
 
-export const getProductionPlatformHost = () =>
-  `${PRODUCTION_PLATFORM_SUBDOMAIN}.${getProductionTenantBaseDomain()}`;
+export const getTenantBaseDomain = () =>
+  requireHostConfig('TENANT_BASE_DOMAIN') ?? DEFAULT_TENANT_BASE_DOMAIN;
+
+export const getPlatformHost = () =>
+  requireHostConfig('PLATFORM_HOST') ??
+  `${DEFAULT_PLATFORM_SUBDOMAIN}.${getTenantBaseDomain()}`;
+
+// Backwards-compatible exports for callers/tests that still use the old names.
+export const getProductionTenantBaseDomain = getTenantBaseDomain;
+export const getProductionPlatformHost = getPlatformHost;
 
 const getPlatformHosts = () =>
   new Set([
-    getProductionPlatformHost(),
-    ...(isProductionRuntime() ? [] : [LOCAL_PLATFORM_HOST]),
+    getPlatformHost(),
+    ...(isLocalRuntime() ? [LOCAL_PLATFORM_HOST] : []),
   ]);
 
 const getPrimaryTenantBaseDomain = () =>
-  isProductionRuntime()
-    ? getProductionTenantBaseDomain()
-    : LOCAL_TENANT_BASE_DOMAIN;
+  isLocalRuntime() ? LOCAL_TENANT_BASE_DOMAIN : getTenantBaseDomain();
 
 const getTenantBaseDomains = () =>
   new Set([
-    getProductionTenantBaseDomain(),
-    ...(isProductionRuntime() ? [] : [LOCAL_TENANT_BASE_DOMAIN]),
+    getTenantBaseDomain(),
+    ...(isLocalRuntime() ? [LOCAL_TENANT_BASE_DOMAIN] : []),
   ]);
 
 const getReservedTenantSlugs = () => parseReservedTenantSlugs();
@@ -121,7 +138,9 @@ export const resolveRequestHost = (
     if (normalizedForwardedHost) return normalizedForwardedHost;
   }
 
-  return normalizeHost(request.headers.host ?? hostFromUrl(request.originalUrl));
+  return normalizeHost(
+    request.headers.host ?? hostFromUrl(request.originalUrl),
+  );
 };
 
 export const isPlatformHost = (host: string | null | undefined) => {
@@ -152,9 +171,9 @@ export const isTenantSubdomain = (host: string | null | undefined) =>
   getTenantSlugFromHost(host) !== null;
 
 export const hostnameForTenantSlug = (slug: string) =>
-  isProductionRuntime()
-    ? `${slug.toLowerCase()}.${getPrimaryTenantBaseDomain()}`
-    : `${slug.toLowerCase()}.${getPrimaryTenantBaseDomain()}:${LOCAL_TENANT_PORT}`;
+  isLocalRuntime()
+    ? `${slug.toLowerCase()}.${getPrimaryTenantBaseDomain()}:${LOCAL_TENANT_PORT}`
+    : `${slug.toLowerCase()}.${getPrimaryTenantBaseDomain()}`;
 
 export const isAllowedPlatformOrTenantHost = (
   host: string | null | undefined,

--- a/src/effect/platform/tenancy/tenant-constants.ts
+++ b/src/effect/platform/tenancy/tenant-constants.ts
@@ -1,3 +1,3 @@
 export const DEFAULT_TENANT_ID = '00000000-0000-4000-8000-000000000001';
-export const DEFAULT_TENANT_NAME = 'LibreStock';
-export const DEFAULT_TENANT_SLUG = 'librestock';
+export const DEFAULT_TENANT_NAME = 'Stocket';
+export const DEFAULT_TENANT_SLUG = 'stocket';

--- a/src/effect/platform/testing/authorization.spec.ts
+++ b/src/effect/platform/testing/authorization.spec.ts
@@ -186,7 +186,7 @@ describe('requireSuperAdmin', () => {
     await expect(
       fail(
         requireSuperAdmin.pipe(
-          Effect.provide(makeRequestLayer('tenant.librestock.maximilian.pw')),
+          Effect.provide(makeRequestLayer('tenant.stocket.fr')),
           Effect.provide(makeDbLayer([{ user_id: 'user-1' }])),
         ),
       ),
@@ -203,7 +203,7 @@ describe('requireSuperAdmin', () => {
       fail(
         requireSuperAdmin.pipe(
           Effect.provide(
-            makeRequestLayer('default.librestock.maximilian.pw'),
+            makeRequestLayer('app.stocket.fr'),
           ),
           Effect.provide(makeDbLayer([])),
         ),
@@ -220,7 +220,7 @@ describe('requireSuperAdmin', () => {
       fail(
         requireSuperAdmin.pipe(
           Effect.provide(
-            makeRequestLayer('default.librestock.maximilian.pw'),
+            makeRequestLayer('app.stocket.fr'),
           ),
           Effect.provide(makeFailingDbLayer()),
         ),
@@ -237,7 +237,7 @@ describe('requireSuperAdmin', () => {
       run(
         requireSuperAdmin.pipe(
           Effect.provide(
-            makeRequestLayer('default.librestock.maximilian.pw'),
+            makeRequestLayer('app.stocket.fr'),
           ),
           Effect.provide(makeDbLayer([{ user_id: 'user-1' }])),
         ),

--- a/src/effect/platform/testing/host.spec.ts
+++ b/src/effect/platform/testing/host.spec.ts
@@ -10,133 +10,152 @@ import {
   resolveRequestHost,
 } from '../host';
 
+const withEnv = <A>(
+  values: Record<string, string | undefined>,
+  run: () => A,
+): A => {
+  const previous = Object.fromEntries(
+    Object.keys(values).map((key) => [key, process.env[key]]),
+  );
+
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  try {
+    return run();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+};
+
 describe('platform host helpers', () => {
   it('normalizes host casing, ports, lists, and trailing dots', () => {
-    expect(normalizeHost(' Default.LibreStock.Maximilian.PW:443. ')).toBe(
-      'default.librestock.maximilian.pw',
-    );
-    expect(normalizeHost('Tenant.Librestock.Maximilian.PW, proxy.local')).toBe(
-      'tenant.librestock.maximilian.pw',
+    expect(normalizeHost(' App.Stocket.FR:443. ')).toBe('app.stocket.fr');
+    expect(normalizeHost('Tenant.Stocket.FR, proxy.local')).toBe(
+      'tenant.stocket.fr',
     );
   });
 
   it('recognizes platform hosts separately from tenant hosts', () => {
-    expect(isPlatformHost('default.librestock.maximilian.pw')).toBe(true);
+    expect(isPlatformHost('app.stocket.fr')).toBe(true);
     expect(isPlatformHost('localhost:3000')).toBe(true);
-    expect(isTenantSubdomain('default.librestock.maximilian.pw')).toBe(false);
+    expect(isTenantSubdomain('app.stocket.fr')).toBe(false);
     expect(isTenantSubdomain('localhost:3000')).toBe(false);
   });
 
   it('accepts exactly one DNS-safe tenant label under the base domain', () => {
-    expect(getTenantSlugFromHost('tenant-1.librestock.maximilian.pw')).toBe(
-      'tenant-1',
-    );
+    expect(getTenantSlugFromHost('tenant-1.stocket.fr')).toBe('tenant-1');
     expect(getTenantSlugFromHost('tenant-1.localhost:3000')).toBe('tenant-1');
     expect(getTenantSlugFromHost('tenant-1:3000')).toBeNull();
-    expect(isTenantSubdomain('nested.tenant.librestock.maximilian.pw')).toBe(
-      false,
-    );
-    expect(isTenantSubdomain('librestock.maximilian.pw')).toBe(false);
-    expect(isTenantSubdomain('Tenant.librestock.maximilian.pw')).toBe(true);
+    expect(isTenantSubdomain('nested.tenant.stocket.fr')).toBe(false);
+    expect(isTenantSubdomain('stocket.fr')).toBe(false);
+    expect(isTenantSubdomain('Tenant.stocket.fr')).toBe(true);
   });
 
   it('rejects reserved tenant slugs', () => {
-    expect(getTenantSlugFromHost('admin.librestock.maximilian.pw')).toBeNull();
-    expect(
-      getTenantSlugFromHost('superadmin.librestock.maximilian.pw'),
-    ).toBeNull();
+    expect(getTenantSlugFromHost('admin.stocket.fr')).toBeNull();
+    expect(getTenantSlugFromHost('app.stocket.fr')).toBeNull();
+    expect(getTenantSlugFromHost('superadmin.stocket.fr')).toBeNull();
   });
 
   it('builds tenant.localhost:3000 hostnames in local development', () => {
     expect(hostnameForTenantSlug('tenant-1')).toBe('tenant-1.localhost:3000');
   });
 
-  it('builds tenant.librestock.maximilian.pw hostnames in production by default', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    const originalTenantBaseDomain = process.env.TENANT_BASE_DOMAIN;
-    process.env.NODE_ENV = 'production';
-    delete process.env.TENANT_BASE_DOMAIN;
-    try {
-      expect(hostnameForTenantSlug('tenant-1')).toBe(
-        'tenant-1.librestock.maximilian.pw',
-      );
-    } finally {
-      if (originalNodeEnv === undefined) {
-        delete process.env.NODE_ENV;
-      } else {
-        process.env.NODE_ENV = originalNodeEnv;
-      }
-      if (originalTenantBaseDomain === undefined) {
-        delete process.env.TENANT_BASE_DOMAIN;
-      } else {
-        process.env.TENANT_BASE_DOMAIN = originalTenantBaseDomain;
-      }
-    }
+  it('requires TENANT_BASE_DOMAIN outside local runtimes', () => {
+    withEnv(
+      {
+        NODE_ENV: 'production',
+        TENANT_BASE_DOMAIN: undefined,
+        PLATFORM_HOST: 'app.stocket.fr',
+      },
+      () => {
+        expect(() => hostnameForTenantSlug('tenant-1')).toThrow(
+          'TENANT_BASE_DOMAIN is required',
+        );
+      },
+    );
+  });
+
+  it('requires PLATFORM_HOST outside local runtimes', () => {
+    withEnv(
+      {
+        NODE_ENV: 'production',
+        TENANT_BASE_DOMAIN: 'stocket.fr',
+        PLATFORM_HOST: undefined,
+      },
+      () => {
+        expect(() => isPlatformHost('app.stocket.fr')).toThrow(
+          'PLATFORM_HOST is required',
+        );
+      },
+    );
   });
 
   it('builds production tenant hostnames from TENANT_BASE_DOMAIN', () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    const originalTenantBaseDomain = process.env.TENANT_BASE_DOMAIN;
-    process.env.NODE_ENV = 'production';
-    process.env.TENANT_BASE_DOMAIN = 'stock.example.com';
-    try {
-      expect(hostnameForTenantSlug('tenant-1')).toBe('tenant-1.stock.example.com');
-      expect(getTenantSlugFromHost('tenant-1.stock.example.com')).toBe('tenant-1');
-    } finally {
-      if (originalNodeEnv === undefined) {
-        delete process.env.NODE_ENV;
-      } else {
-        process.env.NODE_ENV = originalNodeEnv;
-      }
-      if (originalTenantBaseDomain === undefined) {
-        delete process.env.TENANT_BASE_DOMAIN;
-      } else {
-        process.env.TENANT_BASE_DOMAIN = originalTenantBaseDomain;
-      }
-    }
+    withEnv(
+      {
+        NODE_ENV: 'production',
+        TENANT_BASE_DOMAIN: 'stock.example.com',
+        PLATFORM_HOST: 'app.stock.example.com',
+      },
+      () => {
+        expect(hostnameForTenantSlug('tenant-1')).toBe(
+          'tenant-1.stock.example.com',
+        );
+        expect(getTenantSlugFromHost('tenant-1.stock.example.com')).toBe(
+          'tenant-1',
+        );
+      },
+    );
   });
 
   it('falls back to the original request URL host when no Host header is present', () => {
     const request = HttpServerRequest.fromWeb(
-      new Request('https://tenant.librestock.maximilian.pw/api/v1/branding'),
+      new Request('https://tenant.stocket.fr/api/v1/branding'),
     );
 
-    expect(resolveRequestHost(request)).toBe('tenant.librestock.maximilian.pw');
+    expect(resolveRequestHost(request)).toBe('tenant.stocket.fr');
   });
 
   it('prefers the Host header over the original request URL host', () => {
     const request = HttpServerRequest.fromWeb(
       new Request('https://ignored.example.com/api/v1/branding', {
-        headers: { host: 'tenant.librestock.maximilian.pw' },
+        headers: { host: 'tenant.stocket.fr' },
       }),
     );
 
-    expect(resolveRequestHost(request)).toBe('tenant.librestock.maximilian.pw');
+    expect(resolveRequestHost(request)).toBe('tenant.stocket.fr');
   });
 
   it('trusts x-forwarded-host only from trusted remote addresses', () => {
     const request = HttpServerRequest.fromWeb(
       new Request('https://ignored.example.com/api/v1/branding', {
         headers: {
-          host: 'tenant.librestock.maximilian.pw',
-          'x-forwarded-host': 'forwarded.librestock.maximilian.pw',
+          host: 'tenant.stocket.fr',
+          'x-forwarded-host': 'forwarded.stocket.fr',
         },
       }),
     );
 
     expect(
       resolveRequestHost(request.modify({ remoteAddress: '127.0.0.1' })),
-    ).toBe('forwarded.librestock.maximilian.pw');
+    ).toBe('forwarded.stocket.fr');
     expect(
       resolveRequestHost(request.modify({ remoteAddress: '203.0.113.10' })),
-    ).toBe('tenant.librestock.maximilian.pw');
+    ).toBe('tenant.stocket.fr');
   });
 
   it('falls back to Host when a trusted forwarded host is invalid', () => {
     const request = HttpServerRequest.fromWeb(
       new Request('https://ignored.example.com/api/v1/branding', {
         headers: {
-          host: 'tenant.librestock.maximilian.pw',
+          host: 'tenant.stocket.fr',
           'x-forwarded-host': '',
         },
       }),
@@ -144,18 +163,16 @@ describe('platform host helpers', () => {
 
     expect(
       resolveRequestHost(request.modify({ remoteAddress: '127.0.0.1' })),
-    ).toBe('tenant.librestock.maximilian.pw');
+    ).toBe('tenant.stocket.fr');
   });
 
   it('validates same-origin platform and tenant origins', () => {
-    expect(
-      isAllowedPlatformOrTenantOrigin(
-        'https://default.librestock.maximilian.pw',
-      ),
-    ).toBe(true);
-    expect(
-      isAllowedPlatformOrTenantOrigin('https://tenant.librestock.maximilian.pw'),
-    ).toBe(true);
+    expect(isAllowedPlatformOrTenantOrigin('https://app.stocket.fr')).toBe(
+      true,
+    );
+    expect(isAllowedPlatformOrTenantOrigin('https://tenant.stocket.fr')).toBe(
+      true,
+    );
     expect(isAllowedPlatformOrTenantOrigin('https://example.com')).toBe(false);
   });
 });

--- a/src/effect/platform/testing/tenant-query-usage.spec.ts
+++ b/src/effect/platform/testing/tenant-query-usage.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const backendSrc = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const modulesDir = join(backendSrc, 'modules');
+
+const findRepositoryFiles = (dir: string): string[] => {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      files.push(...findRepositoryFiles(path));
+      continue;
+    }
+
+    if (entry === 'repository.ts') {
+      files.push(path);
+    }
+  }
+
+  return files;
+};
+
+describe('tenant query usage', () => {
+  it('keeps request tenant resolution behind TenantQuery in module repositories', () => {
+    const offenders = findRepositoryFiles(modulesDir)
+      .filter((path) =>
+        readFileSync(path, 'utf8').includes('requireRequestTenantId'),
+      )
+      .map((path) => path.slice(backendSrc.length + 1));
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Standardize request-scoped tenant resolution through `TenantQuery` and prevent writes/joins from crossing tenant boundaries.

- **TenantQuery routing:** area/audit-log/inventory/order/photo/product/stock-movement repositories resolve tenant via `TenantQuery` instead of `requireRequestTenantId`; new architecture guard `tenant-query-usage.spec.ts`.
- **Isolation hardening:** validate foreign-key IDs (supplier, product, order) belong to the tenant, tenant-safe joins, strip incoming `tenant_id` from update payloads; new `InvalidStockMovementOrder` error + `stockMovements.orderNotFound` catalog entries (en/de/fr).

**Stack:** ⬆ top — base is #86 (`feat(tenancy): require explicit platform host config`). Review/merge #86 first.

Closes STC-187

🤖 Generated with [Claude Code](https://claude.com/claude-code)