### PR TITLE
feat: add tenant feature entitlements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           version: 10.28.0
       - run: pnpm install --frozen-lockfile
-      - name: Build shared types
-        run: pnpm --filter @stocket/types barrels && pnpm --filter @stocket/types build
+      - name: Build shared packages
+        run: pnpm --filter @stocket/types barrels && pnpm --filter @stocket/types --filter @stocket/emails build
       - run: pnpm lint
       - run: pnpm type-check
 
@@ -52,8 +52,8 @@ jobs:
         with:
           version: 10.28.0
       - run: pnpm install --frozen-lockfile
-      - name: Build shared types
-        run: pnpm --filter @stocket/types barrels && pnpm --filter @stocket/types build
+      - name: Build shared packages
+        run: pnpm --filter @stocket/types barrels && pnpm --filter @stocket/types --filter @stocket/emails build
       - run: pnpm test
 
   integration-test:
@@ -90,8 +90,8 @@ jobs:
         with:
           version: 10.28.0
       - run: pnpm install --frozen-lockfile
-      - name: Build shared types
-        run: pnpm --filter @stocket/types barrels && pnpm --filter @stocket/types build
+      - name: Build shared packages
+        run: pnpm --filter @stocket/types barrels && pnpm --filter @stocket/types --filter @stocket/emails build
       - run: pnpm test:integration
         env:
           TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/stocket_inventory_test
@@ -116,6 +116,6 @@ jobs:
         with:
           version: 10.28.0
       - run: pnpm install --frozen-lockfile
-      - name: Build shared types
-        run: pnpm --filter @stocket/types barrels && pnpm --filter @stocket/types build
+      - name: Build shared packages
+        run: pnpm --filter @stocket/types barrels && pnpm --filter @stocket/types --filter @stocket/emails build
       - run: pnpm build

--- a/drizzle/0006_tenant_entitlements.sql
+++ b/drizzle/0006_tenant_entitlements.sql
@@ -1,0 +1,46 @@
+CREATE TYPE "public"."tenant_plan_key" AS ENUM('free', 'base', 'growth', 'enterprise');
+CREATE TYPE "public"."tenant_entitlement_source" AS ENUM('system', 'manual', 'billing');
+CREATE TYPE "public"."tenant_feature_key" AS ENUM('smartImport', 'orders');
+
+CREATE TABLE "tenant_entitlement_profiles" (
+  "tenant_id" uuid PRIMARY KEY NOT NULL,
+  "plan_key" "tenant_plan_key" DEFAULT 'free' NOT NULL,
+  "source" "tenant_entitlement_source" DEFAULT 'system' NOT NULL,
+  "updated_by" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE TABLE "tenant_feature_overrides" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "tenant_id" uuid NOT NULL,
+  "feature_key" "tenant_feature_key" NOT NULL,
+  "enabled" boolean NOT NULL,
+  "reason" text,
+  "expires_at" timestamp with time zone,
+  "updated_by" text,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE "tenant_entitlement_profiles"
+  ADD CONSTRAINT "tenant_entitlement_profiles_tenant_id_organization_id_fk"
+  FOREIGN KEY ("tenant_id") REFERENCES "public"."organization"("id")
+  ON DELETE cascade ON UPDATE no action;
+
+ALTER TABLE "tenant_feature_overrides"
+  ADD CONSTRAINT "tenant_feature_overrides_tenant_id_organization_id_fk"
+  FOREIGN KEY ("tenant_id") REFERENCES "public"."organization"("id")
+  ON DELETE cascade ON UPDATE no action;
+
+CREATE INDEX "tenant_entitlement_profiles_plan_key_idx"
+  ON "tenant_entitlement_profiles" USING btree ("plan_key");
+
+CREATE UNIQUE INDEX "tenant_feature_overrides_tenant_feature_unique"
+  ON "tenant_feature_overrides" USING btree ("tenant_id","feature_key");
+
+CREATE INDEX "tenant_feature_overrides_tenant_id_idx"
+  ON "tenant_feature_overrides" USING btree ("tenant_id");
+
+CREATE INDEX "tenant_feature_overrides_expires_at_idx"
+  ON "tenant_feature_overrides" USING btree ("expires_at");

--- a/src/effect/main.ts
+++ b/src/effect/main.ts
@@ -14,6 +14,7 @@ import { AuthService } from './modules/auth/service';
 import { BrandingService } from './modules/branding/service';
 import { CategoriesService } from './modules/categories/service';
 import { ClientsService } from './modules/clients/service';
+import { FeaturesService } from './modules/features/service';
 import { HealthService } from './modules/health/service';
 import { InventoryService } from './modules/inventory/service';
 import { LocationsService } from './modules/locations/service';
@@ -76,6 +77,7 @@ const withPlatform = <A, E, R>(layer: Layer.Layer<A, E, R>) =>
   layer.pipe(Layer.provide(platformLayer));
 
 const rolesApplicationLayer = withPlatform(RolesService.Default);
+const featuresApplicationLayer = withPlatform(FeaturesService.Default);
 const permissionProviderLayer = Layer.effect(
   PermissionProvider,
   Effect.map(RolesService, ({ getPermissionsForUser }) => ({
@@ -83,13 +85,13 @@ const permissionProviderLayer = Layer.effect(
   })),
 ).pipe(Layer.provide(rolesApplicationLayer));
 const authApplicationLayer = AuthService.Default.pipe(
-  Layer.provide(rolesApplicationLayer),
+  Layer.provide(Layer.mergeAll(rolesApplicationLayer, featuresApplicationLayer)),
 );
 const usersApplicationLayer = UsersService.Default.pipe(
   Layer.provide(Layer.mergeAll(platformLayer, rolesApplicationLayer)),
 );
 const superAdminApplicationLayer = SuperAdminService.Default.pipe(
-  Layer.provide(platformLayer),
+  Layer.provide(Layer.mergeAll(platformLayer, featuresApplicationLayer)),
 );
 
 const shouldRunStartupMigrations = () =>
@@ -275,6 +277,7 @@ const applicationLayer = Layer.mergeAll(
   NodePath.layer,
   TracingLive,
   startupLayer,
+  featuresApplicationLayer,
   foundationalServicesLayer,
   rolesApplicationLayer,
   permissionProviderLayer,

--- a/src/effect/modules/auth/mappers.spec.ts
+++ b/src/effect/modules/auth/mappers.spec.ts
@@ -3,6 +3,11 @@ import {
   toProfileResponse,
   toSessionClaimsResponse,
 } from './mappers';
+import {
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
 
 describe('auth mappers', () => {
   const session = {
@@ -37,6 +42,18 @@ describe('auth mappers', () => {
           tenantName: 'Stocket',
           tenantSlug: 'stocket',
         },
+        {
+          tenantId: '00000000-0000-4000-8000-000000000001',
+          planKey: PlanKey.FREE,
+          source: EntitlementSource.SYSTEM,
+          features: {
+            [FeatureKey.SMART_IMPORT]: false,
+            [FeatureKey.ORDERS]: true,
+          },
+          overrides: [],
+          updated_at: null,
+          updated_by: null,
+        },
       ),
     ).toEqual({
       id: 'user-1',
@@ -46,6 +63,11 @@ describe('auth mappers', () => {
       tenantId: '00000000-0000-4000-8000-000000000001',
       tenantName: 'Stocket',
       tenantSlug: 'stocket',
+      planKey: PlanKey.FREE,
+      features: {
+        [FeatureKey.SMART_IMPORT]: false,
+        [FeatureKey.ORDERS]: true,
+      },
       roles: ['Admin'],
       permissions: {
         roles: ['read', 'write'],

--- a/src/effect/modules/auth/mappers.ts
+++ b/src/effect/modules/auth/mappers.ts
@@ -3,6 +3,7 @@ import type {
   ProfileResponseDto,
   SessionClaimsResponseDto,
 } from '@stocket/types/auth';
+import type { TenantFeaturesResponseDto } from '@stocket/types/features';
 import type { UserSession } from '../../platform/auth/user-session';
 import {
   getSessionIdFromSession,
@@ -16,6 +17,7 @@ export const toCurrentUserResponse = (
   session: UserSession,
   userPermissions: UserPermissions,
   tenant: TenantContext,
+  tenantFeatures: TenantFeaturesResponseDto,
 ): CurrentUserResponseDto => {
   const { id, name, email, image } = session.user;
 
@@ -27,6 +29,8 @@ export const toCurrentUserResponse = (
     tenantId: tenant.tenantId,
     tenantName: tenant.tenantName,
     tenantSlug: tenant.tenantSlug,
+    planKey: tenantFeatures.planKey,
+    features: tenantFeatures.features,
     roles: userPermissions.roleNames,
     permissions: userPermissions.permissions,
   };

--- a/src/effect/modules/auth/service.integration.spec.ts
+++ b/src/effect/modules/auth/service.integration.spec.ts
@@ -22,6 +22,7 @@
 import { HttpServerRequest } from '@effect/platform';
 import { Effect, Layer, ManagedRuntime } from 'effect';
 import { Permission, Resource } from '@stocket/types/auth';
+import { FeatureKey, PlanKey } from '@stocket/types/features';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import type { BetterAuthService } from '../../platform/auth/better-auth';
 import type { DrizzleDb } from '../../platform/db/drizzle';
@@ -38,6 +39,7 @@ import {
   withTestDb,
 } from '../../testing/test-harness';
 import { RolesService } from '../roles/service';
+import { FeaturesService } from '../features/service';
 import {
   seedDefaultTenantMembership,
   seedRole,
@@ -126,6 +128,9 @@ beforeAll(() => {
 const buildRolesServiceLayer = () =>
   RolesService.Default.pipe(Layer.provide(dbLayer));
 
+const buildFeaturesServiceLayer = () =>
+  FeaturesService.Default.pipe(Layer.provide(dbLayer));
+
 const buildAuthServiceLayer = (
   userIdOrNull: string | null,
   extras: {
@@ -138,6 +143,7 @@ const buildAuthServiceLayer = (
   // those tags remain visible in the resulting layer's output context.
   const deps = Layer.mergeAll(
     dbLayer,
+    buildFeaturesServiceLayer(),
     buildBetterAuthLayer(userIdOrNull, extras.getSessionSpy),
     makeRequestLayer(extras.requestHeaders),
   );
@@ -218,6 +224,11 @@ describe('AuthService Integration', () => {
         expect(result.id).toBe(TEST_USER_ID);
         expect(result.name).toBe('Integration Test User');
         expect(result.email).toBe('integration@example.com');
+        expect(result.planKey).toBe(PlanKey.FREE);
+        expect(result.features).toEqual({
+          [FeatureKey.SMART_IMPORT]: false,
+          [FeatureKey.ORDERS]: true,
+        });
         expect(result.roles).toEqual(['Integration Admin']);
         expect(result.permissions[Resource.ROLES]).toEqual(
           expect.arrayContaining([Permission.READ, Permission.WRITE]),
@@ -347,6 +358,7 @@ describe('AuthService Integration', () => {
             Layer.mergeAll(
               dbLayer,
               buildRolesServiceLayer(),
+              buildFeaturesServiceLayer(),
               buildBetterAuthLayer(TEST_USER_ID),
               makeRequestLayer(),
             ),

--- a/src/effect/modules/auth/service.spec.ts
+++ b/src/effect/modules/auth/service.spec.ts
@@ -10,7 +10,13 @@
 import { describe, expect, it } from '@effect/vitest';
 import { Effect, Layer } from 'effect';
 import { Permission, Resource } from '@stocket/types/auth';
+import {
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
 import { makeTestLayer } from '../../testing/test-harness';
+import { FeaturesService } from '../features/service';
 import { RolesService, type UserPermissions } from '../roles/service';
 import { AuthService } from './service';
 
@@ -70,12 +76,33 @@ const rolesLayer = (overrides: Partial<RolesService> = {}) =>
     ...overrides,
   });
 
-const serviceLayer = (roles = rolesLayer()) =>
-  AuthService.DefaultWithoutDependencies.pipe(Layer.provide(roles));
+const featuresLayer = (overrides: Partial<FeaturesService> = {}) =>
+  makeTestLayer(FeaturesService)({
+    getFeaturesForTenant: () =>
+      Effect.succeed({
+        tenantId: '00000000-0000-4000-8000-000000000001',
+        planKey: PlanKey.FREE,
+        source: EntitlementSource.SYSTEM,
+        features: {
+          [FeatureKey.SMART_IMPORT]: false,
+          [FeatureKey.ORDERS]: true,
+        },
+        overrides: [],
+        updated_at: null,
+        updated_by: null,
+      }),
+    ...overrides,
+  });
+
+const serviceLayer = (roles = rolesLayer(), features = featuresLayer()) =>
+  AuthService.DefaultWithoutDependencies.pipe(
+    Layer.provide(Layer.mergeAll(roles, features)),
+  );
 
 const withService = <A, E, R>(
   body: (svc: AuthService) => Effect.Effect<A, E, R>,
   rolesOverrides?: Partial<RolesService>,
+  featuresOverrides?: Partial<FeaturesService>,
 ): Effect.Effect<A, E, never> =>
   // `requireSession` is replaced by the `vi.mock` above, so its residual
   // `BetterAuthService | HttpServerRequest` requirements are discharged at
@@ -85,7 +112,9 @@ const withService = <A, E, R>(
     const svc = yield* AuthService;
     return yield* body(svc);
   }).pipe(
-    Effect.provide(serviceLayer(rolesLayer(rolesOverrides))),
+    Effect.provide(
+      serviceLayer(rolesLayer(rolesOverrides), featuresLayer(featuresOverrides)),
+    ),
   ) as unknown as Effect.Effect<A, E, never>;
 
 // ---------------------------------------------------------------------------
@@ -113,6 +142,11 @@ describe('AuthService', () => {
               tenantId: '00000000-0000-4000-8000-000000000001',
               tenantName: 'Stocket',
               tenantSlug: 'stocket',
+              planKey: PlanKey.FREE,
+              features: {
+                [FeatureKey.SMART_IMPORT]: false,
+                [FeatureKey.ORDERS]: true,
+              },
               roles: ['Admin'],
               permissions: {
                 [Resource.ROLES]: [Permission.READ, Permission.WRITE],
@@ -205,6 +239,33 @@ describe('AuthService', () => {
                 statusCode: 500,
                 message: 'boom',
                 messageKey: 'roles.loadPermissionsFailed',
+              } as any),
+          },
+        );
+      },
+    );
+
+    it.effect(
+      'propagates errors from FeaturesService.getFeaturesForTenant',
+      () => {
+        mockRequireSession.mockReturnValue(Effect.succeed(makeSession()));
+
+        return withService(
+          (svc) =>
+            Effect.gen(function* () {
+              const error = yield* Effect.flip(svc.me());
+              expect(error).toMatchObject({
+                _tag: 'FeaturesInfrastructureError',
+              });
+            }),
+          undefined,
+          {
+            getFeaturesForTenant: () =>
+              Effect.fail({
+                _tag: 'FeaturesInfrastructureError',
+                statusCode: 500,
+                message: 'boom',
+                messageKey: 'features.repositoryFailed',
               } as any),
           },
         );

--- a/src/effect/modules/auth/service.ts
+++ b/src/effect/modules/auth/service.ts
@@ -8,12 +8,14 @@ import {
   toProfileResponse,
   toSessionClaimsResponse,
 } from './mappers';
+import { FeaturesService } from '../features/service';
 
 export class AuthService extends Effect.Service<AuthService>()(
   '@stocket/effect/auth/AuthService',
   {
     effect: Effect.gen(function* () {
       const rolesService = yield* RolesService;
+      const featuresService = yield* FeaturesService;
       const trace = makeServiceTracer({
         serviceName: 'AuthService',
         module: 'auth',
@@ -30,7 +32,15 @@ export class AuthService extends Effect.Service<AuthService>()(
             session.user.id,
             tenant.tenantId,
           );
-          return toCurrentUserResponse(session, userPermissions, tenant);
+          const tenantFeatures = yield* featuresService.getFeaturesForTenant(
+            tenant.tenantId,
+          );
+          return toCurrentUserResponse(
+            session,
+            userPermissions,
+            tenant,
+            tenantFeatures,
+          );
         }),
       );
 
@@ -56,6 +66,6 @@ export class AuthService extends Effect.Service<AuthService>()(
         sessionClaims,
       };
     }),
-    dependencies: [RolesService.Default],
+    dependencies: [RolesService.Default, FeaturesService.Default],
   },
 ) {}

--- a/src/effect/modules/features/features.errors.ts
+++ b/src/effect/modules/features/features.errors.ts
@@ -1,0 +1,24 @@
+import type { FeatureKey } from '@stocket/types/features';
+import {
+  ForbiddenError,
+  InternalError,
+  NotFoundError,
+} from '../../platform/effect/domain-errors';
+
+export class FeatureNotEnabled extends ForbiddenError('FeatureNotEnabled')<{
+  readonly featureKey: FeatureKey;
+}> {}
+
+export class FeatureTenantNotFound extends NotFoundError(
+  'FeatureTenantNotFound',
+)<{
+  readonly tenantId: string;
+}> {}
+
+export class FeaturesInfrastructureError extends InternalError(
+  'FeaturesInfrastructureError',
+)<{
+  readonly action: string;
+  readonly cause?: unknown;
+}> {}
+

--- a/src/effect/modules/features/index.ts
+++ b/src/effect/modules/features/index.ts
@@ -1,0 +1,5 @@
+export * from './features.errors';
+export * from './registry';
+export * from './repository';
+export * from './service';
+

--- a/src/effect/modules/features/registry.ts
+++ b/src/effect/modules/features/registry.ts
@@ -1,0 +1,36 @@
+import {
+  FeatureKey,
+  type FeatureStates,
+  PlanKey,
+} from '@stocket/types/features';
+
+export const DEFAULT_PLAN_KEY = PlanKey.FREE;
+
+export const FEATURE_KEYS = [
+  FeatureKey.SMART_IMPORT,
+  FeatureKey.ORDERS,
+] as const;
+
+export const PLAN_FEATURE_DEFAULTS: Record<PlanKey, FeatureStates> = {
+  [PlanKey.FREE]: {
+    [FeatureKey.SMART_IMPORT]: false,
+    [FeatureKey.ORDERS]: true,
+  },
+  [PlanKey.BASE]: {
+    [FeatureKey.SMART_IMPORT]: false,
+    [FeatureKey.ORDERS]: true,
+  },
+  [PlanKey.GROWTH]: {
+    [FeatureKey.SMART_IMPORT]: true,
+    [FeatureKey.ORDERS]: true,
+  },
+  [PlanKey.ENTERPRISE]: {
+    [FeatureKey.SMART_IMPORT]: true,
+    [FeatureKey.ORDERS]: true,
+  },
+};
+
+export const featuresForPlan = (planKey: PlanKey): FeatureStates => ({
+  ...PLAN_FEATURE_DEFAULTS[planKey],
+});
+

--- a/src/effect/modules/features/repository.ts
+++ b/src/effect/modules/features/repository.ts
@@ -1,0 +1,151 @@
+import { Effect } from 'effect';
+import { and, eq, sql } from 'drizzle-orm';
+import {
+  EntitlementSource,
+  type FeatureKey,
+  type PlanKey,
+} from '@stocket/types/features';
+import { DrizzleDatabase } from '../../platform/db/drizzle';
+import {
+  organizations,
+  tenantEntitlementProfiles,
+  tenantFeatureOverrides,
+} from '../../platform/db/schema';
+import { makeTryAsync } from '../../platform/effect/try-async';
+import { FeaturesInfrastructureError } from './features.errors';
+
+const tryAsync = makeTryAsync(
+  (action, cause) =>
+    new FeaturesInfrastructureError({
+      action,
+      cause,
+      messageKey: 'features.repositoryFailed',
+    }),
+);
+
+export type TenantEntitlementProfileRow =
+  typeof tenantEntitlementProfiles.$inferSelect;
+export type TenantFeatureOverrideRow =
+  typeof tenantFeatureOverrides.$inferSelect;
+
+export class FeaturesRepository extends Effect.Service<FeaturesRepository>()(
+  '@stocket/effect/features/FeaturesRepository',
+  {
+    effect: Effect.gen(function* () {
+      const db = yield* DrizzleDatabase;
+
+      const tenantExists = (tenantId: string) =>
+        tryAsync('check tenant exists', async () => {
+          const rows = await db
+            .select({ id: organizations.id })
+            .from(organizations)
+            .where(eq(organizations.id, tenantId))
+            .limit(1);
+          return rows.length > 0;
+        });
+
+      const findProfile = (tenantId: string) =>
+        tryAsync('load tenant entitlement profile', async () => {
+          const rows = await db
+            .select()
+            .from(tenantEntitlementProfiles)
+            .where(eq(tenantEntitlementProfiles.tenant_id, tenantId))
+            .limit(1);
+          return rows[0] ?? null;
+        });
+
+      const listOverrides = (tenantId: string) =>
+        tryAsync('load tenant feature overrides', async () =>
+          db
+            .select()
+            .from(tenantFeatureOverrides)
+            .where(eq(tenantFeatureOverrides.tenant_id, tenantId)),
+        );
+
+      const upsertPlan = (
+        tenantId: string,
+        planKey: PlanKey,
+        actorUserId: string,
+      ) =>
+        tryAsync('upsert tenant entitlement profile', async () => {
+          await db
+            .insert(tenantEntitlementProfiles)
+            .values({
+              tenant_id: tenantId,
+              plan_key: planKey,
+              source: EntitlementSource.MANUAL,
+              updated_by: actorUserId,
+              updated_at: new Date(),
+            })
+            .onConflictDoUpdate({
+              target: tenantEntitlementProfiles.tenant_id,
+              set: {
+                plan_key: sql`excluded.plan_key`,
+                source: EntitlementSource.MANUAL,
+                updated_by: actorUserId,
+                updated_at: new Date(),
+              },
+            });
+        });
+
+      const upsertOverride = (
+        tenantId: string,
+        featureKey: FeatureKey,
+        input: {
+          readonly enabled: boolean;
+          readonly reason?: string | null;
+          readonly expires_at?: Date | null;
+        },
+        actorUserId: string,
+      ) =>
+        tryAsync('upsert tenant feature override', async () => {
+          await db
+            .insert(tenantFeatureOverrides)
+            .values({
+              tenant_id: tenantId,
+              feature_key: featureKey,
+              enabled: input.enabled,
+              reason: input.reason ?? null,
+              expires_at: input.expires_at ?? null,
+              updated_by: actorUserId,
+              updated_at: new Date(),
+            })
+            .onConflictDoUpdate({
+              target: [
+                tenantFeatureOverrides.tenant_id,
+                tenantFeatureOverrides.feature_key,
+              ],
+              set: {
+                enabled: sql`excluded.enabled`,
+                reason: sql`excluded.reason`,
+                expires_at: sql`excluded.expires_at`,
+                updated_by: actorUserId,
+                updated_at: new Date(),
+              },
+            });
+        });
+
+      const deleteOverride = (tenantId: string, featureKey: FeatureKey) =>
+        tryAsync('delete tenant feature override', async () => {
+          await db
+            .delete(tenantFeatureOverrides)
+            .where(
+              and(
+                eq(tenantFeatureOverrides.tenant_id, tenantId),
+                eq(tenantFeatureOverrides.feature_key, featureKey),
+              ),
+            );
+        });
+
+      return {
+        tenantExists,
+        findProfile,
+        listOverrides,
+        upsertPlan,
+        upsertOverride,
+        deleteOverride,
+      };
+    }),
+  },
+) {}
+

--- a/src/effect/modules/features/service.integration.spec.ts
+++ b/src/effect/modules/features/service.integration.spec.ts
@@ -1,0 +1,98 @@
+import { Effect, Layer } from 'effect';
+import {
+  FeatureKey,
+  PlanKey,
+  type UpdateTenantFeatureOverride,
+} from '@stocket/types/features';
+import { eq } from 'drizzle-orm';
+import { organizations, tenantFeatureOverrides } from '../../platform/db/schema';
+import { DEFAULT_TENANT_ID } from '../../platform/tenancy/tenant-constants';
+import {
+  getTestDb,
+  makeTestDrizzleLayer,
+  runTest,
+  TEST_USER_ID,
+  withTestDb,
+} from '../../testing/test-harness';
+import type { DrizzleDb } from '../../platform/db/drizzle';
+import { FeaturesService } from './service';
+
+let db: DrizzleDb;
+let TestLayer: Layer.Layer<FeaturesService>;
+
+withTestDb();
+beforeAll(() => {
+  db = getTestDb();
+  TestLayer = FeaturesService.Default.pipe(Layer.provide(makeTestDrizzleLayer()));
+});
+
+const seedTenant = async () => {
+  await db.insert(organizations).values({
+    id: DEFAULT_TENANT_ID,
+    name: 'Stocket',
+    slug: 'stocket',
+  }).onConflictDoNothing();
+};
+
+describe('FeaturesService integration', () => {
+  it('returns default free-plan features when no entitlement rows exist', async () => {
+    await seedTenant();
+
+    const result = await runTest(
+      Effect.flatMap(FeaturesService, (svc) =>
+        svc.getFeaturesForTenant(DEFAULT_TENANT_ID),
+      ),
+      TestLayer,
+    );
+
+    expect(result.planKey).toBe(PlanKey.FREE);
+    expect(result.features).toEqual({
+      [FeatureKey.SMART_IMPORT]: false,
+      [FeatureKey.ORDERS]: true,
+    });
+  });
+
+  it('persists plan and feature overrides for a tenant', async () => {
+    await seedTenant();
+
+    const dto: UpdateTenantFeatureOverride = {
+      enabled: true,
+      reason: 'Beta tenant',
+      expires_at: null,
+    };
+
+    const result = await runTest(
+      Effect.flatMap(FeaturesService, (svc) =>
+        Effect.flatMap(
+          svc.setTenantPlan(
+            DEFAULT_TENANT_ID,
+            { planKey: PlanKey.BASE },
+            TEST_USER_ID,
+          ),
+          () =>
+            svc.setFeatureOverride(
+              DEFAULT_TENANT_ID,
+              FeatureKey.SMART_IMPORT,
+              dto,
+              TEST_USER_ID,
+            ),
+        ),
+      ),
+      TestLayer,
+    );
+
+    expect(result.planKey).toBe(PlanKey.BASE);
+    expect(result.features[FeatureKey.SMART_IMPORT]).toBe(true);
+    const rows = await db
+      .select()
+      .from(tenantFeatureOverrides)
+      .where(eq(tenantFeatureOverrides.tenant_id, DEFAULT_TENANT_ID));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      feature_key: FeatureKey.SMART_IMPORT,
+      enabled: true,
+      reason: 'Beta tenant',
+      updated_by: TEST_USER_ID,
+    });
+  });
+});

--- a/src/effect/modules/features/service.spec.ts
+++ b/src/effect/modules/features/service.spec.ts
@@ -1,0 +1,179 @@
+import { Effect, Layer } from 'effect';
+import {
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
+import { CurrentRequestContext } from '../../platform/http/request-context';
+import { DEFAULT_TENANT_ID } from '../../platform/tenancy/tenant-constants';
+import { FeaturesRepository } from './repository';
+import { FeaturesService } from './service';
+
+const requestContext = {
+  requestId: '00000000-0000-4000-8000-000000000099',
+  path: '/api/v1/features',
+  method: 'GET' as const,
+  ip: null,
+  locale: 'en' as const,
+  tenantId: DEFAULT_TENANT_ID,
+};
+
+const profile = (planKey: PlanKey) =>
+  ({
+    tenant_id: DEFAULT_TENANT_ID,
+    plan_key: planKey,
+    source: EntitlementSource.MANUAL,
+    updated_by: 'admin-1',
+    created_at: new Date('2026-01-01T00:00:00.000Z'),
+    updated_at: new Date('2026-01-01T00:00:00.000Z'),
+  }) as const;
+
+const override = (
+  featureKey: FeatureKey,
+  enabled: boolean,
+  expiresAt: Date | null = null,
+) =>
+  ({
+    id: '00000000-0000-4000-8000-000000000777',
+    tenant_id: DEFAULT_TENANT_ID,
+    feature_key: featureKey,
+    enabled,
+    reason: null,
+    expires_at: expiresAt,
+    updated_by: 'admin-1',
+    created_at: new Date('2026-01-01T00:00:00.000Z'),
+    updated_at: new Date('2026-01-01T00:00:00.000Z'),
+  }) as const;
+
+const makeService = async (repository: Partial<FeaturesRepository>) =>
+  Effect.runPromise(
+    FeaturesService.pipe(
+      Effect.provide(
+        FeaturesService.DefaultWithoutDependencies.pipe(
+          Layer.provide(
+            Layer.succeed(
+              FeaturesRepository,
+              repository as typeof FeaturesRepository.Service,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+const run = <A, E>(effect: Effect.Effect<A, E>) =>
+  Effect.runPromise(
+    effect.pipe(Effect.provideService(CurrentRequestContext, requestContext)),
+  );
+
+const fail = <A, E>(effect: Effect.Effect<A, E>) =>
+  Effect.runPromise(
+    Effect.flip(
+      effect.pipe(Effect.provideService(CurrentRequestContext, requestContext)),
+    ),
+  );
+
+describe('FeaturesService', () => {
+  it('uses the free plan when no tenant profile exists', async () => {
+    const service = await makeService({
+      tenantExists: () => Effect.succeed(true),
+      findProfile: () => Effect.succeed(null),
+      listOverrides: () => Effect.succeed([]),
+    });
+
+    const result = await run(service.getFeaturesForTenant(DEFAULT_TENANT_ID));
+
+    expect(result.planKey).toBe(PlanKey.FREE);
+    expect(result.source).toBe(EntitlementSource.SYSTEM);
+    expect(result.features).toEqual({
+      [FeatureKey.SMART_IMPORT]: false,
+      [FeatureKey.ORDERS]: true,
+    });
+  });
+
+  it('applies active tenant overrides over plan defaults', async () => {
+    const service = await makeService({
+      tenantExists: () => Effect.succeed(true),
+      findProfile: () => Effect.succeed(profile(PlanKey.FREE)),
+      listOverrides: () =>
+        Effect.succeed([
+          override(
+            FeatureKey.SMART_IMPORT,
+            true,
+            new Date('2030-01-01T00:00:00.000Z'),
+          ),
+        ]),
+    });
+
+    const result = await run(service.getFeaturesForTenant(DEFAULT_TENANT_ID));
+
+    expect(result.features[FeatureKey.SMART_IMPORT]).toBe(true);
+    expect(result.features[FeatureKey.ORDERS]).toBe(true);
+  });
+
+  it('ignores expired overrides', async () => {
+    const service = await makeService({
+      tenantExists: () => Effect.succeed(true),
+      findProfile: () => Effect.succeed(profile(PlanKey.GROWTH)),
+      listOverrides: () =>
+        Effect.succeed([
+          override(
+            FeatureKey.SMART_IMPORT,
+            false,
+            new Date('2020-01-01T00:00:00.000Z'),
+          ),
+        ]),
+    });
+
+    const result = await run(service.getFeaturesForTenant(DEFAULT_TENANT_ID));
+
+    expect(result.features[FeatureKey.SMART_IMPORT]).toBe(true);
+  });
+
+  it('invalidates cached values after a plan update', async () => {
+    const findProfile = vi
+      .fn()
+      .mockReturnValueOnce(Effect.succeed(profile(PlanKey.BASE)))
+      .mockReturnValueOnce(Effect.succeed(profile(PlanKey.GROWTH)));
+    const upsertPlan = vi.fn(() => Effect.void);
+    const service = await makeService({
+      tenantExists: () => Effect.succeed(true),
+      findProfile,
+      listOverrides: () => Effect.succeed([]),
+      upsertPlan,
+    });
+
+    const first = await run(service.getFeaturesForTenant(DEFAULT_TENANT_ID));
+    const second = await run(
+      service.setTenantPlan(
+        DEFAULT_TENANT_ID,
+        { planKey: PlanKey.GROWTH },
+        'admin-1',
+      ),
+    );
+
+    expect(first.features[FeatureKey.SMART_IMPORT]).toBe(false);
+    expect(second.features[FeatureKey.SMART_IMPORT]).toBe(true);
+    expect(upsertPlan).toHaveBeenCalledWith(
+      DEFAULT_TENANT_ID,
+      PlanKey.GROWTH,
+      'admin-1',
+    );
+  });
+
+  it('fails requireFeature when the effective feature is disabled', async () => {
+    const service = await makeService({
+      tenantExists: () => Effect.succeed(true),
+      findProfile: () => Effect.succeed(profile(PlanKey.FREE)),
+      listOverrides: () => Effect.succeed([]),
+    });
+
+    const error = await fail(service.requireFeature(FeatureKey.SMART_IMPORT));
+
+    expect(error).toMatchObject({
+      _tag: 'FeatureNotEnabled',
+      statusCode: 403,
+      featureKey: FeatureKey.SMART_IMPORT,
+    });
+  });
+});

--- a/src/effect/modules/features/service.ts
+++ b/src/effect/modules/features/service.ts
@@ -1,0 +1,156 @@
+import { Cache, Duration, Effect } from 'effect';
+import {
+  type FeatureKey,
+  type TenantFeaturesResponseDto,
+  type UpdateTenantFeatureOverride,
+  type UpdateTenantPlan,
+} from '@stocket/types/features';
+import { requireRequestTenantId } from '../../platform/tenancy/tenant-context';
+import { makeServiceTracer } from '../../platform/observability/service-tracer';
+import {
+  FeatureNotEnabled,
+  FeatureTenantNotFound,
+  type FeaturesInfrastructureError,
+} from './features.errors';
+import {
+  FeaturesRepository,
+} from './repository';
+import { buildTenantFeaturesResponse } from './utils';
+
+export class FeaturesService extends Effect.Service<FeaturesService>()(
+  '@stocket/effect/features/FeaturesService',
+  {
+    effect: Effect.gen(function* () {
+      const repository = yield* FeaturesRepository;
+      const trace = makeServiceTracer({
+        serviceName: 'FeaturesService',
+        module: 'features',
+        layer: 'service',
+        entityType: 'tenant',
+      });
+
+      const loadFeaturesForTenant = (
+        tenantId: string,
+      ): Effect.Effect<
+        TenantFeaturesResponseDto,
+        FeaturesInfrastructureError | FeatureTenantNotFound
+      > =>
+        Effect.gen(function* () {
+          if (!(yield* repository.tenantExists(tenantId))) {
+            return yield* Effect.fail(
+              new FeatureTenantNotFound({
+                tenantId,
+                messageKey: 'features.tenantNotFound',
+              }),
+            );
+          }
+          const profile = yield* repository.findProfile(tenantId);
+          const overrides = yield* repository.listOverrides(tenantId);
+          return buildTenantFeaturesResponse(tenantId, profile, overrides);
+        });
+
+      const featureCache = yield* Cache.make({
+        capacity: 1000,
+        timeToLive: Duration.minutes(1),
+        lookup: loadFeaturesForTenant,
+      });
+
+      const invalidateTenant = (tenantId: string) =>
+        featureCache.invalidate(tenantId);
+
+      const requireTenant = (tenantId: string) =>
+        Effect.gen(function* () {
+          if (yield* repository.tenantExists(tenantId)) {
+            return;
+          }
+          return yield* Effect.fail(
+            new FeatureTenantNotFound({
+              tenantId,
+              messageKey: 'features.tenantNotFound',
+            }),
+          );
+        });
+
+      const getFeaturesForTenant = (tenantId: string) =>
+        featureCache.get(tenantId).pipe(
+          trace.span('getFeaturesForTenant', { attributes: { tenantId } }),
+        );
+
+      const setTenantPlan = (
+        tenantId: string,
+        dto: UpdateTenantPlan,
+        actorUserId: string,
+      ) =>
+        Effect.gen(function* () {
+          yield* requireTenant(tenantId);
+          yield* repository.upsertPlan(tenantId, dto.planKey, actorUserId);
+          yield* invalidateTenant(tenantId);
+          return yield* loadFeaturesForTenant(tenantId);
+        }).pipe(
+          trace.span('setTenantPlan', { attributes: { tenantId } }),
+        );
+
+      const setFeatureOverride = (
+        tenantId: string,
+        featureKey: FeatureKey,
+        dto: UpdateTenantFeatureOverride,
+        actorUserId: string,
+      ) =>
+        Effect.gen(function* () {
+          yield* requireTenant(tenantId);
+          yield* repository.upsertOverride(
+            tenantId,
+            featureKey,
+            {
+              enabled: dto.enabled,
+              reason: dto.reason,
+              expires_at: dto.expires_at,
+            },
+            actorUserId,
+          );
+          yield* invalidateTenant(tenantId);
+          return yield* loadFeaturesForTenant(tenantId);
+        }).pipe(
+          trace.span('setFeatureOverride', { attributes: { tenantId } }),
+        );
+
+      const clearFeatureOverride = (tenantId: string, featureKey: FeatureKey) =>
+        Effect.gen(function* () {
+          yield* requireTenant(tenantId);
+          yield* repository.deleteOverride(tenantId, featureKey);
+          yield* invalidateTenant(tenantId);
+          return yield* loadFeaturesForTenant(tenantId);
+        }).pipe(
+          trace.span('clearFeatureOverride', { attributes: { tenantId } }),
+        );
+
+      const requireFeature = (featureKey: FeatureKey) =>
+        Effect.gen(function* () {
+          const tenantId = yield* requireRequestTenantId;
+          const { features } = yield* getFeaturesForTenant(tenantId);
+          if (features[featureKey]) {
+            return;
+          }
+          return yield* Effect.fail(
+            new FeatureNotEnabled({
+              featureKey,
+              messageKey: 'features.notEnabled',
+            }),
+          );
+        }).pipe(
+          trace.span('requireFeature', {
+            attributes: { entityId: featureKey },
+          }),
+        );
+
+      return {
+        getFeaturesForTenant,
+        setTenantPlan,
+        setFeatureOverride,
+        clearFeatureOverride,
+        requireFeature,
+      };
+    }),
+    dependencies: [FeaturesRepository.Default],
+  },
+) {}

--- a/src/effect/modules/features/utils.ts
+++ b/src/effect/modules/features/utils.ts
@@ -1,0 +1,50 @@
+import {
+  EntitlementSource,
+  type FeatureStates,
+  type TenantFeaturesResponseDto,
+} from '@stocket/types/features';
+import type {
+  TenantEntitlementProfileRow,
+  TenantFeatureOverrideRow,
+} from './repository';
+import { DEFAULT_PLAN_KEY, featuresForPlan } from './registry';
+
+const isActiveOverride = (
+  override: TenantFeatureOverrideRow,
+  now: Date,
+): boolean => !override.expires_at || override.expires_at > now;
+
+const toOverrideResponse = (override: TenantFeatureOverrideRow) => ({
+  featureKey: override.feature_key,
+  enabled: override.enabled,
+  reason: override.reason,
+  expires_at: override.expires_at,
+  updated_at: override.updated_at,
+  updated_by: override.updated_by,
+});
+
+export const buildTenantFeaturesResponse = (
+  tenantId: string,
+  profile: TenantEntitlementProfileRow | null,
+  overrides: TenantFeatureOverrideRow[],
+): TenantFeaturesResponseDto => {
+  const planKey = profile?.plan_key ?? DEFAULT_PLAN_KEY;
+  const features: FeatureStates = featuresForPlan(planKey);
+  const now = new Date();
+
+  for (const override of overrides) {
+    if (isActiveOverride(override, now)) {
+      features[override.feature_key] = override.enabled;
+    }
+  }
+
+  return {
+    tenantId,
+    planKey,
+    source: profile?.source ?? EntitlementSource.SYSTEM,
+    features,
+    overrides: overrides.map(toOverrideResponse),
+    updated_at: profile?.updated_at ?? null,
+    updated_by: profile?.updated_by ?? null,
+  };
+};

--- a/src/effect/modules/index.ts
+++ b/src/effect/modules/index.ts
@@ -30,6 +30,7 @@ export const moduleCounterparts = [
   'categories',
   'areas',
   'clients',
+  'features',
   'suppliers',
   'products',
   'photos',

--- a/src/effect/modules/orders/__fixtures__/router-harness.ts
+++ b/src/effect/modules/orders/__fixtures__/router-harness.ts
@@ -6,8 +6,9 @@
  * `HttpRouter.catchAllCause(respondCause)` is re-applied so guard/decode
  * failures map to 401/403/400 instead of escaping as 500.
  */
-import { type Effect } from 'effect';
+import { Effect } from 'effect';
 import type { Permission, Resource } from '@stocket/types/auth';
+import { FeatureKey } from '@stocket/types/features';
 import type { AuditWriteParams } from '../../../platform/audit/index';
 import {
   type makeFakeSession,
@@ -15,6 +16,8 @@ import {
   makeRouterTestHarness,
 } from '../../../testing/router-harness';
 import { ordersRouter } from '../router';
+import { FeatureNotEnabled } from '../../features/features.errors';
+import { FeaturesService } from '../../features/service';
 import { OrdersService } from '../service';
 
 export { FAKE_USER_ID, makeFakeSession } from '../../../testing/router-harness';
@@ -26,6 +29,7 @@ export interface OrdersRouterHarnessOptions {
   readonly auditLog?: (
     params: AuditWriteParams,
   ) => Effect.Effect<void, never, unknown>;
+  readonly ordersFeatureEnabled?: boolean;
 }
 
 export interface OrdersRouterHarness {
@@ -38,9 +42,21 @@ export interface OrdersRouterHarness {
 export const makeOrdersRouterHarness = (
   opts: OrdersRouterHarnessOptions,
 ): OrdersRouterHarness => {
+  const featuresLayer = makeRouterServiceLayer(FeaturesService, {
+    requireFeature: () =>
+      opts.ordersFeatureEnabled === false
+        ? Effect.fail(
+            new FeatureNotEnabled({
+              featureKey: FeatureKey.ORDERS,
+              messageKey: 'features.notEnabled',
+            }),
+          )
+        : Effect.void,
+  });
+
   return makeRouterTestHarness({
     router: ordersRouter,
-    layers: [makeRouterServiceLayer(OrdersService, opts.service)],
+    layers: [makeRouterServiceLayer(OrdersService, opts.service), featuresLayer],
     permissions: opts.permissions,
     roleNames: [],
     session: opts.session,

--- a/src/effect/modules/orders/router.spec.ts
+++ b/src/effect/modules/orders/router.spec.ts
@@ -101,6 +101,23 @@ describe('ordersRouter', () => {
       expect(response.status).toBe(403);
     });
 
+    it('rejects when the Orders feature is disabled', async () => {
+      const findAllPaginated = vi.fn(() => Effect.succeed(paginated));
+      const { handler } = makeOrdersRouterHarness({
+        service: { findAllPaginated },
+        permissions: readOnly,
+        ordersFeatureEnabled: false,
+      });
+
+      const response = await handler(new Request('http://localhost/orders'));
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({
+        messageKey: 'features.notEnabled',
+      });
+      expect(findAllPaginated).not.toHaveBeenCalled();
+    });
+
     it('returns 400 when the query is malformed', async () => {
       const { handler } = makeOrdersRouterHarness({
         service: { findAllPaginated: () => Effect.succeed(paginated) },

--- a/src/effect/modules/orders/router.ts
+++ b/src/effect/modules/orders/router.ts
@@ -9,20 +9,26 @@ import {
 } from '@stocket/types/orders';
 import { Permission, Resource } from '@stocket/types/auth';
 import { AuditAction, AuditEntityType } from '@stocket/types/audit-logs';
+import { FeatureKey } from '@stocket/types/features';
 import { requirePermission } from '../../platform/auth/authorization';
 import { respondJson, respondJsonOk } from '../../platform/http/errors';
 import { AuditLogWriter } from '../../platform/audit/index';
 import { getOptionalSession } from '../../platform/http/session';
 import { makeMessageResponse } from '../../platform/observability/messages';
+import { FeaturesService } from '../features/service';
 import { OrdersService } from './service';
 
 const OrderPathParams = Schema.Struct({ id: OrderIdSchema });
+const requireOrdersFeature = Effect.flatMap(FeaturesService, (features) =>
+  features.requireFeature(FeatureKey.ORDERS),
+);
 
 export const ordersRouter = HttpRouter.empty.pipe(
   HttpRouter.get(
     '/',
     Effect.gen(function* () {
       yield* requirePermission(Resource.ORDERS, Permission.READ);
+      yield* requireOrdersFeature;
       const query = yield* HttpServerRequest.schemaSearchParams(OrderQuerySchema);
       const ordersService = yield* OrdersService;
       return yield* respondJson(ordersService.findAllPaginated(query));
@@ -32,6 +38,7 @@ export const ordersRouter = HttpRouter.empty.pipe(
     '/:id',
     Effect.gen(function* () {
       yield* requirePermission(Resource.ORDERS, Permission.READ);
+      yield* requireOrdersFeature;
       const { id } = yield* HttpRouter.schemaPathParams(OrderPathParams);
       const ordersService = yield* OrdersService;
       return yield* respondJson(ordersService.findOne(id));
@@ -41,6 +48,7 @@ export const ordersRouter = HttpRouter.empty.pipe(
     '/',
     Effect.gen(function* () {
       yield* requirePermission(Resource.ORDERS, Permission.WRITE);
+      yield* requireOrdersFeature;
       const dto = yield* HttpServerRequest.schemaBodyJson(CreateOrderSchema);
       const session = yield* getOptionalSession;
       const ordersService = yield* OrdersService;
@@ -58,6 +66,7 @@ export const ordersRouter = HttpRouter.empty.pipe(
     '/:id',
     Effect.gen(function* () {
       yield* requirePermission(Resource.ORDERS, Permission.WRITE);
+      yield* requireOrdersFeature;
       const { id } = yield* HttpRouter.schemaPathParams(OrderPathParams);
       const dto = yield* HttpServerRequest.schemaBodyJson(UpdateOrderSchema);
       const ordersService = yield* OrdersService;
@@ -75,6 +84,7 @@ export const ordersRouter = HttpRouter.empty.pipe(
     '/:id/status',
     Effect.gen(function* () {
       yield* requirePermission(Resource.ORDERS, Permission.WRITE);
+      yield* requireOrdersFeature;
       const { id } = yield* HttpRouter.schemaPathParams(OrderPathParams);
       const dto = yield* HttpServerRequest.schemaBodyJson(
         UpdateOrderStatusSchema,
@@ -94,6 +104,7 @@ export const ordersRouter = HttpRouter.empty.pipe(
     '/:id',
     Effect.gen(function* () {
       yield* requirePermission(Resource.ORDERS, Permission.WRITE);
+      yield* requireOrdersFeature;
       const { id } = yield* HttpRouter.schemaPathParams(OrderPathParams);
       const ordersService = yield* OrdersService;
       yield* ordersService.delete(id);

--- a/src/effect/modules/products/__fixtures__/router-harness.ts
+++ b/src/effect/modules/products/__fixtures__/router-harness.ts
@@ -8,6 +8,7 @@
  */
 import { Effect } from 'effect';
 import type { Permission, Resource } from '@stocket/types/auth';
+import { FeatureKey } from '@stocket/types/features';
 import type { AuditWriteParams } from '../../../platform/audit/index';
 import {
   type makeFakeSession,
@@ -15,6 +16,8 @@ import {
   makeRouterTestHarness,
 } from '../../../testing/router-harness';
 import { ProductImportService } from '../import/service';
+import { FeatureNotEnabled } from '../../features/features.errors';
+import { FeaturesService } from '../../features/service';
 import { ProductImportUnsupportedFormat } from '../products.errors';
 import { productsRouter } from '../router';
 import { ProductsService } from '../service';
@@ -29,6 +32,7 @@ export interface ProductsRouterHarnessOptions {
   readonly auditLog?: (
     params: AuditWriteParams,
   ) => Effect.Effect<void, never, unknown>;
+  readonly smartImportFeatureEnabled?: boolean;
 }
 
 export interface ProductsRouterHarness {
@@ -52,12 +56,25 @@ export const makeProductsRouterHarness = (
         ),
     },
   );
+  const featuresLayer = makeRouterServiceLayer(FeaturesService, {
+    requireFeature: (featureKey: FeatureKey) =>
+      featureKey === FeatureKey.SMART_IMPORT &&
+      opts.smartImportFeatureEnabled === false
+        ? Effect.fail(
+            new FeatureNotEnabled({
+              featureKey,
+              messageKey: 'features.notEnabled',
+            }),
+          )
+        : Effect.void,
+  });
 
   return makeRouterTestHarness({
     router: productsRouter,
     layers: [
       makeRouterServiceLayer(ProductsService, opts.service),
       importServiceLayer,
+      featuresLayer,
     ],
     permissions: opts.permissions,
     roleNames: [],

--- a/src/effect/modules/products/import/import.integration.spec.ts
+++ b/src/effect/modules/products/import/import.integration.spec.ts
@@ -2,6 +2,10 @@ import { randomUUID } from 'node:crypto';
 import { and, eq, isNull } from 'drizzle-orm';
 import { Permission, Resource } from '@stocket/types/auth';
 import {
+  EntitlementSource,
+  PlanKey,
+} from '@stocket/types/features';
+import {
   inventory,
   locations,
   members,
@@ -9,6 +13,7 @@ import {
   products,
   rolePermissions,
   roles,
+  tenantEntitlementProfiles,
   tenantDomains,
   userRoles,
 } from '../../../platform/db/schema';
@@ -91,6 +96,25 @@ async function seedDefaultTenantDomain() {
       verified_at: new Date(),
     })
     .onConflictDoNothing();
+
+  await db
+    .insert(tenantEntitlementProfiles)
+    .values({
+      tenant_id: DEFAULT_TENANT_ID,
+      plan_key: PlanKey.GROWTH,
+      source: EntitlementSource.MANUAL,
+      updated_by: TEST_USER_ID,
+      updated_at: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: tenantEntitlementProfiles.tenant_id,
+      set: {
+        plan_key: PlanKey.GROWTH,
+        source: EntitlementSource.MANUAL,
+        updated_by: TEST_USER_ID,
+        updated_at: new Date(),
+      },
+    });
 }
 
 async function seedImportWriteRole(userId: string) {

--- a/src/effect/modules/products/router.spec.ts
+++ b/src/effect/modules/products/router.spec.ts
@@ -421,6 +421,32 @@ describe('productsRouter', () => {
       expect(mockMultipart).not.toHaveBeenCalled();
     });
 
+    it('rejects when SmartImport is disabled', async () => {
+      const importFromCsvContent = vi.fn(() =>
+        Effect.succeed(importResult()),
+      );
+      const { handler } = makeProductsRouterHarness({
+        service: {},
+        importService: { importFromCsvContent },
+        permissions: writeAll,
+        smartImportFeatureEnabled: false,
+      });
+
+      const response = await handler(
+        new Request('http://localhost/products/import', {
+          method: 'POST',
+          body: 'ignored',
+        }),
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({
+        messageKey: 'features.notEnabled',
+      });
+      expect(mockMultipart).not.toHaveBeenCalled();
+      expect(importFromCsvContent).not.toHaveBeenCalled();
+    });
+
     it('rejects without LOCATIONS and INVENTORY write permissions', async () => {
       const importFromCsvContent = vi.fn(() =>
         Effect.succeed(importResult()),

--- a/src/effect/modules/products/router.ts
+++ b/src/effect/modules/products/router.ts
@@ -3,6 +3,7 @@ import { HttpRouter, HttpServerRequest, Multipart } from '@effect/platform';
 import { Effect, Schema } from 'effect';
 import { Permission, Resource } from '@stocket/types/auth';
 import { AuditAction, AuditEntityType } from '@stocket/types/audit-logs';
+import { FeatureKey } from '@stocket/types/features';
 import {
   ProductIdSchema,
   ProductQuerySchema,
@@ -19,6 +20,7 @@ import { respondJson, respondJsonOk } from '../../platform/http/errors';
 import { AuditLogWriter } from '../../platform/audit/index';
 import { getOptionalSession, requireSession } from '../../platform/http/session';
 import { makeMessageResponse } from '../../platform/observability/messages';
+import { FeaturesService } from '../features/service';
 import { ProductImportService } from './import/service';
 import { ProductImportTypes } from './import/types';
 import { ProductsInfrastructureError } from './products.errors';
@@ -41,6 +43,9 @@ const ProductImportUploadSchema = Schema.Struct({
     default: () => 'auto' as const,
   }),
 });
+const requireSmartImportFeature = Effect.flatMap(FeaturesService, (features) =>
+  features.requireFeature(FeatureKey.SMART_IMPORT),
+);
 
 const IncludeDeletedQuery = Schema.Struct({
   include_deleted: Schema.optionalWith(ProductBooleanQuerySchema, {
@@ -99,6 +104,7 @@ export const productsRouter = HttpRouter.empty.pipe(
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
       yield* requirePermission(Resource.LOCATIONS, Permission.WRITE);
       yield* requirePermission(Resource.INVENTORY, Permission.WRITE);
+      yield* requireSmartImportFeature;
       const { file, import_type } =
         yield* HttpServerRequest.schemaBodyMultipart(ProductImportUploadSchema);
       const session = yield* requireSession;

--- a/src/effect/modules/superadmin/router.ts
+++ b/src/effect/modules/superadmin/router.ts
@@ -1,12 +1,23 @@
 import { HttpRouter, HttpServerRequest } from '@effect/platform';
-import { Effect } from 'effect';
+import { Effect, Schema } from 'effect';
 import { requireSuperAdmin } from '../../platform/auth/authorization';
 import { BetterAuthHeaders } from '../../platform/auth/better-auth';
 import { respondJson } from '../../platform/http/errors';
 import { getRequestHeaders } from '../../platform/http/session';
 import { CreateSuperAdminTenantSchema } from '@stocket/types/superadmin';
+import {
+  FeatureKeySchema,
+  UpdateTenantFeatureOverrideSchema,
+  UpdateTenantPlanSchema,
+} from '@stocket/types/features';
 import { getRequestContext } from '../../platform/http/request-context';
 import { SuperAdminService } from './service';
+
+const TenantPathParams = Schema.Struct({ tenantId: Schema.UUID });
+const TenantFeaturePathParams = Schema.Struct({
+  tenantId: Schema.UUID,
+  featureKey: FeatureKeySchema,
+});
 
 export const superAdminRouter = HttpRouter.empty.pipe(
   HttpRouter.get(
@@ -47,6 +58,61 @@ export const superAdminRouter = HttpRouter.empty.pipe(
           })
           .pipe(Effect.provideService(BetterAuthHeaders, requestHeaders)),
         { status: 201 },
+      );
+    }),
+  ),
+  HttpRouter.get(
+    '/tenants/:tenantId/features',
+    Effect.gen(function* () {
+      yield* requireSuperAdmin;
+      const { tenantId } = yield* HttpRouter.schemaPathParams(TenantPathParams);
+      const superAdminService = yield* SuperAdminService;
+      return yield* respondJson(superAdminService.getTenantFeatures(tenantId));
+    }),
+  ),
+  HttpRouter.put(
+    '/tenants/:tenantId/plan',
+    Effect.gen(function* () {
+      const session = yield* requireSuperAdmin;
+      const { tenantId } = yield* HttpRouter.schemaPathParams(TenantPathParams);
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        UpdateTenantPlanSchema,
+      );
+      const superAdminService = yield* SuperAdminService;
+      return yield* respondJson(
+        superAdminService.updateTenantPlan(tenantId, dto, session.user.id),
+      );
+    }),
+  ),
+  HttpRouter.put(
+    '/tenants/:tenantId/features/:featureKey',
+    Effect.gen(function* () {
+      const session = yield* requireSuperAdmin;
+      const { tenantId, featureKey } =
+        yield* HttpRouter.schemaPathParams(TenantFeaturePathParams);
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        UpdateTenantFeatureOverrideSchema,
+      );
+      const superAdminService = yield* SuperAdminService;
+      return yield* respondJson(
+        superAdminService.updateTenantFeatureOverride(
+          tenantId,
+          featureKey,
+          dto,
+          session.user.id,
+        ),
+      );
+    }),
+  ),
+  HttpRouter.del(
+    '/tenants/:tenantId/features/:featureKey',
+    Effect.gen(function* () {
+      yield* requireSuperAdmin;
+      const { tenantId, featureKey } =
+        yield* HttpRouter.schemaPathParams(TenantFeaturePathParams);
+      const superAdminService = yield* SuperAdminService;
+      return yield* respondJson(
+        superAdminService.clearTenantFeatureOverride(tenantId, featureKey),
       );
     }),
   ),

--- a/src/effect/modules/superadmin/service.spec.ts
+++ b/src/effect/modules/superadmin/service.spec.ts
@@ -1,5 +1,11 @@
 import { Effect, Layer } from 'effect';
+import {
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
 import { BetterAuth, BetterAuthHeaders } from '../../platform/auth/better-auth';
+import { FeaturesService } from '../features/service';
 import { UsersRepository } from '../users/repository';
 import { SuperAdminRepository } from './repository';
 import { SuperAdminService } from './service';
@@ -67,12 +73,73 @@ describe('Effect SuperAdminService', () => {
     },
   });
 
+  const makeFeaturesService = () => ({
+    getFeaturesForTenant: vi.fn(() =>
+      Effect.succeed({
+        tenantId: createdTenant.tenant.id,
+        planKey: PlanKey.FREE,
+        source: EntitlementSource.SYSTEM,
+        features: {
+          [FeatureKey.SMART_IMPORT]: false,
+          [FeatureKey.ORDERS]: true,
+        },
+        overrides: [],
+        updated_at: null,
+        updated_by: null,
+      }),
+    ),
+    setTenantPlan: vi.fn(() =>
+      Effect.succeed({
+        tenantId: createdTenant.tenant.id,
+        planKey: PlanKey.GROWTH,
+        source: EntitlementSource.MANUAL,
+        features: {
+          [FeatureKey.SMART_IMPORT]: true,
+          [FeatureKey.ORDERS]: true,
+        },
+        overrides: [],
+        updated_at: new Date('2026-01-01T00:00:00.000Z'),
+        updated_by: actor.userId,
+      }),
+    ),
+    setFeatureOverride: vi.fn(() =>
+      Effect.succeed({
+        tenantId: createdTenant.tenant.id,
+        planKey: PlanKey.FREE,
+        source: EntitlementSource.SYSTEM,
+        features: {
+          [FeatureKey.SMART_IMPORT]: true,
+          [FeatureKey.ORDERS]: true,
+        },
+        overrides: [],
+        updated_at: null,
+        updated_by: null,
+      }),
+    ),
+    clearFeatureOverride: vi.fn(() =>
+      Effect.succeed({
+        tenantId: createdTenant.tenant.id,
+        planKey: PlanKey.FREE,
+        source: EntitlementSource.SYSTEM,
+        features: {
+          [FeatureKey.SMART_IMPORT]: false,
+          [FeatureKey.ORDERS]: true,
+        },
+        overrides: [],
+        updated_at: null,
+        updated_by: null,
+      }),
+    ),
+  });
+
   const makeServiceLayer = ({
     betterAuth,
+    featuresService,
     repository,
     usersRepository,
   }: {
     betterAuth: unknown;
+    featuresService?: unknown;
     repository: unknown;
     usersRepository: unknown;
   }) =>
@@ -80,6 +147,10 @@ describe('Effect SuperAdminService', () => {
       Layer.provide(
         Layer.mergeAll(
           Layer.succeed(BetterAuth, betterAuth as typeof BetterAuth.Service),
+          Layer.succeed(
+            FeaturesService,
+            (featuresService ?? makeFeaturesService()) as typeof FeaturesService.Service,
+          ),
           Layer.succeed(
             SuperAdminRepository,
             repository as typeof SuperAdminRepository.Service,
@@ -121,6 +192,7 @@ describe('Effect SuperAdminService', () => {
     const usersRepository = makeUsersRepository();
     const layer = makeServiceLayer({
       betterAuth,
+      featuresService: makeFeaturesService(),
       repository,
       usersRepository,
     });
@@ -180,6 +252,7 @@ describe('Effect SuperAdminService', () => {
     const usersRepository = makeUsersRepository();
     const layer = makeServiceLayer({
       betterAuth,
+      featuresService: makeFeaturesService(),
       repository,
       usersRepository,
     });
@@ -198,5 +271,71 @@ describe('Effect SuperAdminService', () => {
       email: 'existing@example.com',
       name: 'Existing Admin',
     });
+  });
+
+  it('delegates tenant feature reads and writes to FeaturesService', async () => {
+    const betterAuth = makeBetterAuth();
+    const repository = makeRepository();
+    const usersRepository = makeUsersRepository();
+    const featuresService = makeFeaturesService();
+    const layer = makeServiceLayer({
+      betterAuth,
+      featuresService,
+      repository,
+      usersRepository,
+    });
+
+    const tenantId = createdTenant.tenant.id;
+
+    await run(
+      Effect.flatMap(SuperAdminService, (service) =>
+        service.getTenantFeatures(tenantId),
+      ),
+      layer,
+    );
+    await run(
+      Effect.flatMap(SuperAdminService, (service) =>
+        service.updateTenantPlan(
+          tenantId,
+          { planKey: PlanKey.GROWTH },
+          actor.userId,
+        ),
+      ),
+      layer,
+    );
+    await run(
+      Effect.flatMap(SuperAdminService, (service) =>
+        service.updateTenantFeatureOverride(
+          tenantId,
+          FeatureKey.SMART_IMPORT,
+          { enabled: true, reason: 'Beta tenant', expires_at: null },
+          actor.userId,
+        ),
+      ),
+      layer,
+    );
+    await run(
+      Effect.flatMap(SuperAdminService, (service) =>
+        service.clearTenantFeatureOverride(tenantId, FeatureKey.SMART_IMPORT),
+      ),
+      layer,
+    );
+
+    expect(featuresService.getFeaturesForTenant).toHaveBeenCalledWith(tenantId);
+    expect(featuresService.setTenantPlan).toHaveBeenCalledWith(
+      tenantId,
+      { planKey: PlanKey.GROWTH },
+      actor.userId,
+    );
+    expect(featuresService.setFeatureOverride).toHaveBeenCalledWith(
+      tenantId,
+      FeatureKey.SMART_IMPORT,
+      { enabled: true, reason: 'Beta tenant', expires_at: null },
+      actor.userId,
+    );
+    expect(featuresService.clearFeatureOverride).toHaveBeenCalledWith(
+      tenantId,
+      FeatureKey.SMART_IMPORT,
+    );
   });
 });

--- a/src/effect/modules/superadmin/service.ts
+++ b/src/effect/modules/superadmin/service.ts
@@ -5,6 +5,11 @@ import type {
   SuperAdminMeResponse,
   SuperAdminTenantListResponse,
 } from '@stocket/types/superadmin';
+import type {
+  FeatureKey,
+  UpdateTenantFeatureOverride,
+  UpdateTenantPlan,
+} from '@stocket/types/features';
 import {
   hostnameForTenantSlug,
   isReservedTenantSlug,
@@ -28,6 +33,7 @@ import {
   TenantSlugAlreadyExists,
 } from './superadmin.errors';
 import { SuperAdminRepository } from './repository';
+import { FeaturesService } from '../features/service';
 
 interface BetterAuthCreateUserResponse {
   readonly user: { readonly id: string };
@@ -95,6 +101,7 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
       const repository = yield* SuperAdminRepository;
       const usersRepository = yield* UsersRepository;
       const betterAuth = yield* BetterAuth;
+      const featuresService = yield* FeaturesService;
       const trace = makeServiceTracer({
         serviceName: 'SuperAdminService',
         module: 'superadmin',
@@ -296,12 +303,61 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
         (input) => ({ attributes: { entityId: input.slug } }),
       );
 
+      const getTenantFeatures = trace.traced(
+        'getTenantFeatures',
+        (tenantId: string) => featuresService.getFeaturesForTenant(tenantId),
+        (tenantId) => ({ attributes: { tenantId } }),
+      );
+
+      const updateTenantPlan = trace.traced(
+        'updateTenantPlan',
+        (tenantId: string, dto: UpdateTenantPlan, actorUserId: string) =>
+          featuresService.setTenantPlan(tenantId, dto, actorUserId),
+        (tenantId) => ({ attributes: { tenantId } }),
+      );
+
+      const updateTenantFeatureOverride = trace.traced(
+        'updateTenantFeatureOverride',
+        (
+          tenantId: string,
+          featureKey: FeatureKey,
+          dto: UpdateTenantFeatureOverride,
+          actorUserId: string,
+        ) =>
+          featuresService.setFeatureOverride(
+            tenantId,
+            featureKey,
+            dto,
+            actorUserId,
+          ),
+        (tenantId, featureKey) => ({
+          attributes: { tenantId, entityId: featureKey },
+        }),
+      );
+
+      const clearTenantFeatureOverride = trace.traced(
+        'clearTenantFeatureOverride',
+        (tenantId: string, featureKey: FeatureKey) =>
+          featuresService.clearFeatureOverride(tenantId, featureKey),
+        (tenantId, featureKey) => ({
+          attributes: { tenantId, entityId: featureKey },
+        }),
+      );
+
       return {
         me,
         listTenants,
         createTenant,
+        getTenantFeatures,
+        updateTenantPlan,
+        updateTenantFeatureOverride,
+        clearTenantFeatureOverride,
       };
     }),
-    dependencies: [SuperAdminRepository.Default, UsersRepository.Default],
+    dependencies: [
+      SuperAdminRepository.Default,
+      UsersRepository.Default,
+      FeaturesService.Default,
+    ],
   },
 ) {}

--- a/src/effect/platform/catalogs/de.ts
+++ b/src/effect/platform/catalogs/de.ts
@@ -48,6 +48,11 @@ export const deCatalog: Record<MessageKey, string> = {
   'drizzle.migrationsFailed':
     'Die Better-Auth-Migrationen konnten nicht ausgefuehrt werden.',
   'errors.internalServerError': 'Interner Serverfehler.',
+  'features.notEnabled':
+    'Diese Funktion ist fuer den aktiven Tenant nicht aktiviert.',
+  'features.repositoryFailed':
+    'Der Vorgang fuer Feature-Berechtigungen ist fehlgeschlagen.',
+  'features.tenantNotFound': 'Tenant nicht gefunden.',
   'fulfillment.infrastructureFailed':
     'Der Fulfillment-Vorgang ist fehlgeschlagen.',
   'fulfillment.insufficientInventory':

--- a/src/effect/platform/catalogs/en.ts
+++ b/src/effect/platform/catalogs/en.ts
@@ -40,6 +40,9 @@ export const enCatalog = {
     'Failed to initialize the database connection.',
   'drizzle.migrationsFailed': 'Failed to run Better Auth migrations.',
   'errors.internalServerError': 'Internal Server Error.',
+  'features.notEnabled': 'This feature is not enabled for the active tenant.',
+  'features.repositoryFailed': 'Feature entitlement operation failed.',
+  'features.tenantNotFound': 'Tenant not found.',
   'fulfillment.infrastructureFailed': 'Fulfillment operation failed.',
   'fulfillment.insufficientInventory':
     'Insufficient inventory to fulfill the pick.',

--- a/src/effect/platform/catalogs/fr.ts
+++ b/src/effect/platform/catalogs/fr.ts
@@ -46,6 +46,11 @@ export const frCatalog: Record<MessageKey, string> = {
   'drizzle.migrationsFailed':
     "Echec de l'execution des migrations Better Auth.",
   'errors.internalServerError': 'Erreur interne du serveur.',
+  'features.notEnabled':
+    "Cette fonctionnalite n'est pas activee pour le tenant actif.",
+  'features.repositoryFailed':
+    "L'operation sur les fonctionnalites a echoue.",
+  'features.tenantNotFound': 'Tenant introuvable.',
   'fulfillment.infrastructureFailed': "L'operation de preparation a echoue.",
   'fulfillment.insufficientInventory':
     'Stock insuffisant pour effectuer le prelevement.',

--- a/src/effect/platform/db/schema.ts
+++ b/src/effect/platform/db/schema.ts
@@ -16,6 +16,11 @@ import {
 import { sql } from 'drizzle-orm';
 import { AuditAction, AuditEntityType } from '@stocket/types/audit-logs';
 import { ClientStatus } from '@stocket/types/clients';
+import {
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
 import { LocationType } from '@stocket/types/locations';
 import { OrderStatus } from '@stocket/types/orders';
 import { StockMovementReason } from '@stocket/types/stock-movements';
@@ -83,6 +88,23 @@ export const auditEntityTypeEnum = pgEnum('audit_logs_entity_type', [
   AuditEntityType.AREA,
   AuditEntityType.CLIENT,
   AuditEntityType.ROLE,
+]);
+
+export const tenantPlanKeyEnum = pgEnum('tenant_plan_key', [
+  PlanKey.FREE,
+  PlanKey.BASE,
+  PlanKey.GROWTH,
+  PlanKey.ENTERPRISE,
+]);
+
+export const tenantEntitlementSourceEnum = pgEnum(
+  'tenant_entitlement_source',
+  [EntitlementSource.SYSTEM, EntitlementSource.MANUAL, EntitlementSource.BILLING],
+);
+
+export const tenantFeatureKeyEnum = pgEnum('tenant_feature_key', [
+  FeatureKey.SMART_IMPORT,
+  FeatureKey.ORDERS,
 ]);
 
 // ── Tables ───────────────────────────────────────────────────────────────
@@ -271,6 +293,60 @@ export const platformAuditEvents = pgTable(
   (table) => [
     index('platform_audit_events_actor_user_id_idx').on(table.actor_user_id),
     index('platform_audit_events_created_at_idx').on(table.created_at),
+  ],
+);
+
+export const tenantEntitlementProfiles = pgTable(
+  'tenant_entitlement_profiles',
+  {
+    tenant_id: uuid('tenant_id')
+      .primaryKey()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    plan_key: tenantPlanKeyEnum('plan_key')
+      .notNull()
+      .default(PlanKey.FREE),
+    source: tenantEntitlementSourceEnum('source')
+      .notNull()
+      .default(EntitlementSource.SYSTEM),
+    updated_by: text('updated_by'),
+    created_at: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updated_at: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index('tenant_entitlement_profiles_plan_key_idx').on(table.plan_key),
+  ],
+);
+
+export const tenantFeatureOverrides = pgTable(
+  'tenant_feature_overrides',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    tenant_id: uuid('tenant_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    feature_key: tenantFeatureKeyEnum('feature_key').notNull(),
+    enabled: boolean('enabled').notNull(),
+    reason: text('reason'),
+    expires_at: timestamp('expires_at', { withTimezone: true }),
+    updated_by: text('updated_by'),
+    created_at: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updated_at: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('tenant_feature_overrides_tenant_feature_unique').on(
+      table.tenant_id,
+      table.feature_key,
+    ),
+    index('tenant_feature_overrides_tenant_id_idx').on(table.tenant_id),
+    index('tenant_feature_overrides_expires_at_idx').on(table.expires_at),
   ],
 );
 

--- a/src/effect/platform/observability/service-tracer.ts
+++ b/src/effect/platform/observability/service-tracer.ts
@@ -7,6 +7,7 @@ export type TraceModule =
   | 'auth'
   | 'categories'
   | 'clients'
+  | 'features'
   | 'health'
   | 'locations'
   | 'notifications'

--- a/src/effect/testing/app-harness.ts
+++ b/src/effect/testing/app-harness.ts
@@ -8,6 +8,7 @@ import { AuthService } from '../modules/auth/service';
 import { BrandingService } from '../modules/branding/service';
 import { CategoriesService } from '../modules/categories/service';
 import { ClientsService } from '../modules/clients/service';
+import { FeaturesService } from '../modules/features/service';
 import { HealthService } from '../modules/health/service';
 import { InventoryService } from '../modules/inventory/service';
 import { LocationsService } from '../modules/locations/service';
@@ -54,6 +55,7 @@ export const makeTestApplicationLayer = (options: TestHttpAppOptions = {}) => {
     layer.pipe(Layer.provide(platformLayer));
 
   const rolesApplicationLayer = withPlatform(RolesService.Default);
+  const featuresApplicationLayer = withPlatform(FeaturesService.Default);
   const permissionProviderLayer = Layer.effect(
     PermissionProvider,
     Effect.map(RolesService, ({ getPermissionsForUser }) => ({
@@ -61,13 +63,15 @@ export const makeTestApplicationLayer = (options: TestHttpAppOptions = {}) => {
     })),
   ).pipe(Layer.provide(rolesApplicationLayer));
   const authApplicationLayer = AuthService.Default.pipe(
-    Layer.provide(rolesApplicationLayer),
+    Layer.provide(
+      Layer.mergeAll(rolesApplicationLayer, featuresApplicationLayer),
+    ),
   );
   const usersApplicationLayer = UsersService.Default.pipe(
     Layer.provide(Layer.mergeAll(platformLayer, rolesApplicationLayer)),
   );
   const superAdminApplicationLayer = SuperAdminService.Default.pipe(
-    Layer.provide(platformLayer),
+    Layer.provide(Layer.mergeAll(platformLayer, featuresApplicationLayer)),
   );
 
   const foundationalServicesLayer = Layer.mergeAll(
@@ -131,6 +135,7 @@ export const makeTestApplicationLayer = (options: TestHttpAppOptions = {}) => {
     auditLayer.pipe(Layer.provide(platformLayer)),
     foundationalServicesLayer,
     rolesApplicationLayer,
+    featuresApplicationLayer,
     permissionProviderLayer,
     authApplicationLayer,
     usersApplicationLayer,


### PR DESCRIPTION
## Summary
- add tenant entitlement profile and feature override schema, migration, repository, and service
- expose superadmin plan/feature override endpoints and include plan/features in /auth/me
- gate Orders and SmartImport server routes with entitlement checks

## Verification
- pnpm type-check
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/vitest run --config vitest.integration.config.ts
- ./node_modules/.bin/oxlint src test (1 existing warning, 0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tenant entitlements and feature management, including plan selection (Free/Base/Growth/Enterprise) and per-feature enablement overrides (with optional expiration).
  * Superadmin can view and manage tenant plan and feature flags via new feature management endpoints.
  * Orders and Products import are now feature-gated (disabled features return HTTP 403 with `features.notEnabled`).
  * Auth “current user” responses now include the tenant’s `planKey` and effective `features`.
  * Added localized feature-related error messages (EN/DE/FR).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->