### PR TITLE
[codex] Improve Sortly product imports

### DIFF
--- a/plans/sortly-import-improvements.md
+++ b/plans/sortly-import-improvements.md
@@ -1,0 +1,367 @@
+# Sortly Import Improvements Plan
+
+## Why
+
+The current product CSV importer can ingest normalized product CSVs and Sortly item exports, but it still treats the import as a direct one-shot write. The next iteration should make larger Sortly migrations reviewable before they mutate tenant data, add supplier support, and model locations/inventory more accurately for shelf-level exports.
+
+## Current State
+
+- Maintained importer: `src/effect/modules/products/import/*`.
+- CLI entrypoint: `src/scripts/import-products.ts`, wrapped by `scripts/import.sh`.
+- API entrypoint: `POST /api/v1/products/import`.
+- Supported formats:
+  - `normalized-products`
+  - `sortly-items`
+  - `auto`
+- Current Sortly behavior:
+  - imports only `Entry Type = Item`;
+  - maps `SID` or `Sortly ID (SID)` to product SKU;
+  - maps `Primary Folder` through `Subfolder-level4` to category path;
+  - maps `Location` to a root location;
+  - maps `Quantity` to root inventory at `product_id + location_id`;
+  - maps `Price`, `Min Level`, `Unit`, barcode, notes, and expiry date;
+  - ignores folders, photos, suppliers, item groups, tags, and attributes.
+
+## Sortly CSV Findings
+
+Downloads inspected:
+
+- `/Users/max-vev/Downloads/B3C04AD5-1734-44C8-AFDC-6A7EAA036833.csv`
+- `/Users/max-vev/Downloads/87DD964F-DFCA-488A-858E-714FDE6E5066.csv`
+- `/Users/max-vev/Downloads/inventory_restructured_operational_v2.csv`
+
+Observed shape:
+
+- Columns are stable across these exports: `Entry Name`, `Entry Type`, `SID`, `Item Group Name`, attributes, `Quantity`, `Unit`, `Min Level`, `Price`, `Value`, `Notes`, `Tags`, folder path columns, `Photo1` through `Photo8`, barcode columns, `Location`, and `Expiry Date`.
+- `Item Group Name`, attributes, and `Tags` are empty in the inspected files.
+- Photos are widely populated, but the importer currently ignores them.
+- No explicit supplier/vendor column exists.
+- Supplier-like values appear mostly as brand/category names in folders or item names, so supplier creation should be proposed and reviewed, not inferred silently.
+
+Data quality notes:
+
+- `B3C04AD5...`: 1,074 item rows, 11 non-empty locations, 365 items missing location, 328 missing price, 29 duplicate `SID`s with conflicting product definitions.
+- `87DD...`: 976 item rows, 50 non-empty locations, 55 items missing location, all prices missing, 16 duplicate `SID`s with conflicting product definitions.
+- `inventory_restructured_operational_v2.csv`: better top-level operational category structure, 976 item rows, 50 non-empty locations, 55 missing locations, 16 conflicting duplicate `SID`s.
+
+## Main Product Decisions
+
+### Product Identity
+
+Current behavior uses Sortly `SID` as SKU. That is risky for the inspected exports because some rows reuse a `SID` for different product names.
+
+Proposed rule:
+
+- Keep `SID` as the preferred SKU when it is unique for a product definition.
+- In preview, flag conflicting duplicate SIDs as blocking issues.
+- Allow an explicit import option for conflict handling:
+  - `reject` default: safest; skips conflicting rows.
+  - `derive-sku`: creates a deterministic SKU such as `<SID>-<short-row-hash>` for conflicts.
+  - `name-suffix`: only if the user wants readable SKUs; more fragile.
+- Do not silently merge different item names under one product.
+
+### Categories
+
+Current folder-path mapping is reasonable. Keep it deterministic.
+
+Proposed additions:
+
+- Preview the category tree before import.
+- Report missing folders and rows defaulting to `Uncategorized`.
+- Support an optional mapping file or review payload that remaps folder paths to existing category ids.
+
+### Suppliers
+
+There is no direct supplier field in the Sortly CSVs. Supplier support should be added to normalized rows first, then AI or user mapping can populate those fields.
+
+Normalized row additions:
+
+- `supplier_name`
+- `supplier_sku`
+- `supplier_cost`
+
+Write behavior:
+
+- Find supplier by tenant + normalized name.
+- Create supplier only when the approved import plan says creation is allowed.
+- Set `products.primary_supplier_id`.
+- Set `products.supplier_sku`.
+- Optionally create/update `supplier_products` later if the app starts using that relationship in product workflows.
+
+Supplier inference should be preview-only:
+
+- candidate from first folder segment when it looks brand-like;
+- candidate from item-name prefix before a comma, when repeated across many rows;
+- candidate from notes only when strong patterns exist.
+
+### Locations And Areas
+
+Current behavior treats every Sortly `Location` as a root location. That is too flat for shelf/bin values like `Bay I - Shelf 3`.
+
+Proposed model:
+
+- Import actual physical places as `locations`.
+- Import shelf/bin/box substructure as `areas`.
+- Attach inventory to `location_id + area_id` where a mapping exists.
+
+MVP options:
+
+- Keep current flat root-location behavior for existing API compatibility.
+- Add optional normalized fields:
+  - `location`
+  - `area_path`
+- In Sortly preview, propose area splits for obvious patterns:
+  - `Bay I - Shelf 3` -> location `Main Store Room` or configured default, area `Bay I / Shelf 3`.
+  - `Store Room - Box 6` -> location `Store Room`, area `Box 6`.
+  - existing plain places like `Big garage` remain locations.
+
+The final import should not guess the warehouse name. If the CSV only has shelf-like values, require a default location or approved mapping.
+
+### Inventory
+
+Current root inventory import should remain supported.
+
+Additions:
+
+- Support `area_path` imports.
+- Reject root inventory writes when area-scoped inventory exists, preserving the existing safety check.
+- For area-scoped imports, get or create areas under the selected location.
+- Preview inventory writes as `create`, `update`, `skip`, or `conflict`.
+- Keep `quantity` as snapshot quantity for Sortly item exports, not a stock movement stream.
+
+### Photos
+
+Do not include photos in the first supplier/location/inventory MVP unless explicitly prioritized.
+
+Reason:
+
+- Sortly photo URLs may require external download and storage.
+- The app already has S3/MinIO product photo handling, but import needs idempotency, size/type checks, and failure isolation.
+
+Plan as a later slice:
+
+- preview rows with photos;
+- optionally download and store first photo as primary;
+- preserve source URL in photo metadata only if the schema supports it or a metadata extension is approved.
+
+## AI-Assisted Importer
+
+The AI should propose a mapping plan, not write directly.
+
+Inputs:
+
+- CSV headers.
+- Row count and sampled rows.
+- Column value distributions.
+- Duplicate/conflict report.
+- Existing categories, suppliers, locations, and areas for the tenant.
+- User preferences such as default location, whether to create suppliers, and conflict policy.
+
+Output schema should be deterministic and validated:
+
+```ts
+interface ImportPlanProposal {
+  format: 'sortly-items' | 'normalized-products' | 'unknown';
+  confidence: number;
+  productIdentity: {
+    sourceColumn: string;
+    conflictPolicy: 'reject' | 'derive-sku';
+  };
+  categoryMappings: Array<{
+    sourcePath: string;
+    targetCategoryId?: string;
+    targetPath?: string;
+    action: 'use-existing' | 'create' | 'default';
+  }>;
+  supplierMappings: Array<{
+    sourcePattern: string;
+    supplierName: string;
+    targetSupplierId?: string;
+    action: 'use-existing' | 'create' | 'ignore';
+    confidence: number;
+  }>;
+  locationMappings: Array<{
+    sourceLocation: string;
+    targetLocationId?: string;
+    targetLocationName?: string;
+    areaPath?: string;
+    action: 'use-existing' | 'create-location' | 'create-area' | 'ignore';
+    confidence: number;
+  }>;
+  warnings: Array<{
+    row?: number;
+    field?: string;
+    message: string;
+  }>;
+}
+```
+
+Guardrails:
+
+- Validate the AI response against an Effect schema before showing it.
+- Treat low-confidence supplier/location mappings as suggestions requiring explicit approval.
+- Never let AI-generated mappings bypass normal row validation.
+- Keep actual import execution in the existing deterministic `ProductImportService`.
+
+## Implementation Slices
+
+### Slice 1: Deterministic Preview
+
+Backend:
+
+- Add `ProductImportPreviewService` or extend the import service with `previewCsvContent`.
+- Reuse `parseCsvContent`, `detectProductImportFormat`, and row normalization.
+- Return detected format, row counts, proposed categories, locations, duplicate SKU conflicts, missing fields, and inventory actions.
+- Add CLI command:
+  - `pnpm import:sortly -- --preview <file>` or a separate script option, depending on current script ergonomics.
+- Add API endpoint:
+  - `POST /api/v1/products/import/preview`.
+
+Types:
+
+- Add `ProductImportPreviewDto`, `ProductImportWarningDto`, and mapping DTOs in `@stocket/types/products`.
+
+Tests:
+
+- Unit tests for preview summaries and duplicate SID conflicts.
+- Integration test that preview is tenant-scoped and does not write rows.
+
+### Slice 2: Supplier Columns In Normalized Import
+
+Backend:
+
+- Extend `NormalizedProductImportRow`.
+- Add supplier cache to import caches.
+- Add repository methods:
+  - `findSupplierByName`
+  - `createSupplier`
+- Extend product import values with `primary_supplier_id` and `supplier_sku`.
+- Keep supplier creation behind an option, defaulting to `false` for API import until preview/approval exists.
+
+Types:
+
+- Extend result DTO with `suppliersCreated` if the UI needs stats.
+
+Tests:
+
+- Import creates approved supplier and links product.
+- Import links to existing supplier by tenant + name.
+- Import does not leak supplier matches across tenants.
+
+### Slice 3: Area-Aware Inventory Import
+
+Backend:
+
+- Extend normalized row with `area_path`.
+- Add area cache.
+- Add repository methods:
+  - `findAreaByNameParentAndLocation`
+  - `createArea`
+  - `findInventoryByProductLocationAndArea`
+- Add validation for root-vs-area inventory conflicts.
+
+Tests:
+
+- Root inventory path remains unchanged.
+- Area inventory creates nested areas and attaches inventory to area.
+- Root import still fails if area-scoped inventory exists.
+- Area import does not overwrite root inventory unless explicitly configured.
+
+### Slice 4: Reviewable UI Flow
+
+Frontend:
+
+- Change import dialog from one-shot upload to:
+  - choose file;
+  - analyze;
+  - review issues and mappings;
+  - confirm import.
+- Show blocking issues separately from warnings.
+- Include explicit controls for duplicate SID policy, default location, supplier creation, and area handling.
+
+Tests:
+
+- Hook/unit coverage for preview and confirm calls.
+- Component test for blocking duplicate warning display if existing UI test infrastructure supports it.
+
+### Slice 5: AI Proposal Layer
+
+Backend:
+
+- Add an AI proposal service behind a feature flag/config check.
+- Keep model call optional; deterministic preview works without it.
+- Send only sampled rows and aggregate stats unless full-file upload is explicitly needed and acceptable.
+- Validate AI proposal schema.
+- Persist nothing until the user confirms.
+
+Frontend:
+
+- Add "Suggest mappings" action after deterministic preview.
+- Display AI suggestions as editable mappings, not hidden defaults.
+
+Tests:
+
+- Schema validation for accepted/rejected AI proposal payloads.
+- Service test with mocked AI client.
+- Import execution test proving unapproved suggestions do not write data.
+
+## API Shape Draft
+
+Preview:
+
+```http
+POST /api/v1/products/import/preview
+Content-Type: multipart/form-data
+
+file=<csv>
+import_type=auto|normalized-products|sortly-items
+```
+
+Confirm:
+
+```http
+POST /api/v1/products/import
+Content-Type: multipart/form-data
+
+file=<csv>
+import_type=sortly-items
+plan=<approved JSON mapping plan>
+```
+
+Alternative:
+
+- Store preview file server-side with an import session id.
+- Confirm by `import_session_id` plus approved plan.
+- This is better for large files, but it introduces lifecycle cleanup and storage concerns. Use direct re-upload for MVP unless file size becomes a real issue.
+
+## Acceptance Criteria
+
+- Raw Sortly exports can be previewed without writes.
+- Preview reports duplicate SID conflicts, missing categories/locations/prices, proposed category tree, proposed locations/areas, and supplier candidates.
+- Deterministic import can create/link suppliers from approved normalized supplier fields.
+- Deterministic import can create root inventory or area-scoped inventory based on approved mapping.
+- Existing normalized and Sortly import behavior remains backward-compatible.
+- AI suggestions are optional, validated, visible, editable, and never applied without confirmation.
+
+## Open Questions
+
+- Should conflicting duplicate Sortly SIDs be rejected forever, or should we support deterministic derived SKUs?
+- What is the default physical location for shelf-like Sortly values in the restructured file?
+- Should first folder segment be treated as category, supplier candidate, or both?
+- Is importing Sortly photos part of this migration, or should it stay separate?
+- Should supplier creation be available to all product import users, or require `SUPPLIERS:write` in addition to product/location/inventory permissions?
+- Do we want a durable import session model now, or is re-upload on confirm acceptable for the first UI?
+
+## Suggested First PR
+
+Build Slice 1 only:
+
+- backend preview service;
+- shared preview DTOs;
+- CLI preview mode;
+- API preview endpoint;
+- focused tests;
+- no AI dependency;
+- no write behavior changes.
+
+This gives us immediate visibility into real Sortly files and de-risks the supplier/location/area decisions before changing import writes.

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -4,8 +4,8 @@ set -eu
 usage() {
   cat <<'USAGE' >&2
 Usage:
-  sh ./scripts/import.sh sortly <sortly-export.csv>
-  sh ./scripts/import.sh products <normalized-products.csv>
+  sh ./scripts/import.sh sortly [--preview|--propose] <sortly-export.csv>
+  sh ./scripts/import.sh products [--preview|--propose] <normalized-products.csv>
 
 Import types:
   sortly    Import Sortly Item rows from a raw Sortly export; folder rows are ignored
@@ -23,21 +23,21 @@ shift
 
 case "$kind" in
   sortly)
-    if [ "$#" -ne 1 ]; then
+    if [ "$#" -lt 1 ]; then
       usage
       exit 1
     fi
 
-    infisical run --env=dev -- tsx src/scripts/import-products.ts --import-type sortly-items "$1"
+    infisical run --env=dev -- tsx src/scripts/import-products.ts --import-type sortly-items "$@"
     ;;
 
   products)
-    if [ "$#" -ne 1 ]; then
+    if [ "$#" -lt 1 ]; then
       usage
       exit 1
     fi
 
-    infisical run --env=dev -- tsx src/scripts/import-products.ts --import-type normalized-products "$1"
+    infisical run --env=dev -- tsx src/scripts/import-products.ts --import-type normalized-products "$@"
     ;;
 
   -h|--help|help)

--- a/src/effect/modules/products/import/repository.ts
+++ b/src/effect/modules/products/import/repository.ts
@@ -5,9 +5,11 @@ import { DrizzleDatabase } from '../../../platform/db/drizzle';
 import { TenantQuery } from '../../../platform/tenancy/tenant-query';
 import {
   categories,
+  areas,
   inventory,
   locations,
   products,
+  suppliers,
 } from '../../../platform/db/schema';
 import { ProductsInfrastructureError } from '../products.errors';
 
@@ -94,6 +96,62 @@ export class ProductImportRepository extends Effect.Service<ProductImportReposit
           });
         });
 
+      const findAreaByNameParentAndLocation = (
+        name: string,
+        parentId: string | null,
+        locationId: string,
+      ) =>
+        Effect.gen(function* () {
+          const conditions: SQL[] = [
+            eq(areas.name, name),
+            eq(areas.location_id, locationId),
+          ];
+          conditions.push(
+            parentId === null
+              ? isNull(areas.parent_id)
+              : eq(areas.parent_id, parentId),
+          );
+          const where = yield* tenantQuery.whereTenant(areas, ...conditions);
+          return yield* tryAsync('find import area', async () => {
+            const rows = await db.select().from(areas).where(where).limit(1);
+            return rows[0] ?? null;
+          });
+        });
+
+      const createArea = (data: typeof areas.$inferInsert) =>
+        Effect.gen(function* () {
+          const values = yield* tenantQuery.insertValues(data);
+          return yield* tryAsync('create import area', async () => {
+            const rows = await db.insert(areas).values(values).returning();
+            return rows[0]!;
+          });
+        });
+
+      const findSupplierByName = (name: string) =>
+        Effect.gen(function* () {
+          const where = yield* tenantQuery.whereTenant(
+            suppliers,
+            eq(suppliers.name, name),
+          );
+          return yield* tryAsync('find import supplier', async () => {
+            const rows = await db
+              .select()
+              .from(suppliers)
+              .where(where)
+              .limit(1);
+            return rows[0] ?? null;
+          });
+        });
+
+      const createSupplier = (data: typeof suppliers.$inferInsert) =>
+        Effect.gen(function* () {
+          const values = yield* tenantQuery.insertValues(data);
+          return yield* tryAsync('create import supplier', async () => {
+            const rows = await db.insert(suppliers).values(values).returning();
+            return rows[0]!;
+          });
+        });
+
       const findProductBySku = (sku: string) =>
         Effect.gen(function* () {
           const where = yield* tenantQuery.whereTenant(
@@ -101,11 +159,7 @@ export class ProductImportRepository extends Effect.Service<ProductImportReposit
             eq(products.sku, sku),
           );
           return yield* tryAsync('find import product by sku', async () => {
-            const rows = await db
-              .select()
-              .from(products)
-              .where(where)
-              .limit(1);
+            const rows = await db.select().from(products).where(where).limit(1);
             return rows[0] ?? null;
           });
         });
@@ -139,12 +193,20 @@ export class ProductImportRepository extends Effect.Service<ProductImportReposit
       const findRootInventoryByProductAndLocation = (
         productId: string,
         locationId: string,
+      ) => findInventoryByProductLocationArea(productId, locationId, null);
+
+      const findInventoryByProductLocationArea = (
+        productId: string,
+        locationId: string,
+        areaId: string | null,
       ) =>
         Effect.gen(function* () {
           const where = yield* tenantQuery.whereTenant(
             inventory,
             ...inventoryProductLocationConditions(productId, locationId),
-            isNull(inventory.area_id),
+            areaId === null
+              ? isNull(inventory.area_id)
+              : eq(inventory.area_id, areaId),
           );
           return yield* tryAsync('find import inventory', async () => {
             const rows = await db
@@ -207,10 +269,15 @@ export class ProductImportRepository extends Effect.Service<ProductImportReposit
         createCategory,
         findLocationByName,
         createLocation,
+        findAreaByNameParentAndLocation,
+        createArea,
+        findSupplierByName,
+        createSupplier,
         findProductBySku,
         createProduct,
         updateProduct,
         findRootInventoryByProductAndLocation,
+        findInventoryByProductLocationArea,
         hasAreaScopedInventoryForProductAndLocation,
         createInventory,
         updateInventory,

--- a/src/effect/modules/products/import/service.spec.ts
+++ b/src/effect/modules/products/import/service.spec.ts
@@ -28,20 +28,23 @@ function makeInMemoryRepository() {
   let nextId = 1;
   const categories: any[] = [];
   const locations: any[] = [];
+  const areas: any[] = [];
+  const suppliers: any[] = [];
   const productsBySku = new Map<string, any>();
   const inventoryByKey = new Map<string, any>();
 
   const id = (prefix: string) => `${prefix}-${nextId++}`;
 
   const repo = {
-    findCategoryByNameAndParent: vi.fn((name: string, parentId: string | null) =>
-      Effect.sync(
-        () =>
-          categories.find(
-            (category) =>
-              category.name === name && category.parent_id === parentId,
-          ) ?? null,
-      ),
+    findCategoryByNameAndParent: vi.fn(
+      (name: string, parentId: string | null) =>
+        Effect.sync(
+          () =>
+            categories.find(
+              (category) =>
+                category.name === name && category.parent_id === parentId,
+            ) ?? null,
+        ),
     ),
     createCategory: vi.fn((data: any) =>
       Effect.sync(() => {
@@ -59,6 +62,37 @@ function makeInMemoryRepository() {
       Effect.sync(() => {
         const row = makeRow({ id: id('loc'), ...data } as any);
         locations.push(row);
+        return row;
+      }),
+    ),
+    findAreaByNameParentAndLocation: vi.fn(
+      (name: string, parentId: string | null, locationId: string) =>
+        Effect.sync(
+          () =>
+            areas.find(
+              (area) =>
+                area.name === name &&
+                area.parent_id === parentId &&
+                area.location_id === locationId,
+            ) ?? null,
+        ),
+    ),
+    createArea: vi.fn((data: any) =>
+      Effect.sync(() => {
+        const row = makeRow({ id: id('area'), ...data } as any);
+        areas.push(row);
+        return row;
+      }),
+    ),
+    findSupplierByName: vi.fn((name: string) =>
+      Effect.sync(
+        () => suppliers.find((supplier) => supplier.name === name) ?? null,
+      ),
+    ),
+    createSupplier: vi.fn((data: any) =>
+      Effect.sync(() => {
+        const row = makeRow({ id: id('supplier'), ...data } as any);
+        suppliers.push(row);
         return row;
       }),
     ),
@@ -91,7 +125,16 @@ function makeInMemoryRepository() {
     findRootInventoryByProductAndLocation: vi.fn(
       (productId: string, locationId: string) =>
         Effect.sync(
-          () => inventoryByKey.get(`${productId}:${locationId}`) ?? null,
+          () => inventoryByKey.get(`${productId}:${locationId}:root`) ?? null,
+        ),
+    ),
+    findInventoryByProductLocationArea: vi.fn(
+      (productId: string, locationId: string, areaId: string | null) =>
+        Effect.sync(
+          () =>
+            inventoryByKey.get(
+              `${productId}:${locationId}:${areaId ?? 'root'}`,
+            ) ?? null,
         ),
     ),
     hasAreaScopedInventoryForProductAndLocation: vi.fn(() =>
@@ -100,7 +143,10 @@ function makeInMemoryRepository() {
     createInventory: vi.fn((data: any) =>
       Effect.sync(() => {
         const row = makeRow({ id: id('inv'), ...data } as any);
-        inventoryByKey.set(`${row.product_id}:${row.location_id}`, row);
+        inventoryByKey.set(
+          `${row.product_id}:${row.location_id}:${row.area_id ?? 'root'}`,
+          row,
+        );
         return row;
       }),
     ),
@@ -122,6 +168,8 @@ function makeInMemoryRepository() {
     repo: repo as Partial<ProductImportRepository>,
     categories,
     locations,
+    areas,
+    suppliers,
     productsBySku,
     inventoryByKey,
   };
@@ -163,10 +211,13 @@ const seedExistingProductWithRootInventory = (
       name: 'Same Product',
       category_id: 'cat-1',
       description: null,
+      standard_cost: null,
       unit: null,
       barcode: null,
       standard_price: null,
       reorder_point: 0,
+      primary_supplier_id: null,
+      supplier_sku: null,
       is_active: true,
       is_perishable: false,
       notes: null,
@@ -174,7 +225,7 @@ const seedExistingProductWithRootInventory = (
     } as any),
   );
   state.inventoryByKey.set(
-    'prod-1:loc-1',
+    'prod-1:loc-1:root',
     makeRow({
       id: 'inv-1',
       product_id: 'prod-1',
@@ -189,8 +240,9 @@ const seedExistingProductWithRootInventory = (
   );
 
   if (options.hasAreaScopedInventory) {
-    (state.repo.hasAreaScopedInventoryForProductAndLocation as any)
-      .mockReturnValue(Effect.succeed(true));
+    (
+      state.repo.hasAreaScopedInventoryForProductAndLocation as any
+    ).mockReturnValue(Effect.succeed(true));
   }
 };
 
@@ -204,12 +256,46 @@ const runImport = (
   );
   return Effect.runPromise(
     Effect.flatMap(ProductImportService, (service) =>
-      service.importFromCsvContent({ content, importType, userId: TEST_USER_ID }),
+      service.importFromCsvContent({
+        content,
+        importType,
+        userId: TEST_USER_ID,
+      }),
     ).pipe(Effect.provide(layer)),
   );
 };
 
 const runImportWithState = async (
+  content: string,
+  importType: 'auto' | 'normalized-products' | 'sortly-items' = 'auto',
+  setup?: (state: ReturnType<typeof makeInMemoryRepository>) => void,
+  options: {
+    readonly approvedPlan?: Parameters<
+      ProductImportService['importFromCsvContent']
+    >[0]['approvedPlan'];
+    readonly allowCreateSuppliers?: boolean;
+  } = {},
+) => {
+  const state = makeInMemoryRepository();
+  setup?.(state);
+  const layer = ProductImportService.DefaultWithoutDependencies.pipe(
+    Layer.provide(makeTestLayer(ProductImportRepository)(state.repo)),
+  );
+  const result = await Effect.runPromise(
+    Effect.flatMap(ProductImportService, (service) =>
+      service.importFromCsvContent({
+        content,
+        importType,
+        userId: TEST_USER_ID,
+        approvedPlan: options.approvedPlan,
+        allowCreateSuppliers: options.allowCreateSuppliers,
+      }),
+    ).pipe(Effect.provide(layer)),
+  );
+  return { result, state };
+};
+
+const runPreviewWithState = async (
   content: string,
   importType: 'auto' | 'normalized-products' | 'sortly-items' = 'auto',
   setup?: (state: ReturnType<typeof makeInMemoryRepository>) => void,
@@ -221,7 +307,7 @@ const runImportWithState = async (
   );
   const result = await Effect.runPromise(
     Effect.flatMap(ProductImportService, (service) =>
-      service.importFromCsvContent({ content, importType, userId: TEST_USER_ID }),
+      service.previewCsvContent({ content, importType }),
     ).pipe(Effect.provide(layer)),
   );
   return { result, state };
@@ -238,7 +324,11 @@ const failImport = (
   return Effect.runPromise(
     Effect.flip(
       Effect.flatMap(ProductImportService, (service) =>
-        service.importFromCsvContent({ content, importType, userId: TEST_USER_ID }),
+        service.importFromCsvContent({
+          content,
+          importType,
+          userId: TEST_USER_ID,
+        }),
       ).pipe(Effect.provide(layer)),
     ),
   );
@@ -390,7 +480,8 @@ SKU-1,Second Name,Food,Bar
   });
 
   it('allows consistent duplicate SKUs for multiple locations', async () => {
-    const { result, state } = await runImportWithState(`sku,name,category_path,location,quantity,reorder_point
+    const { result, state } =
+      await runImportWithState(`sku,name,category_path,location,quantity,reorder_point
 SKU-1,Same Product,Food,Warehouse,5,1
 SKU-1,Same Product,Food,Bar,7,1
 `);
@@ -404,7 +495,8 @@ SKU-1,Same Product,Food,Bar,7,1
   });
 
   it('reports normalized duplicate SKUs with conflicting reorder points', async () => {
-    const result = await runImport(`sku,name,category_path,location,quantity,reorder_point
+    const result =
+      await runImport(`sku,name,category_path,location,quantity,reorder_point
 SKU-1,Same Product,Food,Warehouse,5,1
 SKU-1,Same Product,Food,Bar,7,2
 `);
@@ -440,6 +532,284 @@ Item,Same Product,SORT-1,Food,7,Bar,5
     expect(result.errors).toEqual([]);
   });
 
+  it('previews Sortly imports without creating rows', async () => {
+    const { result, state } = await runPreviewWithState(
+      `Entry Type,Entry Name,SID,Primary Folder,Quantity,Location,Price
+Folder,Spa,FOLDER-1,,,,
+Item,Aesop Soap,SORT-1,Aesop,5,Bay I - Shelf 3,
+Item,Aesop Soap Copy,SORT-1,Aesop,2,Bay I - Shelf 3,
+`,
+      'sortly-items',
+    );
+
+    expect(result).toMatchObject({
+      format: 'sortly-items',
+      totalRows: 3,
+      itemRows: 2,
+      folderRows: 1,
+      importableRows: 2,
+    });
+    expect(result.duplicateSkuConflicts).toHaveLength(1);
+    expect(result.locationMappings[0]).toMatchObject({
+      sourceLocation: 'Bay I - Shelf 3',
+      areaPath: 'Bay I / Shelf 3',
+      action: 'create-area',
+    });
+    expect(result.supplierMappings[0]).toMatchObject({
+      supplierName: 'Aesop',
+      action: 'create',
+    });
+    expect(state.categories).toHaveLength(0);
+    expect(state.locations).toHaveLength(0);
+    expect(state.productsBySku.size).toBe(0);
+  });
+
+  it('previews existing area-scoped inventory as an update', async () => {
+    const { result } = await runPreviewWithState(
+      `sku,name,category_path,location,area_path,quantity
+SKU-1,Same Product,Food,Warehouse,Bay I / Shelf 3,8
+`,
+      'normalized-products',
+      (state) => {
+        state.categories.push(
+          makeRow({
+            id: 'cat-1',
+            name: 'Food',
+            parent_id: null,
+            description: null,
+          } as any),
+        );
+        state.locations.push(
+          makeRow({
+            id: 'loc-1',
+            name: 'Warehouse',
+            type: 'WAREHOUSE',
+            address: '',
+            contact_person: '',
+            phone: '',
+            is_active: true,
+          } as any),
+        );
+        state.areas.push(
+          makeRow({
+            id: 'area-1',
+            location_id: 'loc-1',
+            parent_id: null,
+            name: 'Bay I',
+            code: '',
+            description: null,
+            is_active: true,
+          } as any),
+          makeRow({
+            id: 'area-2',
+            location_id: 'loc-1',
+            parent_id: 'area-1',
+            name: 'Shelf 3',
+            code: '',
+            description: null,
+            is_active: true,
+          } as any),
+        );
+        state.productsBySku.set(
+          'SKU-1',
+          makeRow({
+            id: 'prod-1',
+            sku: 'SKU-1',
+            name: 'Same Product',
+            category_id: 'cat-1',
+            description: null,
+            standard_cost: null,
+            unit: null,
+            barcode: null,
+            standard_price: null,
+            reorder_point: 0,
+            primary_supplier_id: null,
+            supplier_sku: null,
+            is_active: true,
+            is_perishable: false,
+            notes: null,
+            deleted_at: null,
+          } as any),
+        );
+        state.inventoryByKey.set(
+          'prod-1:loc-1:area-2',
+          makeRow({
+            id: 'inv-1',
+            product_id: 'prod-1',
+            location_id: 'loc-1',
+            area_id: 'area-2',
+            quantity: 4,
+            batch_number: '',
+            expiry_date: null,
+            cost_per_unit: null,
+            received_date: null,
+          } as any),
+        );
+      },
+    );
+
+    expect(result.inventoryPreviews[0]).toMatchObject({
+      row: 2,
+      sku: 'SKU-1',
+      location: 'Warehouse',
+      areaPath: 'Bay I / Shelf 3',
+      quantity: 8,
+      action: 'update',
+    });
+  });
+
+  it('creates approved suppliers and links imported products', async () => {
+    const { result, state } = await runImportWithState(
+      `sku,name,category_path,location,quantity,supplier_name,supplier_sku,supplier_cost
+SKU-1,Soap,Amenities,Warehouse,5,Aesop,AES-1,1.25
+`,
+      'normalized-products',
+      undefined,
+      { allowCreateSuppliers: true },
+    );
+
+    expect(result.suppliersCreated).toBe(1);
+    expect(result.productsCreated).toBe(1);
+    const product = state.productsBySku.get('SKU-1');
+    expect(product).toMatchObject({
+      primary_supplier_id: state.suppliers[0].id,
+      supplier_sku: 'AES-1',
+      standard_cost: 1.25,
+    });
+  });
+
+  it('creates approved Sortly suppliers from category-root mappings', async () => {
+    const { result, state } = await runImportWithState(
+      `Entry Type,Entry Name,SID,Primary Folder,Quantity,Location
+Item,Aesop Soap,SORT-1,Aesop,5,Warehouse
+`,
+      'sortly-items',
+      undefined,
+      {
+        allowCreateSuppliers: true,
+        approvedPlan: {
+          allowCreateSuppliers: true,
+          supplierMappings: [
+            {
+              sourcePattern: 'Aesop',
+              supplierName: 'Aesop',
+              action: 'create',
+              confidence: 0.55,
+              rowCount: 1,
+            },
+          ],
+        },
+      },
+    );
+
+    expect(result.suppliersCreated).toBe(1);
+    const product = state.productsBySku.get('SORT-1');
+    expect(product).toMatchObject({
+      primary_supplier_id: state.suppliers[0].id,
+    });
+  });
+
+  it('does not create suppliers for ignored approved supplier mappings', async () => {
+    const { result, state } = await runImportWithState(
+      `sku,name,category_path,location,quantity,supplier_name
+SKU-1,Soap,Amenities,Warehouse,5,Aesop
+`,
+      'normalized-products',
+      undefined,
+      {
+        allowCreateSuppliers: true,
+        approvedPlan: {
+          allowCreateSuppliers: true,
+          supplierMappings: [
+            {
+              sourcePattern: 'Aesop',
+              supplierName: 'Aesop',
+              action: 'ignore',
+              confidence: 1,
+              rowCount: 1,
+            },
+          ],
+        },
+      },
+    );
+
+    expect(result.suppliersCreated).toBe(0);
+    expect(state.suppliers).toHaveLength(0);
+    expect(state.productsBySku.get('SKU-1')).toMatchObject({
+      primary_supplier_id: null,
+    });
+  });
+
+  it('preserves existing supplier fields when import rows do not provide supplier values', async () => {
+    const { result, state } = await runImportWithState(
+      `sku,name,category_path,location,quantity
+SKU-1,Same Product,Food,Warehouse,8
+`,
+      'normalized-products',
+      (state) => {
+        seedExistingProductWithRootInventory(state);
+        state.suppliers.push(
+          makeRow({
+            id: 'supplier-1',
+            name: 'Existing Supplier',
+            notes: null,
+            is_active: true,
+          } as any),
+        );
+        state.productsBySku.set('SKU-1', {
+          ...state.productsBySku.get('SKU-1'),
+          primary_supplier_id: 'supplier-1',
+          supplier_sku: 'EXISTING-SKU',
+          standard_cost: 3.5,
+        });
+      },
+    );
+
+    expect(result.productsUpdated).toBe(0);
+    expect(result.inventoryRecordsUpdated).toBe(1);
+    expect(state.productsBySku.get('SKU-1')).toMatchObject({
+      primary_supplier_id: 'supplier-1',
+      supplier_sku: 'EXISTING-SKU',
+      standard_cost: 3.5,
+    });
+  });
+
+  it('imports area-scoped inventory when an approved area path is present', async () => {
+    const { result, state } = await runImportWithState(
+      `sku,name,category_path,location,area_path,quantity
+SKU-1,Soap,Amenities,Main Store,Bay I / Shelf 3,5
+`,
+      'normalized-products',
+    );
+
+    expect(result.areasCreated).toBe(2);
+    expect(result.inventoryRecordsCreated).toBe(1);
+    const product = state.productsBySku.get('SKU-1');
+    const location = state.locations.find((row) => row.name === 'Main Store');
+    const shelf = state.areas.find((row) => row.name === 'Shelf 3');
+    expect(
+      state.inventoryByKey.get(`${product.id}:${location.id}:${shelf.id}`),
+    ).toMatchObject({ quantity: 5 });
+  });
+
+  it('can derive SKUs for approved conflicting Sortly IDs', async () => {
+    const { result, state } = await runImportWithState(
+      `Entry Type,Entry Name,SID,Primary Folder,Quantity,Location
+Item,Black Glove,SORT-1,Amenities,5,Warehouse
+Item,White Glove,SORT-1,Amenities,7,Warehouse
+`,
+      'sortly-items',
+      undefined,
+      { approvedPlan: { skuConflictPolicy: 'derive-sku' } },
+    );
+
+    expect(result.rowsSkipped).toBe(0);
+    expect(result.productsCreated).toBe(2);
+    expect([...state.productsBySku.keys()]).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^SORT-1-/)]),
+    );
+  });
+
   it('clears stale inventory expiry dates when an update row has an empty expiry date', async () => {
     const existingExpiry = new Date('2026-01-01T00:00:00.000Z');
     const { result, state } = await runImportWithState(
@@ -454,7 +824,7 @@ SKU-1,Same Product,Food,Warehouse,8
     );
 
     expect(result.inventoryRecordsUpdated).toBe(1);
-    expect(state.inventoryByKey.get('prod-1:loc-1')).toMatchObject({
+    expect(state.inventoryByKey.get('prod-1:loc-1:root')).toMatchObject({
       quantity: 8,
       expiry_date: null,
     });
@@ -510,7 +880,7 @@ SKU-1,Changed Product,Drinks,Warehouse,8
       name: 'Same Product',
       category_id: 'cat-1',
     });
-    expect(state.inventoryByKey.get('prod-1:loc-1')).toMatchObject({
+    expect(state.inventoryByKey.get('prod-1:loc-1:root')).toMatchObject({
       quantity: 4,
     });
   });

--- a/src/effect/modules/products/import/service.ts
+++ b/src/effect/modules/products/import/service.ts
@@ -1,18 +1,27 @@
-import { Effect } from 'effect';
+import { Effect, Schema } from 'effect';
 import { LocationType } from '@stocket/types/locations';
+import type { TenantNotResolved } from '../../../platform/tenancy/tenant-context';
 import type {
+  DuplicateSkuConflict,
   ImportCaches,
+  ImportAreaRow,
   ImportCategoryRow,
   ImportLocationRow,
   ImportProductRow,
   ImportProductsFromCsvOptions,
+  ImportSupplierRow,
   NormalizedProductImportRow,
+  PreviewProductRowsOptions,
+  ProductImportAiProposalDto,
+  ProductImportApprovedPlanDto,
+  ProductImportPreviewDto,
   ProductImportResultDto,
   ProductImportValues,
+  ProposeProductImportPlanOptions,
 } from './types';
 import {
+  collectDuplicateSkuConflicts,
   detectProductImportFormat,
-  findConflictingDuplicateSkuRows,
   formatImportError,
   makeEmptyProductImportResult,
   normalizeCategoryPath,
@@ -32,6 +41,264 @@ import {
   ProductsInfrastructureError,
 } from '../products.errors';
 import { ProductImportRepository } from './repository';
+
+const normalizeImportName = (value: string): string => value.trim();
+
+type PreviewWarning = ProductImportPreviewDto['warnings'][number];
+type PreviewCategoryMapping =
+  ProductImportPreviewDto['categoryMappings'][number];
+type PreviewLocationMapping =
+  ProductImportPreviewDto['locationMappings'][number];
+type PreviewSupplierMapping =
+  ProductImportPreviewDto['supplierMappings'][number];
+type PreviewInventory = ProductImportPreviewDto['inventoryPreviews'][number];
+type PreviewDuplicateSkuConflict =
+  ProductImportPreviewDto['duplicateSkuConflicts'][number];
+type ApprovedSupplierMapping = NonNullable<
+  ProductImportApprovedPlanDto['supplierMappings']
+>[number];
+
+type DecodedProductImportAiProposal = {
+  readonly format: ProductImportAiProposalDto['format'];
+  readonly confidence: number;
+  readonly productIdentity: {
+    readonly sourceColumn: string;
+    readonly conflictPolicy: ProductImportAiProposalDto['productIdentity']['conflictPolicy'];
+  };
+  readonly categoryMappings: ReadonlyArray<PreviewCategoryMapping>;
+  readonly supplierMappings: ReadonlyArray<PreviewSupplierMapping>;
+  readonly locationMappings: ReadonlyArray<PreviewLocationMapping>;
+  readonly warnings: ReadonlyArray<PreviewWarning>;
+};
+
+const ImportWarningSchema = Schema.Struct({
+  row: Schema.optional(Schema.Number),
+  field: Schema.optional(Schema.String),
+  severity: Schema.Literal('error', 'warning'),
+  message: Schema.String,
+});
+
+const CategoryMappingSchema = Schema.Struct({
+  sourcePath: Schema.String,
+  targetCategoryId: Schema.optional(Schema.String),
+  targetPath: Schema.String,
+  action: Schema.Literal('use-existing', 'create', 'default'),
+  rowCount: Schema.Number,
+});
+
+const SupplierMappingSchema = Schema.Struct({
+  sourcePattern: Schema.String,
+  supplierName: Schema.String,
+  targetSupplierId: Schema.optional(Schema.String),
+  action: Schema.Literal('use-existing', 'create', 'ignore'),
+  confidence: Schema.Number,
+  rowCount: Schema.Number,
+});
+
+const LocationMappingSchema = Schema.Struct({
+  sourceLocation: Schema.String,
+  targetLocationId: Schema.optional(Schema.String),
+  targetLocationName: Schema.optional(Schema.String),
+  areaPath: Schema.optional(Schema.String),
+  action: Schema.Literal(
+    'use-existing',
+    'create-location',
+    'create-area',
+    'ignore',
+  ),
+  confidence: Schema.Number,
+  rowCount: Schema.Number,
+});
+
+const ProductImportAiProposalSchema = Schema.Struct({
+  format: Schema.Literal('sortly-items', 'normalized-products', 'unknown'),
+  confidence: Schema.Number,
+  productIdentity: Schema.Struct({
+    sourceColumn: Schema.String,
+    conflictPolicy: Schema.Literal('reject', 'derive-sku'),
+  }),
+  categoryMappings: Schema.Array(CategoryMappingSchema),
+  supplierMappings: Schema.Array(SupplierMappingSchema),
+  locationMappings: Schema.Array(LocationMappingSchema),
+  warnings: Schema.Array(ImportWarningSchema),
+});
+
+const deriveSkuForConflict = (row: NormalizedProductImportRow): string => {
+  const hashInput = `${row.sku}:${row.name}:${row.category_path}:${row.sourceRow}`;
+  let hash = 0;
+  for (let i = 0; i < hashInput.length; i++) {
+    hash = (hash * 31 + hashInput.charCodeAt(i)) >>> 0;
+  }
+  return `${row.sku}-${hash.toString(36).slice(0, 6)}`;
+};
+
+const isGenericSupplierCandidate = (value: string): boolean => {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return true;
+  if (/^\d+\s/.test(normalized)) return true;
+  return [
+    'accessories',
+    'amenities, miscellaneous',
+    'equipment',
+    'minis',
+    'spa',
+    'table accessories',
+  ].includes(normalized);
+};
+
+const inferAreaPathFromLocation = (
+  locationName: string,
+): {
+  readonly locationName?: string;
+  readonly areaPath?: string;
+  readonly confidence: number;
+} => {
+  const name = locationName.trim();
+  const bayShelfMatch = name.match(/^(Bay\s+[A-Z])\s*-\s*(Shelf\s+\d+)$/i);
+  if (bayShelfMatch?.[1] && bayShelfMatch[2]) {
+    return {
+      areaPath: `${bayShelfMatch[1].trim()} / ${bayShelfMatch[2].trim()}`,
+      confidence: 0.75,
+    };
+  }
+
+  const storeRoomBoxMatch = name.match(/^(Store Room)\s*-\s*(Box\s+\d+)$/i);
+  if (storeRoomBoxMatch?.[1] && storeRoomBoxMatch[2]) {
+    return {
+      locationName: storeRoomBoxMatch[1].trim(),
+      areaPath: storeRoomBoxMatch[2].trim(),
+      confidence: 0.9,
+    };
+  }
+
+  return { confidence: 0.6 };
+};
+
+const findApprovedLocationMapping = (
+  plan: ProductImportApprovedPlanDto | undefined,
+  sourceLocation: string,
+) =>
+  plan?.locationMappings?.find(
+    (mapping) => mapping.sourceLocation.trim() === sourceLocation.trim(),
+  );
+
+const resolveLocationName = (
+  row: NormalizedProductImportRow,
+  plan: ProductImportApprovedPlanDto | undefined,
+): string => {
+  const sourceLocation = row.location.trim();
+  const mapping = sourceLocation
+    ? findApprovedLocationMapping(plan, sourceLocation)
+    : undefined;
+  if (mapping?.action === 'ignore') return '';
+  if (mapping?.targetLocationName) return mapping.targetLocationName;
+  if (sourceLocation) return sourceLocation;
+  return plan?.defaultLocationName?.trim() ?? '';
+};
+
+const resolveAreaPath = (
+  row: NormalizedProductImportRow,
+  plan: ProductImportApprovedPlanDto | undefined,
+): string => {
+  const explicit = row.area_path.trim();
+  if (explicit) return explicit;
+  const mapping = row.location.trim()
+    ? findApprovedLocationMapping(plan, row.location)
+    : undefined;
+  return mapping?.areaPath?.trim() ?? '';
+};
+
+const supplierMappingCandidates = (
+  row: NormalizedProductImportRow,
+): readonly string[] => {
+  const explicitSupplier = normalizeImportName(row.supplier_name);
+  if (explicitSupplier) {
+    return [explicitSupplier.toLowerCase()];
+  }
+
+  const firstCategoryPart = normalizeCategoryPath(row.category_path)
+    .split('/')[0]
+    ?.trim();
+
+  return [firstCategoryPart]
+    .filter((candidate): candidate is string => Boolean(candidate))
+    .map((candidate) => candidate.toLowerCase());
+};
+
+const findApprovedSupplierMapping = (
+  plan: ProductImportApprovedPlanDto | undefined,
+  row: NormalizedProductImportRow,
+): ApprovedSupplierMapping | undefined => {
+  const candidates = supplierMappingCandidates(row);
+  if (candidates.length === 0) return undefined;
+
+  return plan?.supplierMappings?.find((mapping) => {
+    const sourcePattern = mapping.sourcePattern.trim().toLowerCase();
+    const supplierName = mapping.supplierName.trim().toLowerCase();
+    return (
+      candidates.includes(sourcePattern) || candidates.includes(supplierName)
+    );
+  });
+};
+
+const resolveSupplierName = (
+  row: NormalizedProductImportRow,
+  mapping: ApprovedSupplierMapping | undefined,
+): string => {
+  if (mapping?.action === 'ignore') return '';
+
+  const explicitSupplier = normalizeImportName(row.supplier_name);
+  if (explicitSupplier) return explicitSupplier;
+
+  return mapping?.supplierName.trim() ?? '';
+};
+
+const makeDeterministicProposal = (
+  preview: ProductImportPreviewDto,
+): ProductImportAiProposalDto => ({
+  format: preview.format,
+  confidence: 0.5,
+  productIdentity: {
+    sourceColumn: preview.format === 'sortly-items' ? 'SID' : 'sku',
+    conflictPolicy: 'reject',
+  },
+  categoryMappings: preview.categoryMappings,
+  supplierMappings: preview.supplierMappings.map((mapping) => ({
+    ...mapping,
+    action: mapping.confidence >= 0.9 ? mapping.action : 'ignore',
+  })),
+  locationMappings: preview.locationMappings,
+  warnings: preview.warnings,
+});
+
+const toPreviewDuplicateSkuConflict = (
+  conflict: DuplicateSkuConflict,
+): PreviewDuplicateSkuConflict => ({
+  sku: conflict.sku,
+  rows: [...conflict.rows],
+  names: [...conflict.names],
+});
+
+const toProductImportAiProposalDto = (
+  proposal: DecodedProductImportAiProposal,
+): ProductImportAiProposalDto => ({
+  format: proposal.format,
+  confidence: proposal.confidence,
+  productIdentity: {
+    sourceColumn: proposal.productIdentity.sourceColumn,
+    conflictPolicy: proposal.productIdentity.conflictPolicy,
+  },
+  categoryMappings: proposal.categoryMappings.map((mapping) => ({
+    ...mapping,
+  })),
+  supplierMappings: proposal.supplierMappings.map((mapping) => ({
+    ...mapping,
+  })),
+  locationMappings: proposal.locationMappings.map((mapping) => ({
+    ...mapping,
+  })),
+  warnings: proposal.warnings.map((warning) => ({ ...warning })),
+});
 
 export class ProductImportService extends Effect.Service<ProductImportService>()(
   '@stocket/effect/products/ProductImportService',
@@ -122,9 +389,127 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
           return location.id;
         });
 
+      const getOrCreateAreaPath = (
+        locationId: string,
+        areaPath: string,
+        caches: ImportCaches,
+        result: ProductImportResultDto,
+      ) =>
+        Effect.gen(function* () {
+          if (areaPath.trim() === '') return null;
+          const parts = normalizeCategoryPath(areaPath)
+            .split('/')
+            .map((part) => part.trim())
+            .filter(Boolean);
+          if (parts.length === 0) return null;
+
+          let parentId: string | null = null;
+          let areaId = '';
+
+          for (const part of parts) {
+            const cacheKey = `${locationId}:${parentId ?? 'root'}:${part}`;
+            const cached = caches.areas.get(cacheKey);
+            if (cached) {
+              parentId = cached;
+              areaId = cached;
+              continue;
+            }
+
+            let area: ImportAreaRow | null =
+              yield* repository.findAreaByNameParentAndLocation(
+                part,
+                parentId,
+                locationId,
+              );
+
+            if (!area) {
+              area = yield* repository.createArea({
+                location_id: locationId,
+                parent_id: parentId,
+                name: part,
+                code: '',
+                description: 'Imported via product import',
+                is_active: true,
+              });
+              result.areasCreated = (result.areasCreated ?? 0) + 1;
+            }
+
+            caches.areas.set(cacheKey, area.id);
+            parentId = area.id;
+            areaId = area.id;
+          }
+
+          return areaId;
+        });
+
+      const findExistingAreaPath = (locationId: string, areaPath: string) =>
+        Effect.gen(function* () {
+          if (areaPath.trim() === '') return null;
+          const parts = normalizeCategoryPath(areaPath)
+            .split('/')
+            .map((part) => part.trim())
+            .filter(Boolean);
+          if (parts.length === 0) return null;
+
+          let parentId: string | null = null;
+          let areaId: string | null = null;
+
+          for (const part of parts) {
+            const area: ImportAreaRow | null =
+              yield* repository.findAreaByNameParentAndLocation(
+                part,
+                parentId,
+                locationId,
+              );
+            if (!area) return null;
+            parentId = area.id;
+            areaId = area.id;
+          }
+
+          return areaId;
+        });
+
+      const getOrCreateSupplier = (
+        row: NormalizedProductImportRow,
+        caches: ImportCaches,
+        result: ProductImportResultDto,
+        approvedPlan: ProductImportApprovedPlanDto | undefined,
+        allowCreateSuppliers: boolean,
+      ) =>
+        Effect.gen(function* () {
+          const mapping = findApprovedSupplierMapping(approvedPlan, row);
+          const name = resolveSupplierName(row, mapping);
+          if (name === '') return null;
+
+          if (caches.suppliers.has(name)) {
+            return caches.suppliers.get(name) ?? null;
+          }
+
+          let supplier: ImportSupplierRow | null =
+            yield* repository.findSupplierByName(name);
+
+          const canCreate =
+            allowCreateSuppliers &&
+            (mapping?.action === 'create' ||
+              (mapping === undefined && row.supplier_name.trim() !== ''));
+
+          if (!supplier && canCreate) {
+            supplier = yield* repository.createSupplier({
+              name,
+              notes: 'Imported via product import',
+              is_active: true,
+            });
+            result.suppliersCreated = (result.suppliersCreated ?? 0) + 1;
+          }
+
+          caches.suppliers.set(name, supplier?.id ?? null);
+          return supplier?.id ?? null;
+        });
+
       const upsertProduct = (
         row: NormalizedProductImportRow,
         categoryId: string,
+        supplierId: string | null,
         caches: ImportCaches,
         result: ProductImportResultDto,
         expiryDate: Date | null,
@@ -135,23 +520,34 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
           const cached = caches.products.get(row.sku);
           if (cached) return cached;
 
+          const existing = yield* repository.findProductBySku(row.sku);
+          const standardCost =
+            row.supplier_cost.trim() !== ''
+              ? parseProductImportNumber(row.supplier_cost)
+              : (existing?.standard_cost ?? null);
+          const primarySupplierId =
+            supplierId ?? existing?.primary_supplier_id ?? null;
+          const supplierSku =
+            row.supplier_sku.trim() !== ''
+              ? nullableText(row.supplier_sku)
+              : (existing?.supplier_sku ?? null);
+
           const values: ProductImportValues = {
             name: row.name,
             description: nullableText(row.description),
             category_id: categoryId,
+            standard_cost: standardCost,
             unit: nullableText(row.unit),
             barcode: nullableText(row.barcode),
             standard_price: parseProductImportNumber(row.standard_price),
             reorder_point: parseInteger(row.reorder_point, 0),
+            primary_supplier_id: primarySupplierId,
+            supplier_sku: supplierSku,
             is_active: parseBoolean(row.is_active, true),
-            is_perishable: parseBoolean(
-              row.is_perishable,
-              Boolean(expiryDate),
-            ),
+            is_perishable: parseBoolean(row.is_perishable, Boolean(expiryDate)),
             notes: nullableText(row.notes),
           };
 
-          const existing = yield* repository.findProductBySku(row.sku);
           if (!existing) {
             const product = yield* repository.createProduct({
               sku: row.sku,
@@ -169,10 +565,10 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
             return existing;
           }
 
-          const product = yield* repository.updateProduct(
-            existing.id,
-            { ...values, updated_by: updatedBy },
-          );
+          const product = yield* repository.updateProduct(existing.id, {
+            ...values,
+            updated_by: updatedBy,
+          });
           if (!product) {
             return yield* Effect.fail(
               new ProductsInfrastructureError({
@@ -189,6 +585,7 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
       const upsertInventory = (
         product: ImportProductRow,
         locationId: string | null,
+        areaId: string | null,
         row: NormalizedProductImportRow,
         result: ProductImportResultDto,
         expiryDate: Date | null,
@@ -196,30 +593,33 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
         Effect.gen(function* () {
           if (!locationId) return;
 
-          const existing =
-            yield* repository.findRootInventoryByProductAndLocation(
-              product.id,
-              locationId,
-            );
+          const existing = yield* repository.findInventoryByProductLocationArea(
+            product.id,
+            locationId,
+            areaId,
+          );
           const quantity = parseInteger(row.quantity, 0);
-          const hasAreaScopedInventory =
-            yield* repository.hasAreaScopedInventoryForProductAndLocation(
-              product.id,
-              locationId,
-            );
-          if (hasAreaScopedInventory) {
-            return yield* Effect.fail(
-              new ProductsInfrastructureError({
-                action: 'import root inventory with area-scoped inventory',
-                messageKey: 'products.importAreaScopedInventoryConflict',
-              }),
-            );
+          if (areaId === null) {
+            const hasAreaScopedInventory =
+              yield* repository.hasAreaScopedInventoryForProductAndLocation(
+                product.id,
+                locationId,
+              );
+            if (hasAreaScopedInventory) {
+              return yield* Effect.fail(
+                new ProductsInfrastructureError({
+                  action: 'import root inventory with area-scoped inventory',
+                  messageKey: 'products.importAreaScopedInventoryConflict',
+                }),
+              );
+            }
           }
 
           if (!existing) {
             yield* repository.createInventory({
               product_id: product.id,
               location_id: locationId,
+              area_id: areaId,
               quantity,
               expiry_date: expiryDate,
             });
@@ -245,9 +645,11 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
       const validateRootInventoryImport = (
         row: NormalizedProductImportRow,
         caches: ImportCaches,
+        approvedPlan: ProductImportApprovedPlanDto | undefined,
       ) =>
         Effect.gen(function* () {
-          const locationName = row.location.trim();
+          if (resolveAreaPath(row, approvedPlan) !== '') return;
+          const locationName = resolveLocationName(row, approvedPlan);
           if (locationName === '') return;
 
           const cachedProduct = caches.products.get(row.sku);
@@ -285,34 +687,460 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
         result: ProductImportResultDto,
         expiryDate: Date | null,
         userId: string,
+        approvedPlan: ProductImportApprovedPlanDto | undefined,
+        allowCreateSuppliers: boolean,
       ) =>
         Effect.gen(function* () {
-          yield* validateRootInventoryImport(row, caches);
+          yield* validateRootInventoryImport(row, caches, approvedPlan);
           const categoryId = yield* getOrCreateCategoryPath(
             row.category_path,
             caches,
             result,
           );
+          const supplierId = yield* getOrCreateSupplier(
+            row,
+            caches,
+            result,
+            approvedPlan,
+            allowCreateSuppliers,
+          );
           const product = yield* upsertProduct(
             row,
             categoryId,
+            supplierId,
             caches,
             result,
             expiryDate,
             userId,
           );
           const locationId = yield* getOrCreateLocation(
-            row.location,
+            resolveLocationName(row, approvedPlan),
             caches,
             result,
           );
-          yield* upsertInventory(product, locationId, row, result, expiryDate);
+          const areaId = locationId
+            ? yield* getOrCreateAreaPath(
+                locationId,
+                resolveAreaPath(row, approvedPlan),
+                caches,
+                result,
+              )
+            : null;
+          yield* upsertInventory(
+            product,
+            locationId,
+            areaId,
+            row,
+            result,
+            expiryDate,
+          );
         });
+
+      const previewCsvContent = ({
+        content,
+        importType = 'auto',
+      }: PreviewProductRowsOptions): Effect.Effect<
+        ProductImportPreviewDto,
+        | ProductImportCsvParseFailed
+        | ProductImportUnsupportedFormat
+        | ProductsInfrastructureError
+        | TenantNotResolved
+      > =>
+        Effect.gen(function* () {
+          const parsed = yield* Effect.try({
+            try: () => parseCsvContent(content),
+            catch: (cause) =>
+              new ProductImportCsvParseFailed({
+                cause,
+                messageKey: 'products.importCsvParseFailed',
+              }),
+          });
+          const format = detectProductImportFormat(parsed.headers, importType);
+          if (!format) {
+            return yield* Effect.fail(
+              new ProductImportUnsupportedFormat({
+                messageKey: 'products.importUnsupportedFormat',
+              }),
+            );
+          }
+
+          const rows = normalizeProductImportRecords(parsed.records, format);
+          const duplicateSkuConflicts = collectDuplicateSkuConflicts(rows, {
+            includeReorderPoint: format === 'normalized-products',
+          });
+          const duplicateConflictRows = new Set(
+            duplicateSkuConflicts.flatMap((conflict) => [...conflict.rows]),
+          );
+          const warnings: PreviewWarning[] = [];
+          const categoryCounts = new Map<string, number>();
+          const locationCounts = new Map<string, number>();
+          const supplierCounts = new Map<string, number>();
+          const inventoryPreviews: PreviewInventory[] = [];
+          let missingRequiredRows = 0;
+
+          for (const conflict of duplicateSkuConflicts) {
+            warnings.push({
+              severity: 'error',
+              message: `Conflicting duplicate SKU "${conflict.sku}" has different product fields`,
+            });
+          }
+
+          for (const row of rows) {
+            if (!row.sku || !row.name) {
+              missingRequiredRows++;
+              warnings.push({
+                row: row.sourceRow,
+                severity: 'error',
+                message: 'Cannot import product without sku and name',
+              });
+              continue;
+            }
+
+            const categoryPath = normalizeCategoryPath(row.category_path);
+            categoryCounts.set(
+              categoryPath,
+              (categoryCounts.get(categoryPath) ?? 0) + 1,
+            );
+
+            const locationName = row.location.trim();
+            if (locationName) {
+              locationCounts.set(
+                locationName,
+                (locationCounts.get(locationName) ?? 0) + 1,
+              );
+            } else {
+              warnings.push({
+                row: row.sourceRow,
+                field: 'location',
+                severity: 'warning',
+                message:
+                  'Inventory row has no location and will not create inventory',
+              });
+            }
+
+            const supplierName = row.supplier_name.trim();
+            if (supplierName) {
+              supplierCounts.set(
+                supplierName,
+                (supplierCounts.get(supplierName) ?? 0) + 1,
+              );
+            } else {
+              const firstCategoryPart =
+                categoryPath.split('/')[0]?.trim() ?? '';
+              if (!isGenericSupplierCandidate(firstCategoryPart)) {
+                supplierCounts.set(
+                  firstCategoryPart,
+                  (supplierCounts.get(firstCategoryPart) ?? 0) + 1,
+                );
+              }
+            }
+
+            if (row.standard_price.trim() === '') {
+              warnings.push({
+                row: row.sourceRow,
+                field: 'standard_price',
+                severity: 'warning',
+                message: 'Product price is missing',
+              });
+            }
+
+            const expiryDate = parseDate(row.expiry_date);
+            if (row.expiry_date.trim() !== '' && expiryDate === null) {
+              warnings.push({
+                row: row.sourceRow,
+                field: 'expiry_date',
+                severity: 'error',
+                message: `Invalid expiry_date "${row.expiry_date}"`,
+              });
+            }
+
+            if (!locationName) {
+              inventoryPreviews.push({
+                row: row.sourceRow,
+                sku: row.sku,
+                location: '',
+                quantity: parseInteger(row.quantity, 0),
+                action: 'skip',
+                reason: 'Missing location',
+              });
+              continue;
+            }
+
+            if (duplicateConflictRows.has(row.sourceRow)) {
+              inventoryPreviews.push({
+                row: row.sourceRow,
+                sku: row.sku,
+                location: locationName,
+                areaPath: row.area_path.trim() || undefined,
+                quantity: parseInteger(row.quantity, 0),
+                action: 'conflict',
+                reason: 'Conflicting duplicate SKU',
+              });
+              continue;
+            }
+
+            const product = yield* repository.findProductBySku(row.sku);
+            const location = yield* repository.findLocationByName(locationName);
+            if (!product || !location) {
+              inventoryPreviews.push({
+                row: row.sourceRow,
+                sku: row.sku,
+                location: locationName,
+                areaPath: row.area_path.trim() || undefined,
+                quantity: parseInteger(row.quantity, 0),
+                action: 'create',
+                reason: !product
+                  ? 'Product will be created'
+                  : 'Location will be created',
+              });
+              continue;
+            }
+
+            const areaPath = row.area_path.trim();
+            const areaId = areaPath
+              ? yield* findExistingAreaPath(location.id, areaPath)
+              : null;
+
+            if (!areaPath) {
+              const hasAreaScopedInventory =
+                yield* repository.hasAreaScopedInventoryForProductAndLocation(
+                  product.id,
+                  location.id,
+                );
+              if (hasAreaScopedInventory) {
+                inventoryPreviews.push({
+                  row: row.sourceRow,
+                  sku: row.sku,
+                  location: locationName,
+                  quantity: parseInteger(row.quantity, 0),
+                  action: 'conflict',
+                  reason:
+                    'Cannot import root inventory while area-scoped inventory exists',
+                });
+                continue;
+              }
+            }
+
+            const existing = areaPath
+              ? areaId
+                ? yield* repository.findInventoryByProductLocationArea(
+                    product.id,
+                    location.id,
+                    areaId,
+                  )
+                : null
+              : yield* repository.findRootInventoryByProductAndLocation(
+                  product.id,
+                  location.id,
+                );
+            inventoryPreviews.push({
+              row: row.sourceRow,
+              sku: row.sku,
+              location: locationName,
+              areaPath: areaPath || undefined,
+              quantity: parseInteger(row.quantity, 0),
+              action: existing ? 'update' : 'create',
+              reason: areaPath && !areaId ? 'Area will be created' : undefined,
+            });
+          }
+
+          const categoryMappings: PreviewCategoryMapping[] = [];
+          for (const [sourcePath, rowCount] of categoryCounts.entries()) {
+            const parts = normalizeCategoryPath(sourcePath)
+              .split('/')
+              .map((part) => part.trim())
+              .filter(Boolean);
+            let parentId: string | null = null;
+            let targetCategoryId: string | undefined;
+            let action: PreviewCategoryMapping['action'] = 'use-existing';
+
+            for (const part of parts) {
+              const category: ImportCategoryRow | null =
+                yield* repository.findCategoryByNameAndParent(part, parentId);
+              if (!category) {
+                action = sourcePath === 'Uncategorized' ? 'default' : 'create';
+                targetCategoryId = undefined;
+                break;
+              }
+              parentId = category.id;
+              targetCategoryId = category.id;
+            }
+
+            categoryMappings.push({
+              sourcePath,
+              targetCategoryId,
+              targetPath: normalizeCategoryPath(sourcePath),
+              action,
+              rowCount,
+            });
+          }
+
+          const locationMappings: PreviewLocationMapping[] = [];
+          for (const [sourceLocation, rowCount] of locationCounts.entries()) {
+            const existing =
+              yield* repository.findLocationByName(sourceLocation);
+            const inferred = inferAreaPathFromLocation(sourceLocation);
+            locationMappings.push({
+              sourceLocation,
+              targetLocationId: existing?.id,
+              targetLocationName: inferred.locationName ?? existing?.name,
+              areaPath: inferred.areaPath,
+              action: existing
+                ? inferred.areaPath
+                  ? 'create-area'
+                  : 'use-existing'
+                : inferred.areaPath
+                  ? 'create-area'
+                  : 'create-location',
+              confidence: inferred.confidence,
+              rowCount,
+            });
+          }
+
+          const supplierMappings: PreviewSupplierMapping[] = [];
+          for (const [supplierName, rowCount] of supplierCounts.entries()) {
+            const existing = yield* repository.findSupplierByName(supplierName);
+            supplierMappings.push({
+              sourcePattern: supplierName,
+              supplierName,
+              targetSupplierId: existing?.id,
+              action: existing ? 'use-existing' : 'create',
+              confidence: format === 'sortly-items' ? 0.55 : 0.95,
+              rowCount,
+            });
+          }
+
+          const itemRows =
+            format === 'sortly-items'
+              ? parsed.records.filter(
+                  (record) =>
+                    String(record['Entry Type'] ?? '').trim() === 'Item',
+                ).length
+              : rows.length;
+          const folderRows =
+            format === 'sortly-items'
+              ? parsed.records.filter(
+                  (record) =>
+                    String(record['Entry Type'] ?? '').trim() === 'Folder',
+                ).length
+              : 0;
+
+          return {
+            format,
+            totalRows: parsed.records.length,
+            itemRows,
+            folderRows,
+            importableRows: rows.length,
+            missingRequiredRows,
+            duplicateSkuConflicts: duplicateSkuConflicts.map(
+              toPreviewDuplicateSkuConflict,
+            ),
+            categoryMappings,
+            supplierMappings,
+            locationMappings,
+            inventoryPreviews,
+            warnings,
+          };
+        }).pipe(Effect.withSpan('ProductImportService.previewCsvContent'));
+
+      const proposeImportPlan = ({
+        content,
+        importType = 'auto',
+      }: ProposeProductImportPlanOptions): Effect.Effect<
+        ProductImportAiProposalDto,
+        | ProductImportCsvParseFailed
+        | ProductImportUnsupportedFormat
+        | ProductsInfrastructureError
+        | TenantNotResolved
+      > =>
+        Effect.gen(function* () {
+          const preview = yield* previewCsvContent({ content, importType });
+          const apiKey = process.env.OPENAI_API_KEY;
+          const isEnabled =
+            process.env.PRODUCT_IMPORT_AI_ENABLED?.toLowerCase() === 'true';
+          if (!isEnabled || !apiKey) {
+            return makeDeterministicProposal(preview);
+          }
+
+          const sampleLines = content.split(/\r?\n/).slice(0, 25).join('\n');
+          const endpoint =
+            process.env.PRODUCT_IMPORT_AI_ENDPOINT ??
+            'https://api.openai.com/v1/chat/completions';
+          const model = process.env.PRODUCT_IMPORT_AI_MODEL ?? 'gpt-4.1-mini';
+
+          const proposalJson = yield* Effect.tryPromise({
+            try: async () => {
+              const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                  authorization: `Bearer ${apiKey}`,
+                  'content-type': 'application/json',
+                },
+                body: JSON.stringify({
+                  model,
+                  response_format: { type: 'json_object' },
+                  messages: [
+                    {
+                      role: 'system',
+                      content:
+                        'Return only JSON matching the requested import proposal schema. Do not invent writes; mark low-confidence supplier mappings as ignore.',
+                    },
+                    {
+                      role: 'user',
+                      content: JSON.stringify({
+                        task: 'Propose a reviewable product import mapping plan.',
+                        preview,
+                        csvSample: sampleLines,
+                        schema:
+                          'ProductImportAiProposalDto with format, confidence, productIdentity, categoryMappings, supplierMappings, locationMappings, warnings.',
+                      }),
+                    },
+                  ],
+                }),
+              });
+              if (!response.ok) {
+                throw new Error(
+                  `AI proposal request failed with status ${response.status}`,
+                );
+              }
+              const body = (await response.json()) as {
+                choices?: Array<{ message?: { content?: string } }>;
+              };
+              const contentText = body.choices?.[0]?.message?.content;
+              if (!contentText) {
+                throw new Error('AI proposal response did not include content');
+              }
+              return JSON.parse(contentText) as unknown;
+            },
+            catch: (cause) =>
+              new ProductsInfrastructureError({
+                action: 'generate product import AI proposal',
+                cause,
+                messageKey: 'products.repositoryFailed',
+              }),
+          });
+
+          const decodedProposal = yield* Schema.decodeUnknown(
+            ProductImportAiProposalSchema,
+          )(proposalJson).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ProductsInfrastructureError({
+                  action: 'validate product import AI proposal',
+                  cause,
+                  messageKey: 'products.repositoryFailed',
+                }),
+            ),
+          );
+          return toProductImportAiProposalDto(decodedProposal);
+        }).pipe(Effect.withSpan('ProductImportService.proposeImportPlan'));
 
       const importFromCsvContent = ({
         content,
         importType = 'auto',
         userId,
+        approvedPlan,
+        allowCreateSuppliers = approvedPlan?.allowCreateSuppliers ?? false,
       }: ImportProductsFromCsvOptions): Effect.Effect<
         ProductImportResultDto,
         ProductImportCsvParseFailed | ProductImportUnsupportedFormat
@@ -337,16 +1165,29 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
 
           const result = makeEmptyProductImportResult();
           const rows = normalizeProductImportRecords(parsed.records, format);
-          const duplicateConflictRows = findConflictingDuplicateSkuRows(rows, {
+          const duplicateConflicts = collectDuplicateSkuConflicts(rows, {
             includeReorderPoint: format === 'normalized-products',
           });
+          const duplicateConflictRows = new Set(
+            duplicateConflicts.flatMap((conflict) => [...conflict.rows]),
+          );
+          const duplicateConflictPolicy =
+            approvedPlan?.skuConflictPolicy ?? 'reject';
           const caches: ImportCaches = {
             categories: new Map<string, string>(),
             locations: new Map<string, string>(),
+            areas: new Map<string, string>(),
+            suppliers: new Map<string, string | null>(),
             products: new Map<string, ImportProductRow>(),
           };
 
           for (const row of rows) {
+            const activeRow =
+              duplicateConflictPolicy === 'derive-sku' &&
+              duplicateConflictRows.has(row.sourceRow)
+                ? { ...row, sku: deriveSkuForConflict(row) }
+                : row;
+
             if (!row.sku || !row.name) {
               pushRowError(
                 result,
@@ -356,7 +1197,10 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
               continue;
             }
 
-            if (duplicateConflictRows.has(row.sourceRow)) {
+            if (
+              duplicateConflictRows.has(row.sourceRow) &&
+              duplicateConflictPolicy === 'reject'
+            ) {
               pushRowError(
                 result,
                 row.sourceRow,
@@ -375,14 +1219,18 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
               continue;
             }
 
-            yield* importRow(row, caches, result, expiryDate, userId).pipe(
+            yield* importRow(
+              activeRow,
+              caches,
+              result,
+              expiryDate,
+              userId,
+              approvedPlan,
+              allowCreateSuppliers,
+            ).pipe(
               Effect.catchAll((error) =>
                 Effect.sync(() => {
-                  pushRowError(
-                    result,
-                    row.sourceRow,
-                    formatImportError(error),
-                  );
+                  pushRowError(result, row.sourceRow, formatImportError(error));
                 }),
               ),
             );
@@ -393,6 +1241,8 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
 
       return {
         importFromCsvContent,
+        previewCsvContent,
+        proposeImportPlan,
       };
     }),
     dependencies: [ProductImportRepository.Default],

--- a/src/effect/modules/products/import/service.ts
+++ b/src/effect/modules/products/import/service.ts
@@ -1069,8 +1069,8 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
           const model = process.env.PRODUCT_IMPORT_AI_MODEL ?? 'gpt-4.1-mini';
 
           const proposalJson = yield* Effect.tryPromise({
-            try: async () => {
-              const response = await fetch(endpoint, {
+            try: () =>
+              fetch(endpoint, {
                 method: 'POST',
                 headers: {
                   authorization: `Bearer ${apiKey}`,
@@ -1097,28 +1097,62 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
                     },
                   ],
                 }),
-              });
-              if (!response.ok) {
-                throw new Error(
-                  `AI proposal request failed with status ${response.status}`,
-                );
-              }
-              const body = (await response.json()) as {
-                choices?: Array<{ message?: { content?: string } }>;
-              };
-              const contentText = body.choices?.[0]?.message?.content;
-              if (!contentText) {
-                throw new Error('AI proposal response did not include content');
-              }
-              return JSON.parse(contentText) as unknown;
-            },
+              }),
             catch: (cause) =>
               new ProductsInfrastructureError({
-                action: 'generate product import AI proposal',
+                action: 'send product import AI proposal request',
                 cause,
                 messageKey: 'products.repositoryFailed',
               }),
-          });
+          }).pipe(
+            Effect.flatMap((response) => {
+              if (!response.ok) {
+                return Effect.fail(
+                  new ProductsInfrastructureError({
+                    action: 'generate product import AI proposal',
+                    cause: new Error(
+                      `AI proposal request failed with status ${response.status}`,
+                    ),
+                    messageKey: 'products.repositoryFailed',
+                  }),
+                );
+              }
+              return Effect.succeed(response);
+            }),
+            Effect.flatMap((response) =>
+              Effect.tryPromise({
+                try: () =>
+                  response.json() as Promise<{
+                    choices?: Array<{ message?: { content?: string } }>;
+                  }>,
+                catch: (cause) =>
+                  new ProductsInfrastructureError({
+                    action: 'parse product import AI proposal response',
+                    cause,
+                    messageKey: 'products.repositoryFailed',
+                  }),
+              }),
+            ),
+            Effect.flatMap((body) =>
+              Effect.try({
+                try: () => {
+                  const contentText = body.choices?.[0]?.message?.content;
+                  if (!contentText) {
+                    throw new Error(
+                      'AI proposal response did not include content',
+                    );
+                  }
+                  return JSON.parse(contentText) as unknown;
+                },
+                catch: (cause) =>
+                  new ProductsInfrastructureError({
+                    action: 'parse product import AI proposal JSON',
+                    cause,
+                    messageKey: 'products.repositoryFailed',
+                  }),
+              }),
+            ),
+          );
 
           const decodedProposal = yield* Schema.decodeUnknown(
             ProductImportAiProposalSchema,

--- a/src/effect/modules/products/import/types.ts
+++ b/src/effect/modules/products/import/types.ts
@@ -1,11 +1,25 @@
 import type {
+  ProductImportAiProposalDto,
+  ProductImportApprovedPlanDto,
   ProductImportErrorDto,
+  ProductImportPreviewDto,
   ProductImportResultDto,
 } from '@stocket/types/products';
-import type { categories, locations } from '../../../platform/db/schema';
+import type {
+  areas,
+  categories,
+  locations,
+  suppliers,
+} from '../../../platform/db/schema';
 import type { ProductRow } from '../products.utils';
 
-export type { ProductImportErrorDto, ProductImportResultDto };
+export type {
+  ProductImportAiProposalDto,
+  ProductImportApprovedPlanDto,
+  ProductImportErrorDto,
+  ProductImportPreviewDto,
+  ProductImportResultDto,
+};
 
 export const ProductImportTypes = [
   'auto',
@@ -36,18 +50,32 @@ export interface NormalizedProductImportRow {
   readonly barcode: string;
   readonly description: string;
   readonly notes: string;
+  readonly supplier_name: string;
+  readonly supplier_sku: string;
+  readonly supplier_cost: string;
+  readonly area_path: string;
   readonly is_active: string;
   readonly is_perishable: string;
   readonly expiry_date: string;
 }
 
+export interface DuplicateSkuConflict {
+  readonly sku: string;
+  readonly rows: readonly number[];
+  readonly names: readonly string[];
+}
+
 export type ImportCategoryRow = typeof categories.$inferSelect;
 export type ImportLocationRow = typeof locations.$inferSelect;
+export type ImportAreaRow = typeof areas.$inferSelect;
+export type ImportSupplierRow = typeof suppliers.$inferSelect;
 export type ImportProductRow = ProductRow;
 
 export interface ImportCaches {
   readonly categories: Map<string, string>;
   readonly locations: Map<string, string>;
+  readonly areas: Map<string, string>;
+  readonly suppliers: Map<string, string | null>;
   readonly products: Map<string, ImportProductRow>;
 }
 
@@ -55,17 +83,32 @@ export interface ImportProductsFromCsvOptions {
   readonly content: string;
   readonly importType?: ProductImportType;
   readonly userId: string;
+  readonly approvedPlan?: ProductImportApprovedPlanDto;
+  readonly allowCreateSuppliers?: boolean;
 }
 
 export interface ProductImportValues {
   readonly name: string;
   readonly description: string | null;
   readonly category_id: string;
+  readonly standard_cost: number | null;
   readonly unit: string | null;
   readonly barcode: string | null;
   readonly standard_price: number | null;
   readonly reorder_point: number;
+  readonly primary_supplier_id: string | null;
+  readonly supplier_sku: string | null;
   readonly is_active: boolean;
   readonly is_perishable: boolean;
   readonly notes: string | null;
+}
+
+export interface PreviewProductRowsOptions {
+  readonly content: string;
+  readonly importType?: ProductImportType;
+}
+
+export interface ProposeProductImportPlanOptions {
+  readonly content: string;
+  readonly importType?: ProductImportType;
 }

--- a/src/effect/modules/products/import/utils.ts
+++ b/src/effect/modules/products/import/utils.ts
@@ -2,6 +2,7 @@ import { parse } from 'csv-parse/sync';
 import type {
   CsvParseResult,
   CsvRecord,
+  DuplicateSkuConflict,
   ImportProductRow,
   NormalizedProductImportRow,
   ProductImportErrorDto,
@@ -24,6 +25,8 @@ const sortlySidHeaders = ['SID', 'Sortly ID (SID)'] as const;
 export const makeEmptyProductImportResult = (): ProductImportResultDto => ({
   categoriesCreated: 0,
   locationsCreated: 0,
+  areasCreated: 0,
+  suppliersCreated: 0,
   productsCreated: 0,
   productsUpdated: 0,
   inventoryRecordsCreated: 0,
@@ -129,6 +132,10 @@ const normalizeNormalizedRecord = (
   barcode: readCell(record, 'barcode'),
   description: readCell(record, 'description'),
   notes: readCell(record, 'notes'),
+  supplier_name: readCell(record, 'supplier_name'),
+  supplier_sku: readCell(record, 'supplier_sku'),
+  supplier_cost: readCell(record, 'supplier_cost'),
+  area_path: readCell(record, 'area_path'),
   is_active: readCell(record, 'is_active'),
   is_perishable: readCell(record, 'is_perishable'),
   expiry_date: readCell(record, 'expiry_date'),
@@ -159,6 +166,10 @@ const normalizeSortlyRecord = (
     barcode: qr1 || qr2,
     description: '',
     notes: readCell(record, 'Notes'),
+    supplier_name: '',
+    supplier_sku: '',
+    supplier_cost: '',
+    area_path: '',
     is_active: 'true',
     is_perishable: expiryDate === '' ? 'false' : 'true',
     expiry_date: expiryDate,
@@ -310,6 +321,9 @@ function productDefinitionKey(
     name: row.name.trim(),
     category_path: normalizeCategoryPath(row.category_path),
     unit: nullableText(row.unit) ?? '',
+    supplier_name: nullableText(row.supplier_name) ?? '',
+    supplier_sku: nullableText(row.supplier_sku) ?? '',
+    supplier_cost: parseProductImportNumber(row.supplier_cost),
     standard_price: parseProductImportNumber(row.standard_price),
     ...(options.includeReorderPoint
       ? { reorder_point: parseInteger(row.reorder_point, 0) }
@@ -326,6 +340,14 @@ export function findConflictingDuplicateSkuRows(
   rows: readonly NormalizedProductImportRow[],
   options: { readonly includeReorderPoint?: boolean } = {},
 ): Set<number> {
+  const conflicts = collectDuplicateSkuConflicts(rows, options);
+  return new Set(conflicts.flatMap((conflict) => [...conflict.rows]));
+}
+
+export function collectDuplicateSkuConflicts(
+  rows: readonly NormalizedProductImportRow[],
+  options: { readonly includeReorderPoint?: boolean } = {},
+): DuplicateSkuConflict[] {
   const keyOptions = {
     includeReorderPoint: options.includeReorderPoint ?? false,
   };
@@ -346,10 +368,21 @@ export function findConflictingDuplicateSkuRows(
     definitionsBySku.set(row.sku, entry);
   }
 
-  const conflicts = new Set<number>();
+  const conflicts: DuplicateSkuConflict[] = [];
   for (const entry of definitionsBySku.values()) {
     if (entry.rows.length > 1 && entry.definitions.size > 1) {
-      entry.rows.forEach((row) => conflicts.add(row));
+      const names = rows
+        .filter((row) => entry.rows.includes(row.sourceRow))
+        .map((row) => row.name.trim())
+        .filter(Boolean);
+      const firstRow = rows.find((row) => entry.rows.includes(row.sourceRow));
+      if (firstRow) {
+        conflicts.push({
+          sku: firstRow.sku,
+          rows: entry.rows,
+          names: [...new Set(names)].sort(),
+        });
+      }
     }
   }
   return conflicts;
@@ -384,20 +417,26 @@ const comparableProductValues = (
   name: product.name,
   description: product.description,
   category_id: product.category_id,
+  standard_cost: product.standard_cost,
   unit: product.unit,
   barcode: product.barcode,
   standard_price: product.standard_price,
   reorder_point: product.reorder_point,
+  primary_supplier_id: product.primary_supplier_id,
+  supplier_sku: product.supplier_sku,
   is_active: product.is_active,
   is_perishable: product.is_perishable,
   notes: product.notes,
   expected_name: values.name,
   expected_description: values.description,
   expected_category_id: values.category_id,
+  expected_standard_cost: values.standard_cost,
   expected_unit: values.unit,
   expected_barcode: values.barcode,
   expected_standard_price: values.standard_price,
   expected_reorder_point: values.reorder_point,
+  expected_primary_supplier_id: values.primary_supplier_id,
+  expected_supplier_sku: values.supplier_sku,
   expected_is_active: values.is_active,
   expected_is_perishable: values.is_perishable,
   expected_notes: values.notes,
@@ -412,10 +451,14 @@ export function productValuesMatch(
     comparison.name === comparison.expected_name &&
     comparison.description === comparison.expected_description &&
     comparison.category_id === comparison.expected_category_id &&
+    comparison.standard_cost === comparison.expected_standard_cost &&
     comparison.unit === comparison.expected_unit &&
     comparison.barcode === comparison.expected_barcode &&
     comparison.standard_price === comparison.expected_standard_price &&
     comparison.reorder_point === comparison.expected_reorder_point &&
+    comparison.primary_supplier_id ===
+      comparison.expected_primary_supplier_id &&
+    comparison.supplier_sku === comparison.expected_supplier_sku &&
     comparison.is_active === comparison.expected_is_active &&
     comparison.is_perishable === comparison.expected_is_perishable &&
     comparison.notes === comparison.expected_notes

--- a/src/effect/modules/products/router.spec.ts
+++ b/src/effect/modules/products/router.spec.ts
@@ -40,9 +40,10 @@ const mockMultipart = vi.hoisted(() => vi.fn());
 const mockReadFile = vi.hoisted(() => vi.fn());
 
 vi.mock('@effect/platform', async () => {
-  const actual = await vi.importActual<typeof import('@effect/platform')>(
-    '@effect/platform',
-  );
+  const actual =
+    await vi.importActual<typeof import('@effect/platform')>(
+      '@effect/platform',
+    );
   const { Effect } = await vi.importActual<typeof import('effect')>('effect');
 
   return {
@@ -56,9 +57,10 @@ vi.mock('@effect/platform', async () => {
 });
 
 vi.mock('node:fs/promises', async () => {
-  const actual = await vi.importActual<typeof import('node:fs/promises')>(
-    'node:fs/promises',
-  );
+  const actual =
+    await vi.importActual<typeof import('node:fs/promises')>(
+      'node:fs/promises',
+    );
   return {
     ...actual,
     readFile: (...args: unknown[]) => mockReadFile(...args),
@@ -110,7 +112,14 @@ const makeProductResponse = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-const bulkResult = (overrides: Partial<{ succeeded: string[]; failures: unknown[]; success_count: number; failure_count: number }> = {}) => ({
+const bulkResult = (
+  overrides: Partial<{
+    succeeded: string[];
+    failures: unknown[];
+    success_count: number;
+    failure_count: number;
+  }> = {},
+) => ({
   succeeded: [PRODUCT_ID],
   failures: [],
   success_count: 1,
@@ -151,6 +160,10 @@ const writeAll = {
   [Resource.PRODUCTS]: [Permission.READ, Permission.WRITE],
   [Resource.LOCATIONS]: [Permission.READ, Permission.WRITE],
   [Resource.INVENTORY]: [Permission.READ, Permission.WRITE],
+};
+const writeAllWithSuppliers = {
+  ...writeAll,
+  [Resource.SUPPLIERS]: [Permission.READ, Permission.WRITE],
 };
 const readOnly = {
   [Resource.PRODUCTS]: [Permission.READ],
@@ -422,9 +435,7 @@ describe('productsRouter', () => {
     });
 
     it('rejects without LOCATIONS and INVENTORY write permissions', async () => {
-      const importFromCsvContent = vi.fn(() =>
-        Effect.succeed(importResult()),
-      );
+      const importFromCsvContent = vi.fn(() => Effect.succeed(importResult()));
       const { handler } = makeProductsRouterHarness({
         service: {},
         importService: { importFromCsvContent },
@@ -450,9 +461,7 @@ describe('productsRouter', () => {
         Schema.Struct({ file: Schema.String }),
       )({}).pipe(Effect.flip, Effect.runSync);
       mockMultipart.mockReturnValue(Effect.fail(multipartError));
-      const importFromCsvContent = vi.fn(() =>
-        Effect.succeed(importResult()),
-      );
+      const importFromCsvContent = vi.fn(() => Effect.succeed(importResult()));
       const { handler } = makeProductsRouterHarness({
         service: {},
         importService: { importFromCsvContent },
@@ -478,9 +487,7 @@ describe('productsRouter', () => {
         }),
       );
       mockReadFile.mockRejectedValueOnce(new Error('disk read failed'));
-      const importFromCsvContent = vi.fn(() =>
-        Effect.succeed(importResult()),
-      );
+      const importFromCsvContent = vi.fn(() => Effect.succeed(importResult()));
       const { handler } = makeProductsRouterHarness({
         service: {},
         importService: { importFromCsvContent },
@@ -502,6 +509,34 @@ describe('productsRouter', () => {
       expect(importFromCsvContent).not.toHaveBeenCalled();
     });
 
+    it('returns 400 when the approved plan shape is invalid', async () => {
+      mockMultipart.mockReturnValue(
+        Effect.succeed({
+          file: makePersistedFile(),
+          import_type: 'auto',
+          plan: JSON.stringify({
+            supplierMappings: [{}],
+          }),
+        }),
+      );
+      const importFromCsvContent = vi.fn(() => Effect.succeed(importResult()));
+      const { handler } = makeProductsRouterHarness({
+        service: {},
+        importService: { importFromCsvContent },
+        permissions: writeAll,
+      });
+
+      const response = await handler(
+        new Request('http://localhost/products/import', {
+          method: 'POST',
+          body: 'ignored',
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(importFromCsvContent).not.toHaveBeenCalled();
+    });
+
     it('calls the import service and returns ProductImportResultDto', async () => {
       mockMultipart.mockReturnValue(
         Effect.succeed({
@@ -509,9 +544,7 @@ describe('productsRouter', () => {
           import_type: 'auto',
         }),
       );
-      const importFromCsvContent = vi.fn(() =>
-        Effect.succeed(importResult()),
-      );
+      const importFromCsvContent = vi.fn(() => Effect.succeed(importResult()));
       const { handler } = makeProductsRouterHarness({
         service: {},
         importService: { importFromCsvContent },
@@ -532,6 +565,98 @@ describe('productsRouter', () => {
         content: 'sku,name,category_path\nSKU-1,Whisky,Spirits\n',
         importType: 'auto',
         userId: '00000000-0000-4000-a000-000000000001',
+        approvedPlan: undefined,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // POST /products/import/preview and /products/import/propose
+  // -------------------------------------------------------------------
+  describe('POST /products/import/preview', () => {
+    it('calls the preview service and returns ProductImportPreviewDto', async () => {
+      mockMultipart.mockReturnValue(
+        Effect.succeed({
+          file: makePersistedFile(),
+          import_type: 'auto',
+        }),
+      );
+      const preview = {
+        format: 'normalized-products' as const,
+        totalRows: 1,
+        itemRows: 1,
+        folderRows: 0,
+        importableRows: 1,
+        missingRequiredRows: 0,
+        duplicateSkuConflicts: [],
+        categoryMappings: [],
+        supplierMappings: [],
+        locationMappings: [],
+        inventoryPreviews: [],
+        warnings: [],
+      };
+      const previewCsvContent = vi.fn(() => Effect.succeed(preview));
+      const { handler } = makeProductsRouterHarness({
+        service: {},
+        importService: { previewCsvContent },
+        permissions: writeAllWithSuppliers,
+      });
+
+      const response = await handler(
+        new Request('http://localhost/products/import/preview', {
+          method: 'POST',
+          body: 'ignored',
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual(preview);
+      expect(previewCsvContent).toHaveBeenCalledWith({
+        content: 'sku,name,category_path\nSKU-1,Whisky,Spirits\n',
+        importType: 'auto',
+      });
+    });
+  });
+
+  describe('POST /products/import/propose', () => {
+    it('calls the AI proposal service and returns a proposal', async () => {
+      mockMultipart.mockReturnValue(
+        Effect.succeed({
+          file: makePersistedFile(),
+          import_type: 'sortly-items',
+        }),
+      );
+      const proposal = {
+        format: 'sortly-items' as const,
+        confidence: 0.5,
+        productIdentity: {
+          sourceColumn: 'SID',
+          conflictPolicy: 'reject' as const,
+        },
+        categoryMappings: [],
+        supplierMappings: [],
+        locationMappings: [],
+        warnings: [],
+      };
+      const proposeImportPlan = vi.fn(() => Effect.succeed(proposal));
+      const { handler } = makeProductsRouterHarness({
+        service: {},
+        importService: { proposeImportPlan },
+        permissions: writeAllWithSuppliers,
+      });
+
+      const response = await handler(
+        new Request('http://localhost/products/import/propose', {
+          method: 'POST',
+          body: 'ignored',
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual(proposal);
+      expect(proposeImportPlan).toHaveBeenCalledWith({
+        content: 'sku,name,category_path\nSKU-1,Whisky,Spirits\n',
+        importType: 'sortly-items',
       });
     });
   });
@@ -790,8 +915,7 @@ describe('productsRouter', () => {
     it('returns 400 on malformed body', async () => {
       const { handler } = makeProductsRouterHarness({
         service: {
-          bulkUpdateStatus: () =>
-            Effect.die('service should not be called'),
+          bulkUpdateStatus: () => Effect.die('service should not be called'),
         },
         permissions: writeAll,
       });

--- a/src/effect/modules/products/router.ts
+++ b/src/effect/modules/products/router.ts
@@ -17,11 +17,20 @@ import {
 import { requirePermission } from '../../platform/auth/authorization';
 import { respondJson, respondJsonOk } from '../../platform/http/errors';
 import { AuditLogWriter } from '../../platform/audit/index';
-import { getOptionalSession, requireSession } from '../../platform/http/session';
+import {
+  getOptionalSession,
+  requireSession,
+} from '../../platform/http/session';
 import { makeMessageResponse } from '../../platform/observability/messages';
 import { ProductImportService } from './import/service';
-import { ProductImportTypes } from './import/types';
-import { ProductsInfrastructureError } from './products.errors';
+import {
+  ProductImportTypes,
+  type ProductImportApprovedPlanDto,
+} from './import/types';
+import {
+  ProductImportCsvParseFailed,
+  ProductsInfrastructureError,
+} from './products.errors';
 import { ProductsService } from './service';
 
 /**
@@ -30,7 +39,13 @@ import { ProductsService } from './service';
  * them even though every field encodes to a string at runtime. This helper hides the cast.
  */
 const searchParams = <A, I, R>(schema: Schema.Schema<A, I, R>) =>
-  HttpServerRequest.schemaSearchParams(schema as unknown as Schema.Schema<A, Record<string, string | ReadonlyArray<string> | undefined>, R>);
+  HttpServerRequest.schemaSearchParams(
+    schema as unknown as Schema.Schema<
+      A,
+      Record<string, string | ReadonlyArray<string> | undefined>,
+      R
+    >,
+  );
 
 const ProductPathParams = Schema.Struct({ id: ProductIdSchema });
 const CategoryPathParams = Schema.Struct({ categoryId: Schema.UUID });
@@ -40,6 +55,50 @@ const ProductImportUploadSchema = Schema.Struct({
   import_type: Schema.optionalWith(ProductImportTypeSchema, {
     default: () => 'auto' as const,
   }),
+  plan: Schema.optional(Schema.String),
+});
+const ProductImportCategoryMappingSchema = Schema.Struct({
+  sourcePath: Schema.String,
+  targetCategoryId: Schema.optional(Schema.String),
+  targetPath: Schema.String,
+  action: Schema.Literal('use-existing', 'create', 'default'),
+  rowCount: Schema.Number,
+});
+const ProductImportSupplierMappingSchema = Schema.Struct({
+  sourcePattern: Schema.String,
+  supplierName: Schema.String,
+  targetSupplierId: Schema.optional(Schema.String),
+  action: Schema.Literal('use-existing', 'create', 'ignore'),
+  confidence: Schema.Number,
+  rowCount: Schema.Number,
+});
+const ProductImportLocationMappingSchema = Schema.Struct({
+  sourceLocation: Schema.String,
+  targetLocationId: Schema.optional(Schema.String),
+  targetLocationName: Schema.optional(Schema.String),
+  areaPath: Schema.optional(Schema.String),
+  action: Schema.Literal(
+    'use-existing',
+    'create-location',
+    'create-area',
+    'ignore',
+  ),
+  confidence: Schema.Number,
+  rowCount: Schema.Number,
+});
+const ProductImportApprovedPlanSchema = Schema.Struct({
+  skuConflictPolicy: Schema.optional(Schema.Literal('reject', 'derive-sku')),
+  allowCreateSuppliers: Schema.optional(Schema.Boolean),
+  defaultLocationName: Schema.optional(Schema.String),
+  categoryMappings: Schema.optional(
+    Schema.Array(ProductImportCategoryMappingSchema),
+  ),
+  supplierMappings: Schema.optional(
+    Schema.Array(ProductImportSupplierMappingSchema),
+  ),
+  locationMappings: Schema.optional(
+    Schema.Array(ProductImportLocationMappingSchema),
+  ),
 });
 
 const IncludeDeletedQuery = Schema.Struct({
@@ -53,6 +112,41 @@ const PermanentQuery = Schema.Struct({
     default: () => false,
   }),
 });
+
+const readUploadedProductImportFile = (
+  file: Schema.Schema.Type<typeof Multipart.SingleFileSchema>,
+) =>
+  Effect.tryPromise({
+    try: () => readFile(file.path),
+    catch: (cause) =>
+      new ProductsInfrastructureError({
+        action: 'read uploaded product import file',
+        cause,
+        messageKey: 'products.importReadUploadFailed',
+      }),
+  });
+
+const planParseFailed = (cause: unknown) =>
+  new ProductImportCsvParseFailed({
+    cause,
+    messageKey: 'products.importCsvParseFailed',
+  });
+
+const parseApprovedImportPlan = (plan: string | undefined) => {
+  if (!plan) return Effect.succeed(undefined);
+
+  return Effect.try({
+    try: () => JSON.parse(plan) as unknown,
+    catch: planParseFailed,
+  }).pipe(
+    Effect.flatMap((value) =>
+      Schema.decodeUnknown(ProductImportApprovedPlanSchema)(value).pipe(
+        Effect.mapError(planParseFailed),
+      ),
+    ),
+    Effect.map((value) => value as ProductImportApprovedPlanDto),
+  );
+};
 
 export const productsRouter = HttpRouter.empty.pipe(
   HttpRouter.get(
@@ -76,8 +170,9 @@ export const productsRouter = HttpRouter.empty.pipe(
     '/bulk',
     Effect.gen(function* () {
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-      const dto =
-        yield* HttpServerRequest.schemaBodyJson(BulkCreateProductsSchema);
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        BulkCreateProductsSchema,
+      );
       const session = yield* getOptionalSession;
       const userId = session?.user.id;
       const productsService = yield* ProductsService;
@@ -94,31 +189,66 @@ export const productsRouter = HttpRouter.empty.pipe(
     }),
   ),
   HttpRouter.post(
+    '/import/preview',
+    Effect.gen(function* () {
+      yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
+      yield* requirePermission(Resource.LOCATIONS, Permission.WRITE);
+      yield* requirePermission(Resource.INVENTORY, Permission.WRITE);
+      yield* requirePermission(Resource.SUPPLIERS, Permission.READ);
+      const { file, import_type } =
+        yield* HttpServerRequest.schemaBodyMultipart(ProductImportUploadSchema);
+      const buffer = yield* readUploadedProductImportFile(file);
+
+      const productImportService = yield* ProductImportService;
+      const result = yield* productImportService.previewCsvContent({
+        content: buffer.toString('utf8'),
+        importType: import_type,
+      });
+      return yield* respondJsonOk(result);
+    }),
+  ),
+  HttpRouter.post(
+    '/import/propose',
+    Effect.gen(function* () {
+      yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
+      yield* requirePermission(Resource.LOCATIONS, Permission.WRITE);
+      yield* requirePermission(Resource.INVENTORY, Permission.WRITE);
+      yield* requirePermission(Resource.SUPPLIERS, Permission.READ);
+      const { file, import_type } =
+        yield* HttpServerRequest.schemaBodyMultipart(ProductImportUploadSchema);
+      const buffer = yield* readUploadedProductImportFile(file);
+
+      const productImportService = yield* ProductImportService;
+      const result = yield* productImportService.proposeImportPlan({
+        content: buffer.toString('utf8'),
+        importType: import_type,
+      });
+      return yield* respondJsonOk(result);
+    }),
+  ),
+  HttpRouter.post(
     '/import',
     Effect.gen(function* () {
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
       yield* requirePermission(Resource.LOCATIONS, Permission.WRITE);
       yield* requirePermission(Resource.INVENTORY, Permission.WRITE);
-      const { file, import_type } =
+      const { file, import_type, plan } =
         yield* HttpServerRequest.schemaBodyMultipart(ProductImportUploadSchema);
+      const approvedPlan = yield* parseApprovedImportPlan(plan);
+      if (approvedPlan?.allowCreateSuppliers) {
+        yield* requirePermission(Resource.SUPPLIERS, Permission.WRITE);
+      }
       const session = yield* requireSession;
       const userId = session.user.id;
 
-      const buffer = yield* Effect.tryPromise({
-        try: () => readFile(file.path),
-        catch: (cause) =>
-          new ProductsInfrastructureError({
-            action: 'read uploaded product import file',
-            cause,
-            messageKey: 'products.importReadUploadFailed',
-          }),
-      });
+      const buffer = yield* readUploadedProductImportFile(file);
 
       const productImportService = yield* ProductImportService;
       const result = yield* productImportService.importFromCsvContent({
         content: buffer.toString('utf8'),
         importType: import_type,
         userId,
+        approvedPlan,
       });
       return yield* respondJsonOk(result);
     }),
@@ -130,9 +260,7 @@ export const productsRouter = HttpRouter.empty.pipe(
       const { categoryId } =
         yield* HttpRouter.schemaPathParams(CategoryPathParams);
       const productsService = yield* ProductsService;
-      return yield* respondJson(
-        productsService.findByCategoryTree(categoryId),
-      );
+      return yield* respondJson(productsService.findByCategoryTree(categoryId));
     }),
   ),
   HttpRouter.get(
@@ -149,8 +277,9 @@ export const productsRouter = HttpRouter.empty.pipe(
     '/',
     Effect.gen(function* () {
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-      const dto =
-        yield* HttpServerRequest.schemaBodyJson(CreateProductRequestSchema);
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        CreateProductRequestSchema,
+      );
       const session = yield* getOptionalSession;
       const userId = session?.user.id;
       const productsService = yield* ProductsService;
@@ -168,8 +297,9 @@ export const productsRouter = HttpRouter.empty.pipe(
     '/bulk/status',
     Effect.gen(function* () {
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-      const dto =
-        yield* HttpServerRequest.schemaBodyJson(BulkUpdateStatusSchema);
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        BulkUpdateStatusSchema,
+      );
       const session = yield* getOptionalSession;
       const userId = session?.user.id;
       const productsService = yield* ProductsService;
@@ -240,8 +370,9 @@ export const productsRouter = HttpRouter.empty.pipe(
     Effect.gen(function* () {
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
       const { id } = yield* HttpRouter.schemaPathParams(ProductPathParams);
-      const dto =
-        yield* HttpServerRequest.schemaBodyJson(UpdateProductRequestSchema);
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        UpdateProductRequestSchema,
+      );
       const session = yield* getOptionalSession;
       const userId = session?.user.id;
       const productsService = yield* ProductsService;

--- a/src/scripts/import-products.ts
+++ b/src/scripts/import-products.ts
@@ -17,25 +17,33 @@ import * as relations from '../effect/platform/db/relations';
 import { ProductImportService } from '../effect/modules/products/import/service';
 import {
   ProductImportTypes,
+  type ProductImportApprovedPlanDto,
   type ProductImportType,
 } from '../effect/modules/products/import/types';
 import { getDatabaseUrl } from '../config/db-connection.utils';
 
+const SCRIPT_PREVIEW_USER_ID = '00000000-0000-4000-a000-000000000202';
+
 interface CliOptions {
   readonly csvFilePath: string;
   readonly importType: ProductImportType;
+  readonly mode: 'import' | 'preview' | 'propose';
   readonly tenantId: string;
   readonly tenantName: string;
   readonly tenantSlug: string;
   readonly userId: string;
+  readonly approvedPlanPath?: string;
+  readonly allowCreateSuppliers: boolean;
 }
 
 const usage = () => {
   console.error(`Usage:
   tsx src/scripts/import-products.ts [--import-type auto|normalized-products|sortly-items] [--tenant-id <uuid>] <csv-file>
+  tsx src/scripts/import-products.ts --preview [--import-type auto|normalized-products|sortly-items] <csv-file>
+  tsx src/scripts/import-products.ts --propose [--import-type auto|normalized-products|sortly-items] <csv-file>
 
 Environment:
-  IMPORT_USER_ID      Required user id to attribute created/updated products to.
+  IMPORT_USER_ID      Required for import mode to attribute created/updated products to.
   IMPORT_TENANT_ID    Tenant id to scope import writes. Defaults to the default tenant.
   IMPORT_TENANT_NAME  Optional tenant display name for the script request context.
   IMPORT_TENANT_SLUG  Optional tenant slug for the script request context.`);
@@ -54,7 +62,10 @@ const takeValue = (args: string[], index: number, flag: string): string => {
 
 function readOptions(args: string[], env: NodeJS.ProcessEnv): CliOptions {
   let importType: ProductImportType = 'auto';
+  let mode: CliOptions['mode'] = 'import';
   let tenantId = env.IMPORT_TENANT_ID ?? DEFAULT_TENANT_ID;
+  let approvedPlanPath: string | undefined;
+  let allowCreateSuppliers = false;
   let csvFilePath: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
@@ -72,6 +83,32 @@ function readOptions(args: string[], env: NodeJS.ProcessEnv): CliOptions {
       }
       importType = value;
       i++;
+      continue;
+    }
+
+    if (arg === '--preview') {
+      mode = 'preview';
+      continue;
+    }
+
+    if (arg === '--propose') {
+      mode = 'propose';
+      continue;
+    }
+
+    if (arg === '--allow-create-suppliers') {
+      allowCreateSuppliers = true;
+      continue;
+    }
+
+    if (arg === '--plan') {
+      approvedPlanPath = takeValue(args, i, arg);
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith('--plan=')) {
+      approvedPlanPath = arg.slice('--plan='.length);
       continue;
     }
 
@@ -109,13 +146,14 @@ function readOptions(args: string[], env: NodeJS.ProcessEnv): CliOptions {
     throw new Error('Please provide a CSV file path');
   }
 
-  if (!env.IMPORT_USER_ID) {
+  if (mode === 'import' && !env.IMPORT_USER_ID) {
     throw new Error('IMPORT_USER_ID is required');
   }
 
   return {
     csvFilePath,
     importType,
+    mode,
     tenantId,
     tenantName:
       env.IMPORT_TENANT_NAME ??
@@ -123,7 +161,9 @@ function readOptions(args: string[], env: NodeJS.ProcessEnv): CliOptions {
     tenantSlug:
       env.IMPORT_TENANT_SLUG ??
       (tenantId === DEFAULT_TENANT_ID ? DEFAULT_TENANT_SLUG : tenantId),
-    userId: env.IMPORT_USER_ID,
+    userId: env.IMPORT_USER_ID ?? SCRIPT_PREVIEW_USER_ID,
+    approvedPlanPath,
+    allowCreateSuppliers,
   };
 }
 
@@ -155,6 +195,8 @@ function printSummary(result: Awaited<ReturnType<typeof runImport>>) {
   console.log('Summary:');
   console.log(`  - Categories created: ${result.categoriesCreated}`);
   console.log(`  - Locations created: ${result.locationsCreated}`);
+  console.log(`  - Areas created: ${result.areasCreated ?? 0}`);
+  console.log(`  - Suppliers created: ${result.suppliersCreated ?? 0}`);
   console.log(`  - Products created: ${result.productsCreated}`);
   console.log(`  - Products updated: ${result.productsUpdated}`);
   console.log(
@@ -176,11 +218,40 @@ function printSummary(result: Awaited<ReturnType<typeof runImport>>) {
   }
 }
 
+function printPreview(result: Awaited<ReturnType<typeof runPreview>>) {
+  console.log('\nImport preview completed.\n');
+  console.log(`Format: ${result.format}`);
+  console.log(`Rows: ${result.importableRows}/${result.totalRows} importable`);
+  console.log(`Categories: ${result.categoryMappings.length}`);
+  console.log(`Locations: ${result.locationMappings.length}`);
+  console.log(`Supplier candidates: ${result.supplierMappings.length}`);
+  console.log(
+    `Duplicate SKU conflicts: ${result.duplicateSkuConflicts.length}`,
+  );
+  console.log(`Warnings: ${result.warnings.length}`);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+function printProposal(result: Awaited<ReturnType<typeof runPropose>>) {
+  console.log('\nImport proposal completed.\n');
+  console.log(JSON.stringify(result, null, 2));
+}
+
+function readApprovedPlan(
+  options: CliOptions,
+): ProductImportApprovedPlanDto | undefined {
+  if (!options.approvedPlanPath) return undefined;
+  return JSON.parse(
+    fs.readFileSync(options.approvedPlanPath, 'utf-8'),
+  ) as ProductImportApprovedPlanDto;
+}
+
 async function runImport(options: CliOptions) {
   const { db, pool } = createDatabase();
 
   try {
     const content = fs.readFileSync(options.csvFilePath, 'utf-8');
+    const approvedPlan = readApprovedPlan(options);
     const serviceLayer = ProductImportService.Default.pipe(
       Layer.provide(
         Layer.mergeAll(
@@ -199,6 +270,70 @@ async function runImport(options: CliOptions) {
           content,
           importType: options.importType,
           userId: options.userId,
+          approvedPlan,
+          allowCreateSuppliers:
+            options.allowCreateSuppliers ||
+            approvedPlan?.allowCreateSuppliers === true,
+        }),
+      ).pipe(Effect.provide(serviceLayer)),
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+async function runPreview(options: CliOptions) {
+  const { db, pool } = createDatabase();
+
+  try {
+    const content = fs.readFileSync(options.csvFilePath, 'utf-8');
+    const serviceLayer = ProductImportService.Default.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          Layer.succeed(DrizzleDatabase, db),
+          Layer.succeed(
+            CurrentRequestContext,
+            makeScriptRequestContext(options),
+          ),
+        ),
+      ),
+    );
+
+    return await Effect.runPromise(
+      Effect.flatMap(ProductImportService, (service) =>
+        service.previewCsvContent({
+          content,
+          importType: options.importType,
+        }),
+      ).pipe(Effect.provide(serviceLayer)),
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+async function runPropose(options: CliOptions) {
+  const { db, pool } = createDatabase();
+
+  try {
+    const content = fs.readFileSync(options.csvFilePath, 'utf-8');
+    const serviceLayer = ProductImportService.Default.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          Layer.succeed(DrizzleDatabase, db),
+          Layer.succeed(
+            CurrentRequestContext,
+            makeScriptRequestContext(options),
+          ),
+        ),
+      ),
+    );
+
+    return await Effect.runPromise(
+      Effect.flatMap(ProductImportService, (service) =>
+        service.proposeImportPlan({
+          content,
+          importType: options.importType,
         }),
       ).pipe(Effect.provide(serviceLayer)),
     );
@@ -215,10 +350,17 @@ async function main() {
     }
 
     console.log(
-      `Starting product import (${options.importType}) for tenant ${options.tenantId}`,
+      `Starting product import ${options.mode} (${options.importType}) for tenant ${options.tenantId}`,
     );
-    const result = await runImport(options);
-    printSummary(result);
+    if (options.mode === 'preview') {
+      printPreview(await runPreview(options));
+      return;
+    }
+    if (options.mode === 'propose') {
+      printProposal(await runPropose(options));
+      return;
+    }
+    printSummary(await runImport(options));
   } catch (error) {
     console.error(
       `\nImport failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/scripts/import-products.ts
+++ b/src/scripts/import-products.ts
@@ -17,7 +17,10 @@ import * as relations from '../effect/platform/db/relations';
 import { ProductImportService } from '../effect/modules/products/import/service';
 import {
   ProductImportTypes,
+  type ProductImportAiProposalDto,
   type ProductImportApprovedPlanDto,
+  type ProductImportPreviewDto,
+  type ProductImportResultDto,
   type ProductImportType,
 } from '../effect/modules/products/import/types';
 import { getDatabaseUrl } from '../config/db-connection.utils';
@@ -190,7 +193,52 @@ function makeScriptRequestContext(options: CliOptions): RequestContext {
   };
 }
 
-function printSummary(result: Awaited<ReturnType<typeof runImport>>) {
+const databaseResource = Effect.acquireRelease(
+  Effect.sync(createDatabase),
+  ({ pool }) => Effect.promise(() => pool.end()),
+);
+
+const readTextFile = (path: string) =>
+  Effect.try({
+    try: () => fs.readFileSync(path, 'utf-8'),
+    catch: (cause) => cause,
+  });
+
+const readApprovedPlan = (
+  options: CliOptions,
+): Effect.Effect<ProductImportApprovedPlanDto | undefined, unknown> => {
+  if (!options.approvedPlanPath) return Effect.succeed(undefined);
+  return readTextFile(options.approvedPlanPath).pipe(
+    Effect.flatMap((content) =>
+      Effect.try({
+        try: () => JSON.parse(content) as ProductImportApprovedPlanDto,
+        catch: (cause) => cause,
+      }),
+    ),
+  );
+};
+
+const ensureCsvFileExists = (path: string) =>
+  Effect.try({
+    try: () => {
+      if (!fs.existsSync(path)) {
+        throw new Error(`File not found: ${path}`);
+      }
+    },
+    catch: (cause) => cause,
+  });
+
+const makeProductImportServiceLayer = (db: DrizzleDb, options: CliOptions) =>
+  ProductImportService.Default.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.succeed(DrizzleDatabase, db),
+        Layer.succeed(CurrentRequestContext, makeScriptRequestContext(options)),
+      ),
+    ),
+  );
+
+function printSummary(result: ProductImportResultDto) {
   console.log('\nImport completed.\n');
   console.log('Summary:');
   console.log(`  - Categories created: ${result.categoriesCreated}`);
@@ -218,7 +266,7 @@ function printSummary(result: Awaited<ReturnType<typeof runImport>>) {
   }
 }
 
-function printPreview(result: Awaited<ReturnType<typeof runPreview>>) {
+function printPreview(result: ProductImportPreviewDto) {
   console.log('\nImport preview completed.\n');
   console.log(`Format: ${result.format}`);
   console.log(`Rows: ${result.importableRows}/${result.totalRows} importable`);
@@ -232,40 +280,20 @@ function printPreview(result: Awaited<ReturnType<typeof runPreview>>) {
   console.log(JSON.stringify(result, null, 2));
 }
 
-function printProposal(result: Awaited<ReturnType<typeof runPropose>>) {
+function printProposal(result: ProductImportAiProposalDto) {
   console.log('\nImport proposal completed.\n');
   console.log(JSON.stringify(result, null, 2));
 }
 
-function readApprovedPlan(
-  options: CliOptions,
-): ProductImportApprovedPlanDto | undefined {
-  if (!options.approvedPlanPath) return undefined;
-  return JSON.parse(
-    fs.readFileSync(options.approvedPlanPath, 'utf-8'),
-  ) as ProductImportApprovedPlanDto;
-}
+function runImport(options: CliOptions) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const content = yield* readTextFile(options.csvFilePath);
+      const approvedPlan = yield* readApprovedPlan(options);
+      const { db } = yield* databaseResource;
+      const serviceLayer = makeProductImportServiceLayer(db, options);
 
-async function runImport(options: CliOptions) {
-  const { db, pool } = createDatabase();
-
-  try {
-    const content = fs.readFileSync(options.csvFilePath, 'utf-8');
-    const approvedPlan = readApprovedPlan(options);
-    const serviceLayer = ProductImportService.Default.pipe(
-      Layer.provide(
-        Layer.mergeAll(
-          Layer.succeed(DrizzleDatabase, db),
-          Layer.succeed(
-            CurrentRequestContext,
-            makeScriptRequestContext(options),
-          ),
-        ),
-      ),
-    );
-
-    return await Effect.runPromise(
-      Effect.flatMap(ProductImportService, (service) =>
+      return yield* Effect.flatMap(ProductImportService, (service) =>
         service.importFromCsvContent({
           content,
           importType: options.importType,
@@ -275,99 +303,78 @@ async function runImport(options: CliOptions) {
             options.allowCreateSuppliers ||
             approvedPlan?.allowCreateSuppliers === true,
         }),
-      ).pipe(Effect.provide(serviceLayer)),
-    );
-  } finally {
-    await pool.end();
-  }
+      ).pipe(Effect.provide(serviceLayer));
+    }),
+  );
 }
 
-async function runPreview(options: CliOptions) {
-  const { db, pool } = createDatabase();
+function runPreview(options: CliOptions) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const content = yield* readTextFile(options.csvFilePath);
+      const { db } = yield* databaseResource;
+      const serviceLayer = makeProductImportServiceLayer(db, options);
 
-  try {
-    const content = fs.readFileSync(options.csvFilePath, 'utf-8');
-    const serviceLayer = ProductImportService.Default.pipe(
-      Layer.provide(
-        Layer.mergeAll(
-          Layer.succeed(DrizzleDatabase, db),
-          Layer.succeed(
-            CurrentRequestContext,
-            makeScriptRequestContext(options),
-          ),
-        ),
-      ),
-    );
-
-    return await Effect.runPromise(
-      Effect.flatMap(ProductImportService, (service) =>
+      return yield* Effect.flatMap(ProductImportService, (service) =>
         service.previewCsvContent({
           content,
           importType: options.importType,
         }),
-      ).pipe(Effect.provide(serviceLayer)),
-    );
-  } finally {
-    await pool.end();
-  }
+      ).pipe(Effect.provide(serviceLayer));
+    }),
+  );
 }
 
-async function runPropose(options: CliOptions) {
-  const { db, pool } = createDatabase();
+function runPropose(options: CliOptions) {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const content = yield* readTextFile(options.csvFilePath);
+      const { db } = yield* databaseResource;
+      const serviceLayer = makeProductImportServiceLayer(db, options);
 
-  try {
-    const content = fs.readFileSync(options.csvFilePath, 'utf-8');
-    const serviceLayer = ProductImportService.Default.pipe(
-      Layer.provide(
-        Layer.mergeAll(
-          Layer.succeed(DrizzleDatabase, db),
-          Layer.succeed(
-            CurrentRequestContext,
-            makeScriptRequestContext(options),
-          ),
-        ),
-      ),
-    );
-
-    return await Effect.runPromise(
-      Effect.flatMap(ProductImportService, (service) =>
+      return yield* Effect.flatMap(ProductImportService, (service) =>
         service.proposeImportPlan({
           content,
           importType: options.importType,
         }),
-      ).pipe(Effect.provide(serviceLayer)),
-    );
-  } finally {
-    await pool.end();
-  }
+      ).pipe(Effect.provide(serviceLayer));
+    }),
+  );
 }
 
-async function main() {
-  try {
-    const options = readOptions(process.argv.slice(2), process.env);
-    if (!fs.existsSync(options.csvFilePath)) {
-      throw new Error(`File not found: ${options.csvFilePath}`);
-    }
+const main = Effect.gen(function* () {
+  const options = yield* Effect.try({
+    try: () => readOptions(process.argv.slice(2), process.env),
+    catch: (cause) => cause,
+  });
+  yield* ensureCsvFileExists(options.csvFilePath);
 
+  yield* Effect.sync(() =>
     console.log(
       `Starting product import ${options.mode} (${options.importType}) for tenant ${options.tenantId}`,
-    );
-    if (options.mode === 'preview') {
-      printPreview(await runPreview(options));
-      return;
-    }
-    if (options.mode === 'propose') {
-      printProposal(await runPropose(options));
-      return;
-    }
-    printSummary(await runImport(options));
-  } catch (error) {
-    console.error(
-      `\nImport failed: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    usage();
-    process.exit(1);
-  }
-}
+    ),
+  );
 
-void main();
+  if (options.mode === 'preview') {
+    const result = yield* runPreview(options);
+    yield* Effect.sync(() => printPreview(result));
+    return;
+  }
+
+  if (options.mode === 'propose') {
+    const result = yield* runPropose(options);
+    yield* Effect.sync(() => printProposal(result));
+    return;
+  }
+
+  const result = yield* runImport(options);
+  yield* Effect.sync(() => printSummary(result));
+});
+
+Effect.runPromise(main).catch((error: unknown) => {
+  console.error(
+    `\nImport failed: ${error instanceof Error ? error.message : String(error)}`,
+  );
+  usage();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements the Sortly import improvement plan in the backend:

- adds deterministic import preview and AI proposal endpoints
- supports approved import plans for duplicate SKU policy, suppliers, locations, and area paths
- imports supplier links/costs and area-scoped inventory
- extends the CLI with preview/propose/plan/supplier creation options
- adds router/service coverage for preview, proposal, approved plans, supplier mappings, area inventory, and data-preservation regressions

## Why

Sortly exports need reviewable mapping before writes, and the importer needs to create/link suppliers, locations, areas, products, and inventory without silently overwriting existing supplier fields.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/vitest run --config vitest.integration.config.ts src/effect/modules/products/import/import.integration.spec.ts`
- `./node_modules/.bin/oxlint src/effect/modules/products/import src/effect/modules/products/router.ts src/effect/modules/products/router.spec.ts src/scripts/import-products.ts`
- `node node_modules/.pnpm/prettier@3.8.4/node_modules/prettier/bin/prettier.cjs --check ...`

## Related PRs

Depends on shared DTOs in https://github.com/stocketfr/packages/pull/20.
Frontend companion PR uses these endpoints.