### PR TITLE
[codex] import products during tenant creation

### DIFF
--- a/src/effect/modules/products/import/service.spec.ts
+++ b/src/effect/modules/products/import/service.spec.ts
@@ -34,14 +34,15 @@ function makeInMemoryRepository() {
   const id = (prefix: string) => `${prefix}-${nextId++}`;
 
   const repo = {
-    findCategoryByNameAndParent: vi.fn((name: string, parentId: string | null) =>
-      Effect.sync(
-        () =>
-          categories.find(
-            (category) =>
-              category.name === name && category.parent_id === parentId,
-          ) ?? null,
-      ),
+    findCategoryByNameAndParent: vi.fn(
+      (name: string, parentId: string | null) =>
+        Effect.sync(
+          () =>
+            categories.find(
+              (category) =>
+                category.name === name && category.parent_id === parentId,
+            ) ?? null,
+        ),
     ),
     createCategory: vi.fn((data: any) =>
       Effect.sync(() => {
@@ -189,8 +190,9 @@ const seedExistingProductWithRootInventory = (
   );
 
   if (options.hasAreaScopedInventory) {
-    (state.repo.hasAreaScopedInventoryForProductAndLocation as any)
-      .mockReturnValue(Effect.succeed(true));
+    (
+      state.repo.hasAreaScopedInventoryForProductAndLocation as any
+    ).mockReturnValue(Effect.succeed(true));
   }
 };
 
@@ -204,7 +206,11 @@ const runImport = (
   );
   return Effect.runPromise(
     Effect.flatMap(ProductImportService, (service) =>
-      service.importFromCsvContent({ content, importType, userId: TEST_USER_ID }),
+      service.importFromCsvContent({
+        content,
+        importType,
+        userId: TEST_USER_ID,
+      }),
     ).pipe(Effect.provide(layer)),
   );
 };
@@ -221,7 +227,11 @@ const runImportWithState = async (
   );
   const result = await Effect.runPromise(
     Effect.flatMap(ProductImportService, (service) =>
-      service.importFromCsvContent({ content, importType, userId: TEST_USER_ID }),
+      service.importFromCsvContent({
+        content,
+        importType,
+        userId: TEST_USER_ID,
+      }),
     ).pipe(Effect.provide(layer)),
   );
   return { result, state };
@@ -238,7 +248,44 @@ const failImport = (
   return Effect.runPromise(
     Effect.flip(
       Effect.flatMap(ProductImportService, (service) =>
-        service.importFromCsvContent({ content, importType, userId: TEST_USER_ID }),
+        service.importFromCsvContent({
+          content,
+          importType,
+          userId: TEST_USER_ID,
+        }),
+      ).pipe(Effect.provide(layer)),
+    ),
+  );
+};
+
+const runValidate = (
+  content: string,
+  importType: 'auto' | 'normalized-products' | 'sortly-items' = 'auto',
+  requireRows = true,
+) => {
+  const { repo } = makeInMemoryRepository();
+  const layer = ProductImportService.DefaultWithoutDependencies.pipe(
+    Layer.provide(makeTestLayer(ProductImportRepository)(repo)),
+  );
+  return Effect.runPromise(
+    Effect.flatMap(ProductImportService, (service) =>
+      service.validateCsvContent({ content, importType, requireRows }),
+    ).pipe(Effect.provide(layer)),
+  );
+};
+
+const failValidate = (
+  content: string,
+  importType: 'auto' | 'normalized-products' | 'sortly-items' = 'auto',
+) => {
+  const { repo } = makeInMemoryRepository();
+  const layer = ProductImportService.DefaultWithoutDependencies.pipe(
+    Layer.provide(makeTestLayer(ProductImportRepository)(repo)),
+  );
+  return Effect.runPromise(
+    Effect.flip(
+      Effect.flatMap(ProductImportService, (service) =>
+        service.validateCsvContent({ content, importType, requireRows: true }),
       ).pipe(Effect.provide(layer)),
     ),
   );
@@ -356,6 +403,72 @@ describe('ProductImportService', () => {
     expect(error).toMatchObject({ _tag: 'ProductImportUnsupportedFormat' });
   });
 
+  it('strictly validates a normalized product CSV', async () => {
+    const validated = await runValidate(`sku,name,category_path,location
+SKU-1,Whisky,Spirits,Warehouse
+`);
+
+    expect(validated.format).toBe('normalized-products');
+    expect(validated.validRows).toHaveLength(1);
+    expect(validated.result.errors).toEqual([]);
+  });
+
+  it('strictly validates a Sortly item CSV', async () => {
+    const validated = await runValidate(
+      `Entry Type,Entry Name,SID,Primary Folder,Quantity
+Folder,Bar,FOLDER-1,Root,0
+Item,Tonic,SORT-1,Drinks,12
+`,
+      'sortly-items',
+    );
+
+    expect(validated.format).toBe('sortly-items');
+    expect(validated.validRows).toHaveLength(1);
+    expect(validated.result.errors).toEqual([]);
+  });
+
+  it('strict validation rejects unsupported CSV headers', async () => {
+    const error = await failValidate('foo,bar\n1,2\n');
+    expect(error).toMatchObject({ _tag: 'ProductImportUnsupportedFormat' });
+  });
+
+  it('strict validation reports empty importable files', async () => {
+    const validated = await runValidate(
+      `Entry Type,Entry Name,SID,Primary Folder
+Folder,Bar,FOLDER-1,Root
+`,
+      'sortly-items',
+    );
+
+    expect(validated.validRows).toHaveLength(0);
+    expect(validated.result.errors).toEqual([
+      { row: 1, error: 'No importable product rows found' },
+    ]);
+  });
+
+  it('strict validation reports row-level import errors', async () => {
+    const validated = await runValidate(`sku,name,category_path,expiry_date
+,Missing SKU,Food,
+SKU-1,First,Food,
+SKU-1,Second,Food,
+SKU-2,Expired,Food,31/02/2025
+`);
+
+    expect(validated.validRows).toHaveLength(0);
+    expect(validated.result.errors).toEqual([
+      { row: 2, error: 'Cannot import product without sku and name' },
+      {
+        row: 3,
+        error: 'Conflicting duplicate SKU "SKU-1" has different product fields',
+      },
+      {
+        row: 4,
+        error: 'Conflicting duplicate SKU "SKU-1" has different product fields',
+      },
+      { row: 5, error: 'Invalid expiry_date "31/02/2025"' },
+    ]);
+  });
+
   it('reports missing sku or name as row errors', async () => {
     const result = await runImport(`sku,name,category_path
 ,Missing SKU,Food
@@ -390,7 +503,8 @@ SKU-1,Second Name,Food,Bar
   });
 
   it('allows consistent duplicate SKUs for multiple locations', async () => {
-    const { result, state } = await runImportWithState(`sku,name,category_path,location,quantity,reorder_point
+    const { result, state } =
+      await runImportWithState(`sku,name,category_path,location,quantity,reorder_point
 SKU-1,Same Product,Food,Warehouse,5,1
 SKU-1,Same Product,Food,Bar,7,1
 `);
@@ -404,7 +518,8 @@ SKU-1,Same Product,Food,Bar,7,1
   });
 
   it('reports normalized duplicate SKUs with conflicting reorder points', async () => {
-    const result = await runImport(`sku,name,category_path,location,quantity,reorder_point
+    const result =
+      await runImport(`sku,name,category_path,location,quantity,reorder_point
 SKU-1,Same Product,Food,Warehouse,5,1
 SKU-1,Same Product,Food,Bar,7,2
 `);

--- a/src/effect/modules/products/import/service.ts
+++ b/src/effect/modules/products/import/service.ts
@@ -9,6 +9,8 @@ import type {
   NormalizedProductImportRow,
   ProductImportResultDto,
   ProductImportValues,
+  ValidateProductImportCsvOptions,
+  ValidatedProductImportCsv,
 } from './types';
 import {
   detectProductImportFormat,
@@ -144,10 +146,7 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
             standard_price: parseProductImportNumber(row.standard_price),
             reorder_point: parseInteger(row.reorder_point, 0),
             is_active: parseBoolean(row.is_active, true),
-            is_perishable: parseBoolean(
-              row.is_perishable,
-              Boolean(expiryDate),
-            ),
+            is_perishable: parseBoolean(row.is_perishable, Boolean(expiryDate)),
             notes: nullableText(row.notes),
           };
 
@@ -169,10 +168,10 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
             return existing;
           }
 
-          const product = yield* repository.updateProduct(
-            existing.id,
-            { ...values, updated_by: updatedBy },
-          );
+          const product = yield* repository.updateProduct(existing.id, {
+            ...values,
+            updated_by: updatedBy,
+          });
           if (!product) {
             return yield* Effect.fail(
               new ProductsInfrastructureError({
@@ -309,12 +308,12 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
           yield* upsertInventory(product, locationId, row, result, expiryDate);
         });
 
-      const importFromCsvContent = ({
+      const validateCsvContent = ({
         content,
         importType = 'auto',
-        userId,
-      }: ImportProductsFromCsvOptions): Effect.Effect<
-        ProductImportResultDto,
+        requireRows = false,
+      }: ValidateProductImportCsvOptions): Effect.Effect<
+        ValidatedProductImportCsv,
         ProductImportCsvParseFailed | ProductImportUnsupportedFormat
       > =>
         Effect.gen(function* () {
@@ -337,14 +336,10 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
 
           const result = makeEmptyProductImportResult();
           const rows = normalizeProductImportRecords(parsed.records, format);
+          const validRows: NormalizedProductImportRow[] = [];
           const duplicateConflictRows = findConflictingDuplicateSkuRows(rows, {
             includeReorderPoint: format === 'normalized-products',
           });
-          const caches: ImportCaches = {
-            categories: new Map<string, string>(),
-            locations: new Map<string, string>(),
-            products: new Map<string, ImportProductRow>(),
-          };
 
           for (const row of rows) {
             if (!row.sku || !row.name) {
@@ -375,14 +370,48 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
               continue;
             }
 
+            validRows.push(row);
+          }
+
+          if (
+            requireRows &&
+            validRows.length === 0 &&
+            result.errors.length === 0
+          ) {
+            pushRowError(result, 1, 'No importable product rows found');
+          }
+
+          return {
+            format,
+            rows,
+            validRows,
+            result,
+          } satisfies ValidatedProductImportCsv;
+        }).pipe(Effect.withSpan('ProductImportService.validateCsvContent'));
+
+      const importFromCsvContent = ({
+        content,
+        importType = 'auto',
+        userId,
+      }: ImportProductsFromCsvOptions): Effect.Effect<
+        ProductImportResultDto,
+        ProductImportCsvParseFailed | ProductImportUnsupportedFormat
+      > =>
+        Effect.gen(function* () {
+          const validated = yield* validateCsvContent({ content, importType });
+          const result = validated.result;
+          const caches: ImportCaches = {
+            categories: new Map<string, string>(),
+            locations: new Map<string, string>(),
+            products: new Map<string, ImportProductRow>(),
+          };
+
+          for (const row of validated.validRows) {
+            const expiryDate = parseDate(row.expiry_date);
             yield* importRow(row, caches, result, expiryDate, userId).pipe(
               Effect.catchAll((error) =>
                 Effect.sync(() => {
-                  pushRowError(
-                    result,
-                    row.sourceRow,
-                    formatImportError(error),
-                  );
+                  pushRowError(result, row.sourceRow, formatImportError(error));
                 }),
               ),
             );
@@ -393,6 +422,7 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
 
       return {
         importFromCsvContent,
+        validateCsvContent,
       };
     }),
     dependencies: [ProductImportRepository.Default],

--- a/src/effect/modules/products/import/types.ts
+++ b/src/effect/modules/products/import/types.ts
@@ -57,6 +57,19 @@ export interface ImportProductsFromCsvOptions {
   readonly userId: string;
 }
 
+export interface ValidateProductImportCsvOptions {
+  readonly content: string;
+  readonly importType?: ProductImportType;
+  readonly requireRows?: boolean;
+}
+
+export interface ValidatedProductImportCsv {
+  readonly format: ProductImportFormat;
+  readonly rows: readonly NormalizedProductImportRow[];
+  readonly validRows: readonly NormalizedProductImportRow[];
+  readonly result: ProductImportResultDto;
+}
+
 export interface ProductImportValues {
   readonly name: string;
   readonly description: string | null;

--- a/src/effect/modules/superadmin/create-tenant-import.integration.spec.ts
+++ b/src/effect/modules/superadmin/create-tenant-import.integration.spec.ts
@@ -1,0 +1,359 @@
+import { eq } from 'drizzle-orm';
+import {
+  categories,
+  inventory,
+  locations,
+  organizations,
+  platformAuditEvents,
+  products,
+  superAdmins,
+} from '../../platform/db/schema';
+import type { DrizzleDb } from '../../platform/db/drizzle';
+import { makeTestHttpAppHandler } from '../../testing/app-harness';
+import {
+  getTestDb,
+  seedBetterAuthUser,
+  TEST_USER_ID,
+  withTestDb,
+} from '../../testing/test-harness';
+import type { BetterAuthStubOptions } from '../../testing/better-auth-test';
+
+let db: DrizzleDb;
+
+const PLATFORM_HOST = 'app.stocket.fr';
+const PLATFORM_ORIGIN = `http://${PLATFORM_HOST}`;
+const TENANT_ADMIN_ID = '00000000-0000-4000-a000-000000000901';
+
+interface PasswordResetRequest {
+  readonly body: {
+    readonly email: string;
+    readonly redirectTo: string;
+  };
+}
+
+const makeSession = (userId = TEST_USER_ID) => ({
+  user: {
+    id: userId,
+    name: 'Platform Admin',
+    email: `${userId}@example.com`,
+    image: null,
+    emailVerified: true,
+    createdAt: new Date('2026-06-01T08:00:00.000Z'),
+    updatedAt: new Date('2026-06-01T08:00:00.000Z'),
+    role: 'user' as const,
+  },
+  session: {
+    id: `session-${userId}`,
+    userId,
+    token: `token-${userId}`,
+    createdAt: new Date('2026-06-01T08:00:00.000Z'),
+    updatedAt: new Date('2026-06-01T08:00:00.000Z'),
+    expiresAt: new Date('2026-07-01T08:00:00.000Z'),
+    activeOrganizationId: null,
+  },
+});
+
+const platformRequest = (path: string, init: RequestInit = {}) => {
+  const headers = new Headers(init.headers);
+  headers.set('host', PLATFORM_HOST);
+
+  return new Request(`${PLATFORM_ORIGIN}${path}`, {
+    ...init,
+    headers,
+  });
+};
+
+const makeCreateTenantForm = (
+  overrides: Partial<{
+    readonly name: string;
+    readonly slug: string;
+    readonly adminName: string;
+    readonly adminEmail: string;
+    readonly adminPassword: string;
+    readonly importFile: File;
+  }> = {},
+) => {
+  const formData = new FormData();
+  formData.append('name', overrides.name ?? 'Imported Tenant');
+  formData.append('slug', overrides.slug ?? 'imported-tenant');
+  formData.append('admin_name', overrides.adminName ?? 'Tenant Admin');
+  formData.append(
+    'admin_email',
+    overrides.adminEmail ?? 'tenant-admin@example.com',
+  );
+  formData.append('admin_password', overrides.adminPassword ?? 'password123');
+  if (overrides.importFile) {
+    formData.append('import_file', overrides.importFile);
+  }
+  return formData;
+};
+
+async function seedPlatformSuperAdmin(userId = TEST_USER_ID) {
+  await seedBetterAuthUser(db, {
+    id: userId,
+    email: `${userId}@example.com`,
+    name: 'Platform Admin',
+  });
+  await db
+    .insert(superAdmins)
+    .values({ user_id: userId })
+    .onConflictDoNothing();
+}
+
+const makeBetterAuthOverrides = () => ({
+  createUser: vi.fn(async () => ({ user: { id: TENANT_ADMIN_ID } })),
+  requestPasswordReset: vi.fn(async (_request: PasswordResetRequest) => ({
+    status: true,
+  })),
+});
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForMockCall(spy: ReturnType<typeof vi.fn>) {
+  for (let attempt = 0; attempt < 25; attempt += 1) {
+    if (spy.mock.calls.length > 0) {
+      return;
+    }
+    await delay(10);
+  }
+}
+
+async function waitForTenantCreateAudit(slug: string) {
+  for (let attempt = 0; attempt < 25; attempt += 1) {
+    const rows = await db
+      .select({ metadata: platformAuditEvents.metadata })
+      .from(platformAuditEvents);
+    if (
+      rows.some(
+        (row) =>
+          typeof row.metadata === 'object' &&
+          row.metadata !== null &&
+          'slug' in row.metadata &&
+          row.metadata.slug === slug,
+      )
+    ) {
+      return;
+    }
+    await delay(10);
+  }
+}
+
+async function postCreateTenant(
+  formData: FormData,
+  betterAuthOverrides = makeBetterAuthOverrides(),
+) {
+  const slug = formData.get('slug');
+  await seedPlatformSuperAdmin();
+  const { handler, dispose } = makeTestHttpAppHandler({
+    session: makeSession(TEST_USER_ID),
+    betterAuthOverrides:
+      betterAuthOverrides as unknown as BetterAuthStubOptions['overrides'],
+  });
+
+  try {
+    const response = await handler(
+      platformRequest('/api/v1/superadmin/tenants', {
+        method: 'POST',
+        body: formData,
+      }),
+    );
+    const json = await response.json();
+    if (response.status === 201 && typeof slug === 'string') {
+      await waitForTenantCreateAudit(slug);
+    }
+    return { response, body: json, betterAuthOverrides };
+  } finally {
+    await dispose();
+  }
+}
+
+async function findTenantBySlug(slug: string) {
+  const rows = await db
+    .select()
+    .from(organizations)
+    .where(eq(organizations.slug, slug))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+withTestDb();
+beforeAll(() => {
+  db = getTestDb();
+});
+
+describe('POST /api/v1/superadmin/tenants import', () => {
+  it('creates a tenant from multipart fields without an import file', async () => {
+    const result = await postCreateTenant(
+      makeCreateTenantForm({ slug: 'tenant-without-file' }),
+    );
+
+    expect(result.response.status).toBe(201);
+    expect(result.body).toMatchObject({
+      tenant: { slug: 'tenant-without-file' },
+      admin: {
+        id: TENANT_ADMIN_ID,
+        email: 'tenant-admin@example.com',
+        name: 'Tenant Admin',
+      },
+    });
+    expect(result.body.productImport).toBeUndefined();
+    await expect(findTenantBySlug('tenant-without-file')).resolves.toBeTruthy();
+  });
+
+  it('creates a tenant and imports a valid product CSV into that tenant', async () => {
+    const csv = `sku,name,category_path,reorder_point,quantity,location,unit
+IMP-001,Imported Whisky,Spirits,4,9,Main Warehouse,bottle
+`;
+    const result = await postCreateTenant(
+      makeCreateTenantForm({
+        slug: 'tenant-with-import',
+        importFile: new File([csv], 'products.csv', { type: 'text/csv' }),
+      }),
+    );
+
+    expect(result.response.status).toBe(201);
+    expect(result.body.productImport).toMatchObject({
+      categoriesCreated: 1,
+      locationsCreated: 1,
+      productsCreated: 1,
+      inventoryRecordsCreated: 1,
+      rowsSkipped: 0,
+      errors: [],
+    });
+
+    const tenant = await findTenantBySlug('tenant-with-import');
+    expect(tenant).toBeTruthy();
+
+    const [product] = await db
+      .select()
+      .from(products)
+      .where(eq(products.tenant_id, tenant!.id))
+      .limit(1);
+    expect(product).toMatchObject({
+      sku: 'IMP-001',
+      name: 'Imported Whisky',
+      created_by: TENANT_ADMIN_ID,
+      updated_by: TENANT_ADMIN_ID,
+    });
+
+    await expect(
+      db.select().from(categories).where(eq(categories.tenant_id, tenant!.id)),
+    ).resolves.toHaveLength(1);
+    await expect(
+      db.select().from(locations).where(eq(locations.tenant_id, tenant!.id)),
+    ).resolves.toHaveLength(1);
+    await expect(
+      db.select().from(inventory).where(eq(inventory.tenant_id, tenant!.id)),
+    ).resolves.toHaveLength(1);
+
+    const [auditEvent] = await db
+      .select()
+      .from(platformAuditEvents)
+      .where(eq(platformAuditEvents.entity_id, tenant!.id))
+      .limit(1);
+    expect(auditEvent?.metadata).toMatchObject({
+      productImport: {
+        filename: 'products.csv',
+        productsCreated: 1,
+        inventoryRecordsCreated: 1,
+      },
+    });
+
+    await waitForMockCall(result.betterAuthOverrides.requestPasswordReset);
+    expect(result.betterAuthOverrides.requestPasswordReset).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(
+      result.betterAuthOverrides.requestPasswordReset.mock.calls[0]?.[0]?.body,
+    ).toMatchObject({
+      email: 'tenant-admin@example.com',
+      redirectTo:
+        'http://tenant-with-import.localhost:3000/reset-password?flow=welcome',
+    });
+  });
+
+  it('rejects an invalid import file without creating a tenant', async () => {
+    const overrides = makeBetterAuthOverrides();
+    const result = await postCreateTenant(
+      makeCreateTenantForm({
+        slug: 'tenant-invalid-import',
+        importFile: new File(
+          ['sku,name,category_path\n,Missing SKU,Food\n'],
+          'invalid.csv',
+          { type: 'text/csv' },
+        ),
+      }),
+      overrides,
+    );
+
+    expect(result.response.status).toBe(400);
+    expect(result.body).toMatchObject({
+      messageKey: 'superadmin.tenantImportInvalid',
+    });
+    expect(result.body.message).toContain('Row 2');
+    await expect(findTenantBySlug('tenant-invalid-import')).resolves.toBeNull();
+    expect(overrides.createUser).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the tenant when import fails inside the transaction', async () => {
+    const longCategoryName = 'A'.repeat(101);
+    const overrides = makeBetterAuthOverrides();
+    const result = await postCreateTenant(
+      makeCreateTenantForm({
+        slug: 'tenant-rollback-import',
+        adminEmail: 'rollback-admin@example.com',
+        importFile: new File(
+          [`sku,name,category_path\nROLLBACK-1,Rollback,${longCategoryName}\n`],
+          'rollback.csv',
+          { type: 'text/csv' },
+        ),
+      }),
+      overrides,
+    );
+
+    expect(result.response.status).toBe(400);
+    expect(result.body).toMatchObject({
+      messageKey: 'superadmin.tenantImportInvalid',
+    });
+    await expect(
+      findTenantBySlug('tenant-rollback-import'),
+    ).resolves.toBeNull();
+    expect(overrides.createUser).toHaveBeenCalledTimes(1);
+    expect(overrides.requestPasswordReset).not.toHaveBeenCalled();
+  });
+
+  it('rejects JSON tenant creation because the endpoint is multipart-only', async () => {
+    await seedPlatformSuperAdmin();
+    const betterAuthOverrides = makeBetterAuthOverrides();
+    const { handler, dispose } = makeTestHttpAppHandler({
+      session: makeSession(TEST_USER_ID),
+      betterAuthOverrides:
+        betterAuthOverrides as unknown as BetterAuthStubOptions['overrides'],
+    });
+
+    try {
+      const response = await handler(
+        platformRequest('/api/v1/superadmin/tenants', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            name: 'JSON Tenant',
+            slug: 'json-tenant',
+            admin: {
+              name: 'Tenant Admin',
+              email: 'json-tenant-admin@example.com',
+              password: 'password123',
+            },
+          }),
+        }),
+      );
+
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(response.status).toBeLessThan(500);
+      await expect(findTenantBySlug('json-tenant')).resolves.toBeNull();
+      expect(betterAuthOverrides.createUser).not.toHaveBeenCalled();
+    } finally {
+      await dispose();
+    }
+  });
+});

--- a/src/effect/modules/superadmin/repository.ts
+++ b/src/effect/modules/superadmin/repository.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { Effect } from 'effect';
 import { and, asc, eq, sql } from 'drizzle-orm';
-import { DrizzleDatabase } from '../../platform/db/drizzle';
+import { DrizzleDatabase, type DrizzleDb } from '../../platform/db/drizzle';
 import {
   betterAuthUsers,
   members,
@@ -70,6 +70,93 @@ export interface CreatedTenantResult {
 
 const rowsOf = <A>(result: unknown): A[] =>
   ((result as { rows?: A[] }).rows ?? (result as A[])) as A[];
+
+const insertTenantWithAdmin = async (
+  tx: DrizzleDb,
+  input: CreateTenantInput,
+): Promise<CreatedTenantResult> => {
+  const tenantId = randomUUID();
+
+  const [tenant] = await tx
+    .insert(organizations)
+    .values({
+      id: tenantId,
+      name: input.name,
+      slug: input.slug,
+    })
+    .returning({
+      id: organizations.id,
+      name: organizations.name,
+      slug: organizations.slug,
+    });
+
+  await tx.insert(tenantDomains).values({
+    tenant_id: tenantId,
+    hostname: input.hostname,
+    kind: 'subdomain',
+    is_primary: true,
+    verified_at: new Date(),
+  });
+
+  for (const seed of defaultRoleSeedDefinitions) {
+    const [role] = await tx
+      .insert(roles)
+      .values({
+        tenant_id: tenantId,
+        name: seed.name,
+        description: seed.description,
+        is_system: true,
+      })
+      .returning({ id: roles.id });
+
+    await tx.insert(rolePermissions).values(
+      seed.permissions.map((permission) => ({
+        role_id: role!.id,
+        resource: permission.resource,
+        permission: permission.permission,
+      })),
+    );
+  }
+
+  await tx
+    .insert(members)
+    .values({
+      id: randomUUID(),
+      organization_id: tenantId,
+      user_id: input.adminUserId,
+      role: 'member',
+    })
+    .onConflictDoNothing();
+
+  const adminRoleRows = await tx
+    .select({ id: roles.id })
+    .from(roles)
+    .where(and(eq(roles.tenant_id, tenantId), eq(roles.name, 'Admin')))
+    .limit(1);
+
+  const adminRoleId = adminRoleRows[0]?.id;
+  if (!adminRoleId) {
+    throw new Error('Admin role seed missing after tenant creation');
+  }
+
+  await tx.insert(userRoles).values({
+    tenant_id: tenantId,
+    user_id: input.adminUserId,
+    role_id: adminRoleId,
+  });
+
+  return {
+    tenant: {
+      id: tenant!.id,
+      name: tenant!.name,
+      slug: tenant!.slug,
+      hostname: input.hostname,
+    },
+    admin: {
+      id: input.adminUserId,
+    },
+  } satisfies CreatedTenantResult;
+};
 
 export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()(
   '@stocket/effect/superadmin/SuperAdminRepository',
@@ -149,90 +236,15 @@ export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()
 
       const createTenantWithAdmin = (input: CreateTenantInput) =>
         tryAsync('create tenant with admin', async () => {
-          const tenantId = randomUUID();
-
-          return db.transaction(async (tx) => {
-            const [tenant] = await tx
-              .insert(organizations)
-              .values({
-                id: tenantId,
-                name: input.name,
-                slug: input.slug,
-              })
-              .returning({
-                id: organizations.id,
-                name: organizations.name,
-                slug: organizations.slug,
-              });
-
-            await tx.insert(tenantDomains).values({
-              tenant_id: tenantId,
-              hostname: input.hostname,
-              kind: 'subdomain',
-              is_primary: true,
-              verified_at: new Date(),
-            });
-
-            for (const seed of defaultRoleSeedDefinitions) {
-              const [role] = await tx
-                .insert(roles)
-                .values({
-                  tenant_id: tenantId,
-                  name: seed.name,
-                  description: seed.description,
-                  is_system: true,
-                })
-                .returning({ id: roles.id });
-
-              await tx.insert(rolePermissions).values(
-                seed.permissions.map((permission) => ({
-                  role_id: role!.id,
-                  resource: permission.resource,
-                  permission: permission.permission,
-                })),
-              );
-            }
-
-            await tx
-              .insert(members)
-              .values({
-                id: randomUUID(),
-                organization_id: tenantId,
-                user_id: input.adminUserId,
-                role: 'member',
-              })
-              .onConflictDoNothing();
-
-            const adminRoleRows = await tx
-              .select({ id: roles.id })
-              .from(roles)
-              .where(and(eq(roles.tenant_id, tenantId), eq(roles.name, 'Admin')))
-              .limit(1);
-
-            const adminRoleId = adminRoleRows[0]?.id;
-            if (!adminRoleId) {
-              throw new Error('Admin role seed missing after tenant creation');
-            }
-
-            await tx.insert(userRoles).values({
-              tenant_id: tenantId,
-              user_id: input.adminUserId,
-              role_id: adminRoleId,
-            });
-
-            return {
-              tenant: {
-                id: tenant!.id,
-                name: tenant!.name,
-                slug: tenant!.slug,
-                hostname: input.hostname,
-              },
-              admin: {
-                id: input.adminUserId,
-              },
-            } satisfies CreatedTenantResult;
-          });
+          return db.transaction(async (tx) =>
+            insertTenantWithAdmin(tx as unknown as DrizzleDb, input),
+          );
         });
+
+      const createTenantWithAdminRecords = (input: CreateTenantInput) =>
+        tryAsync('create tenant with admin records', () =>
+          insertTenantWithAdmin(db, input),
+        );
 
       const recordPlatformAuditEvent = (input: PlatformAuditEventInput) =>
         tryAsync('record platform audit event', async () => {
@@ -254,6 +266,7 @@ export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()
         tenantSlugExists,
         tenantHostnameExists,
         createTenantWithAdmin,
+        createTenantWithAdminRecords,
         recordPlatformAuditEvent,
       };
     }),

--- a/src/effect/modules/superadmin/router.ts
+++ b/src/effect/modules/superadmin/router.ts
@@ -1,12 +1,23 @@
-import { HttpRouter, HttpServerRequest } from '@effect/platform';
-import { Effect } from 'effect';
+import { readFile } from 'node:fs/promises';
+import { HttpRouter, HttpServerRequest, Multipart } from '@effect/platform';
+import { Effect, Schema } from 'effect';
 import { requireSuperAdmin } from '../../platform/auth/authorization';
 import { BetterAuthHeaders } from '../../platform/auth/better-auth';
 import { respondJson } from '../../platform/http/errors';
 import { getRequestHeaders } from '../../platform/http/session';
 import { CreateSuperAdminTenantSchema } from '@stocket/types/superadmin';
 import { getRequestContext } from '../../platform/http/request-context';
+import { SuperAdminTenantImportReadFailed } from './superadmin.errors';
 import { SuperAdminService } from './service';
+
+const CreateSuperAdminTenantUploadSchema = Schema.Struct({
+  name: Schema.String,
+  slug: Schema.String,
+  admin_name: Schema.String,
+  admin_email: Schema.String,
+  admin_password: Schema.String,
+  import_file: Schema.optional(Multipart.SingleFileSchema),
+});
 
 export const superAdminRouter = HttpRouter.empty.pipe(
   HttpRouter.get(
@@ -29,9 +40,35 @@ export const superAdminRouter = HttpRouter.empty.pipe(
     '/tenants',
     Effect.gen(function* () {
       const session = yield* requireSuperAdmin;
-      const dto = yield* HttpServerRequest.schemaBodyJson(
-        CreateSuperAdminTenantSchema,
+      const upload = yield* HttpServerRequest.schemaBodyMultipart(
+        CreateSuperAdminTenantUploadSchema,
       );
+      const dto = yield* Schema.decodeUnknown(CreateSuperAdminTenantSchema)({
+        name: upload.name,
+        slug: upload.slug,
+        admin: {
+          name: upload.admin_name,
+          email: upload.admin_email,
+          password: upload.admin_password,
+        },
+      });
+      const uploadedImportFile = upload.import_file;
+      const importFile = uploadedImportFile
+        ? yield* Effect.tryPromise({
+            try: async () => ({
+              filename: uploadedImportFile.name,
+              content: (await readFile(uploadedImportFile.path)).toString(
+                'utf8',
+              ),
+            }),
+            catch: (cause) =>
+              new SuperAdminTenantImportReadFailed({
+                filename: uploadedImportFile.name,
+                cause,
+                messageKey: 'superadmin.tenantImportReadFailed',
+              }),
+          })
+        : undefined;
       const request = yield* HttpServerRequest.HttpServerRequest;
       const requestContext = yield* getRequestContext;
       const requestHeaders = yield* getRequestHeaders;
@@ -40,11 +77,15 @@ export const superAdminRouter = HttpRouter.empty.pipe(
 
       return yield* respondJson(
         superAdminService
-          .createTenant(dto, {
-            userId: session.user.id,
-            ipAddress: requestContext.ip,
-            userAgent: typeof userAgent === 'string' ? userAgent : null,
-          })
+          .createTenant(
+            dto,
+            {
+              userId: session.user.id,
+              ipAddress: requestContext.ip,
+              userAgent: typeof userAgent === 'string' ? userAgent : null,
+            },
+            importFile ? { importFile } : undefined,
+          )
           .pipe(Effect.provideService(BetterAuthHeaders, requestHeaders)),
         { status: 201 },
       );

--- a/src/effect/modules/superadmin/service.spec.ts
+++ b/src/effect/modules/superadmin/service.spec.ts
@@ -1,5 +1,7 @@
-import { Effect, Layer } from 'effect';
+import { Cause, Effect, Exit, Layer, Option } from 'effect';
 import { BetterAuth, BetterAuthHeaders } from '../../platform/auth/better-auth';
+import { DrizzleDatabase } from '../../platform/db/drizzle';
+import { ProductImportService } from '../products/import/service';
 import { UsersRepository } from '../users/repository';
 import { SuperAdminRepository } from './repository';
 import { SuperAdminService } from './service';
@@ -45,10 +47,13 @@ describe('Effect SuperAdminService', () => {
   const makeRepository = () => ({
     tenantSlugExists: vi.fn().mockReturnValue(Effect.succeed(false)),
     tenantHostnameExists: vi.fn().mockReturnValue(Effect.succeed(false)),
-    findBetterAuthUserByLoweredEmail: vi.fn().mockReturnValue(
-      Effect.succeed(null),
-    ),
+    findBetterAuthUserByLoweredEmail: vi
+      .fn()
+      .mockReturnValue(Effect.succeed(null)),
     createTenantWithAdmin: vi
+      .fn()
+      .mockReturnValue(Effect.succeed(createdTenant)),
+    createTenantWithAdminRecords: vi
       .fn()
       .mockReturnValue(Effect.succeed(createdTenant)),
     recordPlatformAuditEvent: vi.fn().mockReturnValue(Effect.void),
@@ -67,12 +72,41 @@ describe('Effect SuperAdminService', () => {
     },
   });
 
+  const makeProductImportService = () => ({
+    validateCsvContent: vi.fn().mockReturnValue(
+      Effect.succeed({
+        format: 'normalized-products',
+        rows: [],
+        validRows: [],
+        result: {
+          categoriesCreated: 0,
+          locationsCreated: 0,
+          productsCreated: 0,
+          productsUpdated: 0,
+          inventoryRecordsCreated: 0,
+          inventoryRecordsUpdated: 0,
+          rowsSkipped: 0,
+          errors: [],
+        },
+      }),
+    ),
+    importFromCsvContent: vi.fn(),
+  });
+
+  const makeDrizzle = () => ({
+    transaction: vi.fn(),
+  });
+
   const makeServiceLayer = ({
     betterAuth,
+    db = makeDrizzle(),
+    productImportService = makeProductImportService(),
     repository,
     usersRepository,
   }: {
     betterAuth: unknown;
+    db?: unknown;
+    productImportService?: unknown;
     repository: unknown;
     usersRepository: unknown;
   }) =>
@@ -83,6 +117,11 @@ describe('Effect SuperAdminService', () => {
           Layer.succeed(
             SuperAdminRepository,
             repository as typeof SuperAdminRepository.Service,
+          ),
+          Layer.succeed(DrizzleDatabase, db as typeof DrizzleDatabase.Service),
+          Layer.succeed(
+            ProductImportService,
+            productImportService as typeof ProductImportService.Service,
           ),
           Layer.succeed(
             UsersRepository,
@@ -153,7 +192,8 @@ describe('Effect SuperAdminService', () => {
     });
 
     await waitForCall(betterAuth.api.requestPasswordReset);
-    const welcomeRequest = betterAuth.api.requestPasswordReset.mock.calls[0]![0];
+    const welcomeRequest =
+      betterAuth.api.requestPasswordReset.mock.calls[0]![0];
     expect(welcomeRequest.body).toEqual({
       email: 'admin@example.com',
       redirectTo: 'https://acme.localhost:3000/reset-password?flow=welcome',
@@ -198,5 +238,69 @@ describe('Effect SuperAdminService', () => {
       email: 'existing@example.com',
       name: 'Existing Admin',
     });
+  });
+
+  it('rejects an invalid tenant import file before creating the tenant admin', async () => {
+    const betterAuth = makeBetterAuth();
+    const repository = makeRepository();
+    const usersRepository = makeUsersRepository();
+    const productImportService = makeProductImportService();
+    productImportService.validateCsvContent.mockReturnValue(
+      Effect.succeed({
+        format: 'normalized-products',
+        rows: [],
+        validRows: [],
+        result: {
+          categoriesCreated: 0,
+          locationsCreated: 0,
+          productsCreated: 0,
+          productsUpdated: 0,
+          inventoryRecordsCreated: 0,
+          inventoryRecordsUpdated: 0,
+          rowsSkipped: 1,
+          errors: [
+            { row: 2, error: 'Cannot import product without sku and name' },
+          ],
+        },
+      }),
+    );
+    const layer = makeServiceLayer({
+      betterAuth,
+      productImportService,
+      repository,
+      usersRepository,
+    });
+
+    const exit = await Effect.runPromiseExit(
+      Effect.flatMap(SuperAdminService, (service) =>
+        service.createTenant(createTenantInput, actor, {
+          importFile: {
+            filename: 'products.csv',
+            content: 'sku,name,category_path\n,Missing SKU,Food\n',
+          },
+        }),
+      ).pipe(
+        Effect.provideService(BetterAuthHeaders, requestHeaders),
+        Effect.provide(layer),
+      ),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) {
+      throw new Error('Expected tenant import validation to fail');
+    }
+    const failure = Cause.failureOption(exit.cause);
+    expect(Option.isSome(failure)).toBe(true);
+    if (Option.isNone(failure)) {
+      throw new Error('Expected tenant import validation failure');
+    }
+    expect(failure.value).toMatchObject({
+      _tag: 'SuperAdminTenantImportInvalid',
+      messageKey: 'superadmin.tenantImportInvalid',
+    });
+
+    expect(betterAuth.api.createUser).not.toHaveBeenCalled();
+    expect(repository.createTenantWithAdmin).not.toHaveBeenCalled();
+    expect(repository.createTenantWithAdminRecords).not.toHaveBeenCalled();
+    expect(productImportService.importFromCsvContent).not.toHaveBeenCalled();
   });
 });

--- a/src/effect/modules/superadmin/service.ts
+++ b/src/effect/modules/superadmin/service.ts
@@ -1,4 +1,8 @@
-import { Effect } from 'effect';
+import { Cause, Effect, Exit, Layer, Option } from 'effect';
+import type {
+  ProductImportErrorDto,
+  ProductImportResultDto,
+} from '@stocket/types/products';
 import type {
   CreateSuperAdminTenantInput,
   SuperAdminCreateTenantResponse,
@@ -11,23 +15,32 @@ import {
   isValidTenantSlug,
 } from '../../platform/tenancy/host';
 import type { UserSession } from '../../platform/auth/user-session';
+import { DrizzleDatabase, type DrizzleDb } from '../../platform/db/drizzle';
+import { isAppError } from '../../platform/effect/domain-errors';
+import {
+  CurrentRequestContext,
+  type RequestContext,
+} from '../../platform/http/request-context';
 import { makeServiceTracer } from '../../platform/observability/service-tracer';
 import { makeTryAsync } from '../../platform/effect/try-async';
 import { BetterAuth, BetterAuthHeaders } from '../../platform/auth/better-auth';
 import { type LogPayload } from '../../platform/observability/messages';
 import { UsersRepository } from '../users/repository';
-import {
-  tenantWelcomeOrigin,
-  welcomeRedirectUrl,
-} from '../users/users.utils';
+import { tenantWelcomeOrigin, welcomeRedirectUrl } from '../users/users.utils';
 import {
   InvalidTenantSlug,
   ReservedTenantSlug,
   SuperAdminRepositoryError,
+  SuperAdminTenantImportInvalid,
   TenantHostnameAlreadyExists,
   TenantSlugAlreadyExists,
 } from './superadmin.errors';
-import { SuperAdminRepository } from './repository';
+import { ProductImportService } from '../products/import/service';
+import {
+  type CreatedTenantResult,
+  type CreateTenantInput,
+  SuperAdminRepository,
+} from './repository';
 
 interface BetterAuthCreateUserResponse {
   readonly user: { readonly id: string };
@@ -40,8 +53,94 @@ interface BetterAuthCreateUserBody {
   readonly data?: { readonly emailVerified: boolean };
 }
 
+interface TenantImportFile {
+  readonly filename?: string;
+  readonly content: string;
+}
+
+interface CreateTenantOptions {
+  readonly importFile?: TenantImportFile;
+}
+
+interface CreatedTenantWithImportResult extends CreatedTenantResult {
+  readonly productImport?: ProductImportResultDto;
+}
+
 const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
   value !== null && typeof value === 'object';
+
+const importErrorDetails = (errors: readonly ProductImportErrorDto[]): string =>
+  errors
+    .slice(0, 5)
+    .map((error) =>
+      error.row > 0 ? `Row ${error.row}: ${error.error}` : error.error,
+    )
+    .join('; ');
+
+const makeTenantImportInvalid = (
+  file: TenantImportFile,
+  errors: readonly ProductImportErrorDto[],
+  cause?: unknown,
+) => {
+  const details =
+    importErrorDetails(errors) ||
+    (cause instanceof Error && cause.message
+      ? cause.message
+      : 'The import file is not valid.');
+
+  return new SuperAdminTenantImportInvalid({
+    filename: file.filename,
+    details,
+    cause,
+    messageKey: 'superadmin.tenantImportInvalid',
+    messageArgs: { details },
+  });
+};
+
+class SuperAdminTransactionDefect extends Error {
+  constructor(public readonly cause: Cause.Cause<unknown>) {
+    super(Cause.pretty(cause));
+    this.name = 'SuperAdminTransactionDefect';
+  }
+}
+
+const runEffectAsPromise = async <A, E>(
+  effect: Effect.Effect<A, E, never>,
+): Promise<A> => {
+  const exit = await Effect.runPromiseExit(effect);
+  if (Exit.isSuccess(exit)) return exit.value;
+
+  const failure = Cause.failureOption(exit.cause);
+  if (Option.isSome(failure)) throw failure.value;
+  throw new SuperAdminTransactionDefect(exit.cause);
+};
+
+const makeTenantImportRequestContext = (
+  current: Option.Option<RequestContext>,
+  created: CreatedTenantResult,
+  actor: { readonly ipAddress?: string | null },
+): RequestContext => {
+  const base = Option.isSome(current) ? current.value : null;
+  return {
+    requestId: base?.requestId ?? '00000000-0000-4000-8000-000000000301',
+    path: base?.path ?? '/api/v1/superadmin/tenants',
+    method: base?.method ?? ('POST' as RequestContext['method']),
+    ip: base?.ip ?? actor.ipAddress ?? null,
+    locale: base?.locale ?? 'en',
+    tenantId: created.tenant.id,
+    tenantName: created.tenant.name,
+    tenantSlug: created.tenant.slug,
+  };
+};
+
+const mapTransactionCause = (cause: unknown) =>
+  isAppError(cause)
+    ? cause
+    : new SuperAdminRepositoryError({
+        action: 'create tenant with import',
+        cause,
+        messageKey: 'superadmin.repositoryFailed',
+      });
 
 const uniqueConstraintName = (cause: unknown): string | null => {
   if (!isRecord(cause)) return null;
@@ -95,6 +194,8 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
       const repository = yield* SuperAdminRepository;
       const usersRepository = yield* UsersRepository;
       const betterAuth = yield* BetterAuth;
+      const db = yield* DrizzleDatabase;
+      const productImportService = yield* ProductImportService;
       const trace = makeServiceTracer({
         serviceName: 'SuperAdminService',
         module: 'superadmin',
@@ -157,6 +258,98 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
         ),
       );
 
+      const validateTenantImportFile = (file: TenantImportFile) =>
+        productImportService
+          .validateCsvContent({ content: file.content, requireRows: true })
+          .pipe(
+            Effect.mapError((error) =>
+              makeTenantImportInvalid(
+                file,
+                [{ row: 0, error: error.message }],
+                error,
+              ),
+            ),
+            Effect.flatMap((validated) =>
+              validated.result.errors.length > 0
+                ? Effect.fail(
+                    makeTenantImportInvalid(file, validated.result.errors),
+                  )
+                : Effect.succeed(validated),
+            ),
+          );
+
+      const createTenantWithImport = (
+        input: CreateTenantInput,
+        file: TenantImportFile,
+        actor: { readonly ipAddress?: string | null },
+      ) =>
+        Effect.gen(function* () {
+          const requestContext = yield* Effect.serviceOption(
+            CurrentRequestContext,
+          );
+
+          return yield* Effect.tryPromise({
+            try: () =>
+              db.transaction(async (tx) => {
+                const txDb = tx as unknown as DrizzleDb;
+                const txDbLayer = Layer.succeed(DrizzleDatabase, txDb);
+                const txRepositoryLayer = SuperAdminRepository.Default.pipe(
+                  Layer.provide(txDbLayer),
+                );
+
+                const txEffect = Effect.gen(function* () {
+                  const txRepository = yield* SuperAdminRepository;
+                  const created =
+                    yield* txRepository.createTenantWithAdminRecords(input);
+                  const importRequestContext = makeTenantImportRequestContext(
+                    requestContext,
+                    created,
+                    actor,
+                  );
+                  const txImportLayer = ProductImportService.Default.pipe(
+                    Layer.provide(txDbLayer),
+                  );
+                  const productImport = yield* Effect.flatMap(
+                    ProductImportService,
+                    (service) =>
+                      service.importFromCsvContent({
+                        content: file.content,
+                        importType: 'auto',
+                        userId: input.adminUserId,
+                      }),
+                  ).pipe(
+                    Effect.provide(txImportLayer),
+                    Effect.provideService(
+                      CurrentRequestContext,
+                      importRequestContext,
+                    ),
+                    Effect.mapError((error) =>
+                      makeTenantImportInvalid(
+                        file,
+                        [{ row: 0, error: error.message }],
+                        error,
+                      ),
+                    ),
+                  );
+
+                  if (productImport.errors.length > 0) {
+                    return yield* Effect.fail(
+                      makeTenantImportInvalid(file, productImport.errors),
+                    );
+                  }
+
+                  return {
+                    ...created,
+                    productImport,
+                  } satisfies CreatedTenantWithImportResult;
+                }).pipe(Effect.provide(txRepositoryLayer));
+
+                return runEffectAsPromise(txEffect);
+              }),
+            catch: mapTransactionCause,
+          });
+        });
+
       const createTenant = trace.traced(
         'createTenant',
         (
@@ -166,6 +359,7 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
             readonly ipAddress?: string | null;
             readonly userAgent?: string | null;
           },
+          options: CreateTenantOptions = {},
         ) =>
           Effect.gen(function* () {
             const slug = input.slug.trim().toLowerCase();
@@ -206,6 +400,10 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
               );
             }
 
+            if (options.importFile) {
+              yield* validateTenantImportFile(options.importFile);
+            }
+
             const normalizedEmail = input.admin.email.trim().toLowerCase();
             const adminName = input.admin.name.trim();
 
@@ -236,25 +434,54 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
               adminCreatedHere = true;
             }
 
-            const created = yield* repository
-              .createTenantWithAdmin({
-                name: input.name.trim(),
-                slug,
-                hostname,
-                adminUserId,
-              })
-              .pipe(
-                Effect.catchAll((error) =>
-                  Effect.fail(mapCreateTenantError(error, slug, hostname)),
-                ),
-                Effect.tapError(() =>
-                  adminCreatedHere
-                    ? usersRepository
-                        .deleteBetterAuthUser(adminUserId)
-                        .pipe(Effect.ignore)
-                    : Effect.void,
-                ),
-              );
+            const tenantInput = {
+              name: input.name.trim(),
+              slug,
+              hostname,
+              adminUserId,
+            } satisfies CreateTenantInput;
+
+            const createTenantRecords = (
+              options.importFile
+                ? createTenantWithImport(tenantInput, options.importFile, actor)
+                : repository
+                    .createTenantWithAdmin(tenantInput)
+                    .pipe(
+                      Effect.map(
+                        (created): CreatedTenantWithImportResult => created,
+                      ),
+                    )
+            ) as Effect.Effect<CreatedTenantWithImportResult, unknown, never>;
+
+            const created = yield* createTenantRecords.pipe(
+              Effect.mapError((error) =>
+                error instanceof SuperAdminRepositoryError
+                  ? mapCreateTenantError(error, slug, hostname)
+                  : error,
+              ),
+              Effect.tapError(() =>
+                adminCreatedHere
+                  ? usersRepository
+                      .deleteBetterAuthUser(adminUserId)
+                      .pipe(Effect.ignore)
+                  : Effect.void,
+              ),
+            );
+
+            const importSummary = created.productImport
+              ? {
+                  filename: options.importFile?.filename ?? null,
+                  categoriesCreated: created.productImport.categoriesCreated,
+                  locationsCreated: created.productImport.locationsCreated,
+                  productsCreated: created.productImport.productsCreated,
+                  productsUpdated: created.productImport.productsUpdated,
+                  inventoryRecordsCreated:
+                    created.productImport.inventoryRecordsCreated,
+                  inventoryRecordsUpdated:
+                    created.productImport.inventoryRecordsUpdated,
+                  rowsSkipped: created.productImport.rowsSkipped,
+                }
+              : undefined;
 
             if (adminCreatedHere) {
               yield* Effect.forkDaemon(
@@ -277,6 +504,7 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
                     slug: created.tenant.slug,
                     hostname: created.tenant.hostname,
                     adminUserId,
+                    ...(importSummary ? { productImport: importSummary } : {}),
                   },
                   ipAddress: actor.ipAddress ?? null,
                   userAgent: actor.userAgent ?? null,
@@ -291,6 +519,9 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
                 email: existing?.email ?? normalizedEmail,
                 name: existing?.name ?? adminName,
               },
+              ...(created.productImport
+                ? { productImport: created.productImport }
+                : {}),
             } satisfies SuperAdminCreateTenantResponse;
           }),
         (input) => ({ attributes: { entityId: input.slug } }),
@@ -302,6 +533,10 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
         createTenant,
       };
     }),
-    dependencies: [SuperAdminRepository.Default, UsersRepository.Default],
+    dependencies: [
+      SuperAdminRepository.Default,
+      UsersRepository.Default,
+      ProductImportService.Default,
+    ],
   },
 ) {}

--- a/src/effect/modules/superadmin/superadmin.errors.ts
+++ b/src/effect/modules/superadmin/superadmin.errors.ts
@@ -24,6 +24,21 @@ export class TenantHostnameAlreadyExists extends ConflictError(
   readonly hostname: string;
 }> {}
 
+export class SuperAdminTenantImportInvalid extends BadRequestError(
+  'SuperAdminTenantImportInvalid',
+)<{
+  readonly filename?: string;
+  readonly details: string;
+  readonly cause?: unknown;
+}> {}
+
+export class SuperAdminTenantImportReadFailed extends InternalError(
+  'SuperAdminTenantImportReadFailed',
+)<{
+  readonly filename?: string;
+  readonly cause?: unknown;
+}> {}
+
 export class SuperAdminRepositoryError extends InternalError(
   'SuperAdminRepositoryError',
 )<{

--- a/src/effect/platform/catalogs/de.ts
+++ b/src/effect/platform/catalogs/de.ts
@@ -160,6 +160,10 @@ export const deCatalog: Record<MessageKey, string> = {
     'Die Superadmin-Autorisierung ist fehlgeschlagen.',
   'superadmin.repositoryFailed': 'Der Superadmin-Vorgang ist fehlgeschlagen.',
   'superadmin.reservedTenantSlug': 'Der Tenant-Slug ist reserviert.',
+  'superadmin.tenantImportInvalid':
+    'Die ausgewaehlte Importdatei kann nicht importiert werden: {details}',
+  'superadmin.tenantImportReadFailed':
+    'Die ausgewaehlte Tenant-Importdatei konnte nicht gelesen werden.',
   'superadmin.tenantHostnameAlreadyExists':
     'Ein Tenant mit diesem Hostnamen existiert bereits.',
   'superadmin.tenantSlugAlreadyExists':

--- a/src/effect/platform/catalogs/en.ts
+++ b/src/effect/platform/catalogs/en.ts
@@ -111,8 +111,7 @@ export const enCatalog = {
   'products.importCsvParseFailed': 'Could not parse the uploaded CSV file.',
   'products.importReadUploadFailed':
     'Failed to read the uploaded product import file.',
-  'products.importUnsupportedFormat':
-    'Unsupported product import CSV headers.',
+  'products.importUnsupportedFormat': 'Unsupported product import CSV headers.',
   'products.infrastructureFailed': 'Product operation failed.',
   'products.notDeleted': 'Product is not deleted.',
   'products.notFound': 'Product not found.',
@@ -132,6 +131,10 @@ export const enCatalog = {
   'superadmin.infrastructureFailed': 'Superadmin authorization failed.',
   'superadmin.repositoryFailed': 'Superadmin operation failed.',
   'superadmin.reservedTenantSlug': 'Tenant slug is reserved.',
+  'superadmin.tenantImportInvalid':
+    'The selected import file cannot be imported: {details}',
+  'superadmin.tenantImportReadFailed':
+    'Failed to read the selected tenant import file.',
   'superadmin.tenantHostnameAlreadyExists':
     'A tenant with this hostname already exists.',
   'superadmin.tenantSlugAlreadyExists':

--- a/src/effect/platform/catalogs/fr.ts
+++ b/src/effect/platform/catalogs/fr.ts
@@ -17,8 +17,7 @@ export const frCatalog: Record<MessageKey, string> = {
   'auth.permissionDenied': 'Permissions insuffisantes.',
   'auth.unauthorized': 'Non autorise.',
   'email.sendFailed': "L'envoi de l'e-mail a echoue.",
-  'email.welcomeRequestFailed':
-    "La demande d'e-mail de bienvenue a echoue.",
+  'email.welcomeRequestFailed': "La demande d'e-mail de bienvenue a echoue.",
   'tenant.membershipRejected':
     "Le tenant actif n'est pas disponible pour cet utilisateur.",
   'tenant.notResolved':
@@ -151,6 +150,10 @@ export const frCatalog: Record<MessageKey, string> = {
   'superadmin.infrastructureFailed': "L'autorisation superadmin a echoue.",
   'superadmin.repositoryFailed': "L'operation superadmin a echoue.",
   'superadmin.reservedTenantSlug': 'Le slug tenant est reserve.',
+  'superadmin.tenantImportInvalid':
+    "Le fichier d'import selectionne ne peut pas etre importe : {details}",
+  'superadmin.tenantImportReadFailed':
+    "La lecture du fichier d'import tenant selectionne a echoue.",
   'superadmin.tenantHostnameAlreadyExists':
     'Un tenant avec cet hote existe deja.',
   'superadmin.tenantSlugAlreadyExists': 'Un tenant avec ce slug existe deja.',

--- a/src/effect/platform/http/errors.ts
+++ b/src/effect/platform/http/errors.ts
@@ -1,4 +1,4 @@
-import { HttpServerError, HttpServerResponse } from '@effect/platform';
+import { HttpServerError, HttpServerResponse, Multipart } from '@effect/platform';
 import { Effect, Cause, ParseResult } from 'effect';
 import { TreeFormatter } from 'effect/ParseResult';
 import { isAppError } from '../effect/domain-errors';
@@ -18,6 +18,7 @@ const STATUS_NAMES: Record<number, string> = {
   404: 'Not Found',
   405: 'Method Not Allowed',
   409: 'Conflict',
+  413: 'Payload Too Large',
   422: 'Unprocessable Entity',
   429: 'Too Many Requests',
   500: 'Internal Server Error',
@@ -91,6 +92,30 @@ const toErrorDetails = (
       error: getStatusName(400),
       messageKey: 'http.parseError',
       messageArgs: { details: TreeFormatter.formatErrorSync(error) },
+    };
+  }
+
+  if (error instanceof Multipart.MultipartError) {
+    if (error.reason === 'InternalError') {
+      return {
+        statusCode: 500,
+        error: getStatusName(500),
+        messageKey: 'http.serverError',
+      };
+    }
+
+    const statusCode =
+      error.reason === 'FileTooLarge' ||
+      error.reason === 'FieldTooLarge' ||
+      error.reason === 'BodyTooLarge'
+        ? 413
+        : 400;
+
+    return {
+      statusCode,
+      error: getStatusName(statusCode),
+      messageKey: 'http.requestError',
+      messageArgs: { details: `Invalid multipart request: ${error.reason}` },
     };
   }
 


### PR DESCRIPTION
## Summary

- Make superadmin tenant creation accept multipart fields plus optional `import_file`.
- Add strict product CSV validation before tenant/admin creation, then import products inside the tenant creation transaction.
- Add tenant-scoped synthetic request context, tenant-admin product attribution, import audit metadata, localized errors, and multipart parse error mapping.
- Add unit and integration coverage for valid imports, invalid imports, rollback, attribution, welcome email, audit metadata, and multipart-only rejection.

## Dependencies

- Depends on stocketfr/packages#19 for the `productImport` response type.

## Validation

- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/vitest run src/effect/modules/products/import/service.spec.ts src/effect/modules/superadmin/service.spec.ts`
- `node_modules/.bin/vitest run --config vitest.integration.config.ts src/effect/modules/superadmin/create-tenant-import.integration.spec.ts`

Claude audit reached `NITS_ONLY` after follow-up fixes.
