### PR TITLE
[codex] Add reviewed Sortly import backend flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@
 - Keep feature work under `src/effect/modules/<feature>/` and follow the existing router/service/repository/schema/error split.
 - For large feature-specific workflows, prefer a subfolder under the module (for example `products/import/`) with its own `service.ts`, `repository.ts`, `types.ts`, `utils.ts`, and tests so normal module behavior stays readable.
 - Keep `service.ts` focused on orchestration. Move module-local row aliases, options, caches, DTO re-exports, and literal tuples to `types.ts`; move pure parsing, normalization, formatting, comparison, and duplicate-detection helpers to `utils.ts`.
+- Any helper utility introduced for backend methods or services should be moved to the nearest module `utils.ts` file instead of living inline in a service.
 - Before adding new row types, literal lists, parsers, or fixture blocks, search for existing equivalents and reuse or centralize them when the behavior is shared.
 - Cross-module access should normally go through services, not another module's repository.
 - Shared request/response contracts should come from `@stocket/types`, not backend-local DTO files.

--- a/drizzle/0006_tenant_feature_overrides.sql
+++ b/drizzle/0006_tenant_feature_overrides.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS "tenant_feature_overrides" (
+  "tenant_id" uuid NOT NULL,
+  "feature_key" varchar(100) NOT NULL,
+  "enabled" boolean NOT NULL,
+  "expires_at" timestamp with time zone,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_by" text,
+  CONSTRAINT "tenant_feature_overrides_tenant_id_feature_key_pk" PRIMARY KEY("tenant_id","feature_key")
+);
+
+DO $$ BEGIN
+ ALTER TABLE "tenant_feature_overrides"
+ ADD CONSTRAINT "tenant_feature_overrides_tenant_id_organization_id_fk"
+ FOREIGN KEY ("tenant_id") REFERENCES "public"."organization"("id")
+ ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "tenant_feature_overrides_tenant_id_idx"
+ON "tenant_feature_overrides" USING btree ("tenant_id");

--- a/src/effect/modules/auth/mappers.spec.ts
+++ b/src/effect/modules/auth/mappers.spec.ts
@@ -3,6 +3,7 @@ import {
   toProfileResponse,
   toSessionClaimsResponse,
 } from './mappers';
+import { DEFAULT_FEATURE_STATES, PlanKey } from '@stocket/types/features';
 
 describe('auth mappers', () => {
   const session = {
@@ -37,6 +38,10 @@ describe('auth mappers', () => {
           tenantName: 'Stocket',
           tenantSlug: 'stocket',
         },
+        {
+          planKey: PlanKey.FREE,
+          features: DEFAULT_FEATURE_STATES,
+        },
       ),
     ).toEqual({
       id: 'user-1',
@@ -46,6 +51,8 @@ describe('auth mappers', () => {
       tenantId: '00000000-0000-4000-8000-000000000001',
       tenantName: 'Stocket',
       tenantSlug: 'stocket',
+      planKey: PlanKey.FREE,
+      features: DEFAULT_FEATURE_STATES,
       roles: ['Admin'],
       permissions: {
         roles: ['read', 'write'],

--- a/src/effect/modules/auth/mappers.ts
+++ b/src/effect/modules/auth/mappers.ts
@@ -3,6 +3,7 @@ import type {
   ProfileResponseDto,
   SessionClaimsResponseDto,
 } from '@stocket/types/auth';
+import type { FeatureStates, PlanKey } from '@stocket/types/features';
 import type { UserSession } from '../../platform/auth/user-session';
 import {
   getSessionIdFromSession,
@@ -16,6 +17,10 @@ export const toCurrentUserResponse = (
   session: UserSession,
   userPermissions: UserPermissions,
   tenant: TenantContext,
+  entitlements: {
+    readonly planKey: PlanKey;
+    readonly features: FeatureStates;
+  },
 ): CurrentUserResponseDto => {
   const { id, name, email, image } = session.user;
 
@@ -27,6 +32,8 @@ export const toCurrentUserResponse = (
     tenantId: tenant.tenantId,
     tenantName: tenant.tenantName,
     tenantSlug: tenant.tenantSlug,
+    planKey: entitlements.planKey,
+    features: entitlements.features,
     roles: userPermissions.roleNames,
     permissions: userPermissions.permissions,
   };

--- a/src/effect/modules/auth/service.integration.spec.ts
+++ b/src/effect/modules/auth/service.integration.spec.ts
@@ -22,10 +22,20 @@
 import { HttpServerRequest } from '@effect/platform';
 import { Effect, Layer, ManagedRuntime } from 'effect';
 import { Permission, Resource } from '@stocket/types/auth';
+import {
+  DEFAULT_FEATURE_STATES,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import type { BetterAuthService } from '../../platform/auth/better-auth';
 import type { DrizzleDb } from '../../platform/db/drizzle';
-import { rolePermissions } from '../../platform/db/schema';
+import {
+  rolePermissions,
+  tenantFeatureOverrides,
+} from '../../platform/db/schema';
+import { DEFAULT_TENANT_ID } from '../../platform/tenancy/tenant-constants';
+import { TenantFeaturesService } from '../../platform/tenancy/tenant-features';
 import {
   makeBetterAuthTestLayer,
   makeFakeBetterAuthUser,
@@ -208,6 +218,12 @@ describe('AuthService Integration', () => {
             { resource: Resource.DASHBOARD, permission: Permission.READ },
           ],
         });
+        await db.insert(tenantFeatureOverrides).values({
+          tenant_id: DEFAULT_TENANT_ID,
+          feature_key: FeatureKey.SMART_IMPORT,
+          enabled: true,
+          updated_by: 'superadmin-1',
+        });
 
         const layer = buildAuthServiceLayer(TEST_USER_ID);
         const result = await run(
@@ -218,6 +234,11 @@ describe('AuthService Integration', () => {
         expect(result.id).toBe(TEST_USER_ID);
         expect(result.name).toBe('Integration Test User');
         expect(result.email).toBe('integration@example.com');
+        expect(result.planKey).toBe(PlanKey.FREE);
+        expect(result.features).toEqual({
+          ...DEFAULT_FEATURE_STATES,
+          [FeatureKey.SMART_IMPORT]: true,
+        });
         expect(result.roles).toEqual(['Integration Admin']);
         expect(result.permissions[Resource.ROLES]).toEqual(
           expect.arrayContaining([Permission.READ, Permission.WRITE]),
@@ -347,6 +368,7 @@ describe('AuthService Integration', () => {
             Layer.mergeAll(
               dbLayer,
               buildRolesServiceLayer(),
+              TenantFeaturesService.Default.pipe(Layer.provide(dbLayer)),
               buildBetterAuthLayer(TEST_USER_ID),
               makeRequestLayer(),
             ),

--- a/src/effect/modules/auth/service.spec.ts
+++ b/src/effect/modules/auth/service.spec.ts
@@ -10,7 +10,14 @@
 import { describe, expect, it } from '@effect/vitest';
 import { Effect, Layer } from 'effect';
 import { Permission, Resource } from '@stocket/types/auth';
+import {
+  DEFAULT_FEATURE_STATES,
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
 import { makeTestLayer } from '../../testing/test-harness';
+import { TenantFeaturesService } from '../../platform/tenancy/tenant-features';
 import { RolesService, type UserPermissions } from '../roles/service';
 import { AuthService } from './service';
 
@@ -70,12 +77,32 @@ const rolesLayer = (overrides: Partial<RolesService> = {}) =>
     ...overrides,
   });
 
-const serviceLayer = (roles = rolesLayer()) =>
-  AuthService.DefaultWithoutDependencies.pipe(Layer.provide(roles));
+const tenantFeaturesLayer = (overrides: Partial<TenantFeaturesService> = {}) =>
+  makeTestLayer(TenantFeaturesService)({
+    listOverrides: () => Effect.succeed([]),
+    getEffectiveFeatures: () => Effect.succeed(DEFAULT_FEATURE_STATES),
+    getTenantFeatures: () =>
+      Effect.succeed({
+        tenantId: '00000000-0000-4000-8000-000000000001',
+        planKey: PlanKey.FREE,
+        source: EntitlementSource.SYSTEM,
+        features: DEFAULT_FEATURE_STATES,
+        overrides: [],
+        updated_at: null,
+        updated_by: null,
+      }),
+    ...overrides,
+  });
+
+const serviceLayer = (roles = rolesLayer(), features = tenantFeaturesLayer()) =>
+  AuthService.DefaultWithoutDependencies.pipe(
+    Layer.provide(Layer.mergeAll(roles, features)),
+  );
 
 const withService = <A, E, R>(
   body: (svc: AuthService) => Effect.Effect<A, E, R>,
   rolesOverrides?: Partial<RolesService>,
+  featuresOverrides?: Partial<TenantFeaturesService>,
 ): Effect.Effect<A, E, never> =>
   // `requireSession` is replaced by the `vi.mock` above, so its residual
   // `BetterAuthService | HttpServerRequest` requirements are discharged at
@@ -85,7 +112,12 @@ const withService = <A, E, R>(
     const svc = yield* AuthService;
     return yield* body(svc);
   }).pipe(
-    Effect.provide(serviceLayer(rolesLayer(rolesOverrides))),
+    Effect.provide(
+      serviceLayer(
+        rolesLayer(rolesOverrides),
+        tenantFeaturesLayer(featuresOverrides),
+      ),
+    ),
   ) as unknown as Effect.Effect<A, E, never>;
 
 // ---------------------------------------------------------------------------
@@ -113,6 +145,8 @@ describe('AuthService', () => {
               tenantId: '00000000-0000-4000-8000-000000000001',
               tenantName: 'Stocket',
               tenantSlug: 'stocket',
+              planKey: PlanKey.FREE,
+              features: DEFAULT_FEATURE_STATES,
               roles: ['Admin'],
               permissions: {
                 [Resource.ROLES]: [Permission.READ, Permission.WRITE],
@@ -210,6 +244,31 @@ describe('AuthService', () => {
         );
       },
     );
+
+    it.effect('returns effective features from TenantFeaturesService', () => {
+      mockRequireSession.mockReturnValue(Effect.succeed(makeSession()));
+      const features = {
+        ...DEFAULT_FEATURE_STATES,
+        [FeatureKey.SMART_IMPORT]: true,
+      };
+      const getEffectiveFeatures = vi
+        .fn()
+        .mockReturnValue(Effect.succeed(features));
+
+      return withService(
+        (svc) =>
+          Effect.gen(function* () {
+            const result = yield* svc.me();
+
+            expect(getEffectiveFeatures).toHaveBeenCalledWith(
+              '00000000-0000-4000-8000-000000000001',
+            );
+            expect(result.features).toEqual(features);
+          }),
+        undefined,
+        { getEffectiveFeatures },
+      );
+    });
   });
 
   describe('profile', () => {

--- a/src/effect/modules/auth/service.ts
+++ b/src/effect/modules/auth/service.ts
@@ -1,7 +1,9 @@
 import { Effect } from 'effect';
+import { PlanKey } from '@stocket/types/features';
 import { requireSession } from '../../platform/http/session';
 import { makeServiceTracer } from '../../platform/observability/service-tracer';
 import { resolveTenantForSession } from '../../platform/tenancy/tenant-context';
+import { TenantFeaturesService } from '../../platform/tenancy/tenant-features';
 import { RolesService } from '../roles/service';
 import {
   toCurrentUserResponse,
@@ -14,6 +16,7 @@ export class AuthService extends Effect.Service<AuthService>()(
   {
     effect: Effect.gen(function* () {
       const rolesService = yield* RolesService;
+      const tenantFeaturesService = yield* TenantFeaturesService;
       const trace = makeServiceTracer({
         serviceName: 'AuthService',
         module: 'auth',
@@ -30,7 +33,13 @@ export class AuthService extends Effect.Service<AuthService>()(
             session.user.id,
             tenant.tenantId,
           );
-          return toCurrentUserResponse(session, userPermissions, tenant);
+          const features = yield* tenantFeaturesService.getEffectiveFeatures(
+            tenant.tenantId,
+          );
+          return toCurrentUserResponse(session, userPermissions, tenant, {
+            planKey: PlanKey.FREE,
+            features,
+          });
         }),
       );
 
@@ -56,6 +65,6 @@ export class AuthService extends Effect.Service<AuthService>()(
         sessionClaims,
       };
     }),
-    dependencies: [RolesService.Default],
+    dependencies: [RolesService.Default, TenantFeaturesService.Default],
   },
 ) {}

--- a/src/effect/modules/products/import/import.integration.spec.ts
+++ b/src/effect/modules/products/import/import.integration.spec.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { and, eq, isNull } from 'drizzle-orm';
 import { Permission, Resource } from '@stocket/types/auth';
 import {
+  areas,
   inventory,
   locations,
   members,
@@ -142,13 +143,24 @@ async function seedImportWriteRole(userId: string) {
   });
 }
 
-function makeCsvUpload(csv: string, filename: string) {
+function makeCsvUpload(
+  csv: string,
+  filename: string,
+  fields: Record<string, string> = {},
+) {
   const formData = new FormData();
   formData.append('file', new File([csv], filename, { type: 'text/csv' }));
+  Object.entries(fields).forEach(([key, value]) => {
+    formData.append(key, value);
+  });
   return formData;
 }
 
-async function postImport(csv: string, filename = 'products.csv') {
+async function postImport(
+  csv: string,
+  filename = 'products.csv',
+  fields: Record<string, string> = {},
+) {
   await seedImportWriteRole(TEST_USER_ID);
   const { handler, dispose } = makeTestHttpAppHandler({
     session: makeSession(TEST_USER_ID),
@@ -158,7 +170,59 @@ async function postImport(csv: string, filename = 'products.csv') {
     const response = await handler(
       tenantRequest('/api/v1/products/import', {
         method: 'POST',
-        body: makeCsvUpload(csv, filename),
+        body: makeCsvUpload(csv, filename, fields),
+      }),
+    );
+    const body = await response.json();
+    return { status: response.status, body };
+  } finally {
+    await dispose();
+  }
+}
+
+async function postPreview(
+  csv: string,
+  filename = 'products.csv',
+  fields: Record<string, string> = {},
+) {
+  await seedImportWriteRole(TEST_USER_ID);
+  const { handler, dispose } = makeTestHttpAppHandler({
+    session: makeSession(TEST_USER_ID),
+  });
+
+  try {
+    const response = await handler(
+      tenantRequest('/api/v1/products/import/preview', {
+        method: 'POST',
+        body: makeCsvUpload(csv, filename, fields),
+      }),
+    );
+    const body = await response.json();
+    return { status: response.status, body };
+  } finally {
+    await dispose();
+  }
+}
+
+async function postCommit(
+  csv: string,
+  mapping: unknown,
+  filename = 'products.csv',
+  fields: Record<string, string> = {},
+) {
+  await seedImportWriteRole(TEST_USER_ID);
+  const { handler, dispose } = makeTestHttpAppHandler({
+    session: makeSession(TEST_USER_ID),
+  });
+
+  try {
+    const response = await handler(
+      tenantRequest('/api/v1/products/import/commit', {
+        method: 'POST',
+        body: makeCsvUpload(csv, filename, {
+          mapping: JSON.stringify(mapping),
+          ...fields,
+        }),
       }),
     );
     const body = await response.json();
@@ -247,7 +311,8 @@ beforeAll(() => {
 
 describe('POST /api/v1/products/import integration', () => {
   it('imports normalized CSV into products, categories, locations, and inventory', async () => {
-    const response = await postImport(`sku,name,category_path,reorder_point,quantity,location,unit,standard_price,barcode,description,notes,is_active,is_perishable,expiry_date
+    const response =
+      await postImport(`sku,name,category_path,reorder_point,quantity,location,unit,standard_price,barcode,description,notes,is_active,is_perishable,expiry_date
 IMP-001,Imported Gin,Beverages / Spirits,4,9,Main Warehouse,bottle,12.50,123456,Juniper gin,Top shelf,true,false,
 `);
 
@@ -343,6 +408,128 @@ Item,Imported Tonic,SORT-001,Drinks,Mixers,12,Bar,can,2,1.50,,QR2,Sortly notes,2
     expect(stock!.expiry_date).toBeInstanceOf(Date);
   });
 
+  it('previews Sortly CSV without writing products, locations, or inventory', async () => {
+    const response = await postPreview(
+      `Entry Type,Entry Name,SID,Primary Folder,Quantity,Location,Photo1
+Folder,Amenities,,,,,
+Item,Imported Soap,SORT-PREVIEW-1,Amenities,6,Bay J - Shelf 4,https://example.com/photo.jpg
+`,
+      'sortly-preview.csv',
+      {
+        import_type: 'sortly-items',
+        known_locations: JSON.stringify(['Bay J']),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      detectedFormat: 'sortly-items',
+      stats: {
+        totalRows: 2,
+        importableRows: 1,
+        itemRows: 1,
+        folderRows: 1,
+        itemsWithPhotos: 1,
+      },
+      suggestedMapping: {
+        locationMappings: [
+          {
+            source: 'Bay J - Shelf 4',
+            locationName: 'Bay J',
+            areaPath: 'Shelf 4',
+          },
+        ],
+      },
+      issues: [],
+    });
+
+    await expect(findProductBySku('SORT-PREVIEW-1')).resolves.toBeNull();
+    const writtenLocations = await db
+      .select()
+      .from(locations)
+      .where(
+        and(
+          eq(locations.tenant_id, DEFAULT_TENANT_ID),
+          eq(locations.name, 'Bay J'),
+        ),
+      );
+    expect(writtenLocations).toHaveLength(0);
+  });
+
+  it('commits approved mappings into nested areas and area-scoped inventory', async () => {
+    const mapping = {
+      categoryMappings: [{ source: 'Amenities', target: 'Amenities' }],
+      locationMappings: [
+        {
+          source: 'Bay J - Shelf 4',
+          locationName: 'Bay J',
+          areaPath: 'Shelf 4',
+        },
+      ],
+    };
+    const response = await postCommit(
+      `Entry Type,Entry Name,SID,Primary Folder,Quantity,Location
+Item,Imported Soap,SORT-COMMIT-1,Amenities,6,Bay J - Shelf 4
+`,
+      mapping,
+      'sortly-commit.csv',
+      { import_type: 'sortly-items' },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      categoriesCreated: 1,
+      locationsCreated: 1,
+      areasCreated: 1,
+      productsCreated: 1,
+      inventoryRecordsCreated: 1,
+      rowsSkipped: 0,
+      errors: [],
+    });
+
+    const product = await findProductBySku('SORT-COMMIT-1');
+    expect(product).toMatchObject({ name: 'Imported Soap' });
+
+    const [location] = await db
+      .select()
+      .from(locations)
+      .where(
+        and(
+          eq(locations.tenant_id, DEFAULT_TENANT_ID),
+          eq(locations.name, 'Bay J'),
+        ),
+      )
+      .limit(1);
+    expect(location).toBeTruthy();
+
+    const [area] = await db
+      .select()
+      .from(areas)
+      .where(
+        and(
+          eq(areas.tenant_id, DEFAULT_TENANT_ID),
+          eq(areas.location_id, location!.id),
+          eq(areas.name, 'Shelf 4'),
+        ),
+      )
+      .limit(1);
+    expect(area).toBeTruthy();
+
+    const [stock] = await db
+      .select()
+      .from(inventory)
+      .where(
+        and(
+          eq(inventory.tenant_id, DEFAULT_TENANT_ID),
+          eq(inventory.product_id, product!.id),
+          eq(inventory.location_id, location!.id),
+          eq(inventory.area_id, area!.id),
+        ),
+      )
+      .limit(1);
+    expect(stock).toMatchObject({ quantity: 6 });
+  });
+
   it('does not update products from another tenant with the same SKU', async () => {
     const otherTenantId = randomUUID();
     const otherCategory = await seedCategory(db, {
@@ -394,7 +581,8 @@ SHARED-SKU,Default Tenant Product,Default Category,3,Default Location
       productSku: 'AREA-SKU',
     });
 
-    const response = await postImport(`sku,name,category_path,reorder_point,quantity,location
+    const response =
+      await postImport(`sku,name,category_path,reorder_point,quantity,location
 AREA-SKU,Area Product,Area Category,10,8,Area Location
 `);
 
@@ -425,7 +613,8 @@ AREA-SKU,Area Product,Area Category,10,8,Area Location
       rootQuantity: 4,
     });
 
-    const response = await postImport(`sku,name,category_path,reorder_point,quantity,location
+    const response =
+      await postImport(`sku,name,category_path,reorder_point,quantity,location
 MIXED-AREA-SKU,Mixed Area Product,Mixed Area Category,10,8,Mixed Area Location
 `);
 

--- a/src/effect/modules/products/import/repository.ts
+++ b/src/effect/modules/products/import/repository.ts
@@ -4,6 +4,7 @@ import { makeTryAsync } from '../../../platform/effect/try-async';
 import { DrizzleDatabase } from '../../../platform/db/drizzle';
 import { TenantQuery } from '../../../platform/tenancy/tenant-query';
 import {
+  areas,
   categories,
   inventory,
   locations,
@@ -94,6 +95,37 @@ export class ProductImportRepository extends Effect.Service<ProductImportReposit
           });
         });
 
+      const findAreaByNameLocationAndParent = (
+        name: string,
+        locationId: string,
+        parentId: string | null,
+      ) =>
+        Effect.gen(function* () {
+          const conditions: SQL[] = [
+            eq(areas.name, name),
+            eq(areas.location_id, locationId),
+          ];
+          conditions.push(
+            parentId === null
+              ? isNull(areas.parent_id)
+              : eq(areas.parent_id, parentId),
+          );
+          const where = yield* tenantQuery.whereTenant(areas, ...conditions);
+          return yield* tryAsync('find import area', async () => {
+            const rows = await db.select().from(areas).where(where).limit(1);
+            return rows[0] ?? null;
+          });
+        });
+
+      const createArea = (data: typeof areas.$inferInsert) =>
+        Effect.gen(function* () {
+          const values = yield* tenantQuery.insertValues(data);
+          return yield* tryAsync('create import area', async () => {
+            const rows = await db.insert(areas).values(values).returning();
+            return rows[0]!;
+          });
+        });
+
       const findProductBySku = (sku: string) =>
         Effect.gen(function* () {
           const where = yield* tenantQuery.whereTenant(
@@ -101,11 +133,7 @@ export class ProductImportRepository extends Effect.Service<ProductImportReposit
             eq(products.sku, sku),
           );
           return yield* tryAsync('find import product by sku', async () => {
-            const rows = await db
-              .select()
-              .from(products)
-              .where(where)
-              .limit(1);
+            const rows = await db.select().from(products).where(where).limit(1);
             return rows[0] ?? null;
           });
         });
@@ -136,15 +164,20 @@ export class ProductImportRepository extends Effect.Service<ProductImportReposit
           });
         });
 
-      const findRootInventoryByProductAndLocation = (
+      const findInventoryByProductLocationArea = (
         productId: string,
         locationId: string,
+        areaId: string | null,
       ) =>
         Effect.gen(function* () {
+          const areaCondition =
+            areaId === null
+              ? isNull(inventory.area_id)
+              : eq(inventory.area_id, areaId);
           const where = yield* tenantQuery.whereTenant(
             inventory,
             ...inventoryProductLocationConditions(productId, locationId),
-            isNull(inventory.area_id),
+            areaCondition,
           );
           return yield* tryAsync('find import inventory', async () => {
             const rows = await db
@@ -155,6 +188,11 @@ export class ProductImportRepository extends Effect.Service<ProductImportReposit
             return rows[0] ?? null;
           });
         });
+
+      const findRootInventoryByProductAndLocation = (
+        productId: string,
+        locationId: string,
+      ) => findInventoryByProductLocationArea(productId, locationId, null);
 
       const hasAreaScopedInventoryForProductAndLocation = (
         productId: string,
@@ -207,9 +245,12 @@ export class ProductImportRepository extends Effect.Service<ProductImportReposit
         createCategory,
         findLocationByName,
         createLocation,
+        findAreaByNameLocationAndParent,
+        createArea,
         findProductBySku,
         createProduct,
         updateProduct,
+        findInventoryByProductLocationArea,
         findRootInventoryByProductAndLocation,
         hasAreaScopedInventoryForProductAndLocation,
         createInventory,

--- a/src/effect/modules/products/import/service.spec.ts
+++ b/src/effect/modules/products/import/service.spec.ts
@@ -4,11 +4,16 @@ import { makeTestLayer } from '../../../testing/utils';
 import { ProductImportRepository } from './repository';
 import {
   detectProductImportFormat,
+  makeProductImportPreview,
   normalizeProductImportRecords,
   parseDate,
+  parseProductImportMappingJson,
   parseProductImportNumber,
+  parseCsvContent,
+  suggestImportMapping,
 } from './utils';
 import { ProductImportService } from './service';
+import { PhotosService } from '../../photos/service';
 
 const TEST_USER_ID = '00000000-0000-4000-a000-000000000001';
 
@@ -26,22 +31,29 @@ const makeRow = <T extends Record<string, unknown>>(overrides: T) =>
 
 function makeInMemoryRepository() {
   let nextId = 1;
+  const areas: any[] = [];
   const categories: any[] = [];
   const locations: any[] = [];
   const productsBySku = new Map<string, any>();
   const inventoryByKey = new Map<string, any>();
 
   const id = (prefix: string) => `${prefix}-${nextId++}`;
+  const inventoryKey = (
+    productId: string,
+    locationId: string,
+    areaId: string | null = null,
+  ) => `${productId}:${locationId}:${areaId ?? 'root'}`;
 
   const repo = {
-    findCategoryByNameAndParent: vi.fn((name: string, parentId: string | null) =>
-      Effect.sync(
-        () =>
-          categories.find(
-            (category) =>
-              category.name === name && category.parent_id === parentId,
-          ) ?? null,
-      ),
+    findCategoryByNameAndParent: vi.fn(
+      (name: string, parentId: string | null) =>
+        Effect.sync(
+          () =>
+            categories.find(
+              (category) =>
+                category.name === name && category.parent_id === parentId,
+            ) ?? null,
+        ),
     ),
     createCategory: vi.fn((data: any) =>
       Effect.sync(() => {
@@ -59,6 +71,25 @@ function makeInMemoryRepository() {
       Effect.sync(() => {
         const row = makeRow({ id: id('loc'), ...data } as any);
         locations.push(row);
+        return row;
+      }),
+    ),
+    findAreaByNameLocationAndParent: vi.fn(
+      (name: string, locationId: string, parentId: string | null) =>
+        Effect.sync(
+          () =>
+            areas.find(
+              (area) =>
+                area.name === name &&
+                area.location_id === locationId &&
+                area.parent_id === parentId,
+            ) ?? null,
+        ),
+    ),
+    createArea: vi.fn((data: any) =>
+      Effect.sync(() => {
+        const row = makeRow({ id: id('area'), ...data } as any);
+        areas.push(row);
         return row;
       }),
     ),
@@ -88,10 +119,18 @@ function makeInMemoryRepository() {
         return null;
       }),
     ),
+    findInventoryByProductLocationArea: vi.fn(
+      (productId: string, locationId: string, areaId: string | null) =>
+        Effect.sync(
+          () =>
+            inventoryByKey.get(inventoryKey(productId, locationId, areaId)) ??
+            null,
+        ),
+    ),
     findRootInventoryByProductAndLocation: vi.fn(
       (productId: string, locationId: string) =>
         Effect.sync(
-          () => inventoryByKey.get(`${productId}:${locationId}`) ?? null,
+          () => inventoryByKey.get(inventoryKey(productId, locationId)) ?? null,
         ),
     ),
     hasAreaScopedInventoryForProductAndLocation: vi.fn(() =>
@@ -100,7 +139,10 @@ function makeInMemoryRepository() {
     createInventory: vi.fn((data: any) =>
       Effect.sync(() => {
         const row = makeRow({ id: id('inv'), ...data } as any);
-        inventoryByKey.set(`${row.product_id}:${row.location_id}`, row);
+        inventoryByKey.set(
+          inventoryKey(row.product_id, row.location_id, row.area_id ?? null),
+          row,
+        );
         return row;
       }),
     ),
@@ -120,14 +162,49 @@ function makeInMemoryRepository() {
 
   return {
     repo: repo as Partial<ProductImportRepository>,
+    areas,
     categories,
     locations,
     productsBySku,
     inventoryByKey,
+    inventoryKey,
   };
 }
 
 type InMemoryImportState = ReturnType<typeof makeInMemoryRepository>;
+
+const makeImportServiceLayer = (repo: Partial<ProductImportRepository>) =>
+  ProductImportService.DefaultWithoutDependencies.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        makeTestLayer(ProductImportRepository)(repo),
+        makeTestLayer(PhotosService)({
+          uploadPhoto: vi.fn(() =>
+            Effect.succeed({
+              id: 'photo-1',
+              product_id: 'prod-1',
+              filename: 'photo.jpg',
+              mimetype: 'image/jpeg',
+              size: 100,
+              storage_path: 'products/prod-1/photos/photo.jpg',
+              display_order: 0,
+              uploaded_by: null,
+              created_at: new Date('2026-01-01T00:00:00.000Z'),
+            }),
+          ),
+          findByProductId: vi.fn(() => Effect.succeed([])),
+          getFile: vi.fn(() =>
+            Effect.succeed({
+              bytes: new Uint8Array(),
+              mimetype: 'image/jpeg',
+              filename: 'photo.jpg',
+            }),
+          ),
+          deletePhoto: vi.fn(() => Effect.void),
+        }),
+      ),
+    ),
+  );
 
 const seedExistingProductWithRootInventory = (
   state: InMemoryImportState,
@@ -174,7 +251,7 @@ const seedExistingProductWithRootInventory = (
     } as any),
   );
   state.inventoryByKey.set(
-    'prod-1:loc-1',
+    state.inventoryKey('prod-1', 'loc-1'),
     makeRow({
       id: 'inv-1',
       product_id: 'prod-1',
@@ -189,8 +266,9 @@ const seedExistingProductWithRootInventory = (
   );
 
   if (options.hasAreaScopedInventory) {
-    (state.repo.hasAreaScopedInventoryForProductAndLocation as any)
-      .mockReturnValue(Effect.succeed(true));
+    (
+      state.repo.hasAreaScopedInventoryForProductAndLocation as any
+    ).mockReturnValue(Effect.succeed(true));
   }
 };
 
@@ -199,12 +277,14 @@ const runImport = (
   importType: 'auto' | 'normalized-products' | 'sortly-items' = 'auto',
 ) => {
   const { repo } = makeInMemoryRepository();
-  const layer = ProductImportService.DefaultWithoutDependencies.pipe(
-    Layer.provide(makeTestLayer(ProductImportRepository)(repo)),
-  );
+  const layer = makeImportServiceLayer(repo);
   return Effect.runPromise(
     Effect.flatMap(ProductImportService, (service) =>
-      service.importFromCsvContent({ content, importType, userId: TEST_USER_ID }),
+      service.importFromCsvContent({
+        content,
+        importType,
+        userId: TEST_USER_ID,
+      }),
     ).pipe(Effect.provide(layer)),
   );
 };
@@ -213,15 +293,21 @@ const runImportWithState = async (
   content: string,
   importType: 'auto' | 'normalized-products' | 'sortly-items' = 'auto',
   setup?: (state: ReturnType<typeof makeInMemoryRepository>) => void,
+  options: Partial<
+    Parameters<ProductImportService['importFromCsvContent']>[0]
+  > = {},
 ) => {
   const state = makeInMemoryRepository();
   setup?.(state);
-  const layer = ProductImportService.DefaultWithoutDependencies.pipe(
-    Layer.provide(makeTestLayer(ProductImportRepository)(state.repo)),
-  );
+  const layer = makeImportServiceLayer(state.repo);
   const result = await Effect.runPromise(
     Effect.flatMap(ProductImportService, (service) =>
-      service.importFromCsvContent({ content, importType, userId: TEST_USER_ID }),
+      service.importFromCsvContent({
+        content,
+        importType,
+        userId: TEST_USER_ID,
+        ...options,
+      }),
     ).pipe(Effect.provide(layer)),
   );
   return { result, state };
@@ -232,13 +318,15 @@ const failImport = (
   importType: 'auto' | 'normalized-products' | 'sortly-items' = 'auto',
 ) => {
   const { repo } = makeInMemoryRepository();
-  const layer = ProductImportService.DefaultWithoutDependencies.pipe(
-    Layer.provide(makeTestLayer(ProductImportRepository)(repo)),
-  );
+  const layer = makeImportServiceLayer(repo);
   return Effect.runPromise(
     Effect.flip(
       Effect.flatMap(ProductImportService, (service) =>
-        service.importFromCsvContent({ content, importType, userId: TEST_USER_ID }),
+        service.importFromCsvContent({
+          content,
+          importType,
+          userId: TEST_USER_ID,
+        }),
       ).pipe(Effect.provide(layer)),
     ),
   );
@@ -351,6 +439,98 @@ describe('ProductImportService', () => {
     expect(parseProductImportNumber('1,234.56')).toBe(1234.56);
   });
 
+  it('builds a preview without writing rows', () => {
+    const parsed =
+      parseCsvContent(`Entry Type,Entry Name,SID,Primary Folder,Quantity,Location,Photo1,Barcode/QR1-Data
+Folder,Amenities,,,,,,
+Item,Shampoo,SORT-1,Amenities,8,Bay J - Shelf 4,https://example.com/photo.jpg,123
+Item,Comb,SORT-2,,3,,,
+`);
+    const format = detectProductImportFormat(parsed.headers, 'sortly-items');
+    expect(format).toBe('sortly-items');
+
+    const preview = makeProductImportPreview(parsed, format!, {
+      knownLocations: ['Bay J'],
+      useLlm: true,
+    });
+
+    expect(preview.stats).toMatchObject({
+      totalRows: 3,
+      importableRows: 2,
+      itemRows: 2,
+      folderRows: 1,
+      rowsMissingLocation: 1,
+      rowsMissingCategory: 1,
+      itemsWithPhotos: 1,
+      itemsWithBarcodes: 1,
+    });
+    expect(preview.locations).toEqual([{ value: 'Bay J - Shelf 4', count: 1 }]);
+    expect(preview.suggestedMapping.locationMappings).toEqual([
+      {
+        source: 'Bay J - Shelf 4',
+        locationName: 'Bay J',
+        areaPath: 'Shelf 4',
+      },
+    ]);
+    expect(preview.warnings).toEqual([
+      {
+        warning:
+          'AI mapping suggestions are not configured in this environment; deterministic suggestions were used.',
+      },
+    ]);
+  });
+
+  it('suggests location and area mappings from Sortly shelf strings', () => {
+    const [row] = normalizeProductImportRecords(
+      [
+        {
+          'Entry Type': 'Item',
+          'Entry Name': 'Soap',
+          SID: 'SORT-1',
+          'Primary Folder': 'Amenities',
+          Location: 'Store Room - Box 6',
+        },
+      ],
+      'sortly-items',
+    );
+
+    expect(suggestImportMapping([row!]).locationMappings).toEqual([
+      {
+        source: 'Store Room - Box 6',
+        locationName: 'Store Room',
+        areaPath: 'Box 6',
+      },
+    ]);
+  });
+
+  it('parses valid import mapping JSON and rejects invalid shapes', () => {
+    expect(
+      parseProductImportMappingJson(
+        JSON.stringify({
+          categoryMappings: [{ source: 'Raw', target: 'Final / Path' }],
+          locationMappings: [
+            {
+              source: 'Bay J - Shelf 4',
+              locationName: 'Bay J',
+              areaPath: 'Shelf 4',
+            },
+          ],
+        }),
+      ),
+    ).toEqual({
+      categoryMappings: [{ source: 'Raw', target: 'Final / Path' }],
+      locationMappings: [
+        {
+          source: 'Bay J - Shelf 4',
+          locationName: 'Bay J',
+          areaPath: 'Shelf 4',
+        },
+      ],
+    });
+    expect(parseProductImportMappingJson('{not json')).toBeNull();
+    expect(parseProductImportMappingJson('{"categoryMappings":[]}')).toBeNull();
+  });
+
   it('rejects unsupported CSV headers', async () => {
     const error = await failImport('foo,bar\n1,2\n');
     expect(error).toMatchObject({ _tag: 'ProductImportUnsupportedFormat' });
@@ -390,7 +570,8 @@ SKU-1,Second Name,Food,Bar
   });
 
   it('allows consistent duplicate SKUs for multiple locations', async () => {
-    const { result, state } = await runImportWithState(`sku,name,category_path,location,quantity,reorder_point
+    const { result, state } =
+      await runImportWithState(`sku,name,category_path,location,quantity,reorder_point
 SKU-1,Same Product,Food,Warehouse,5,1
 SKU-1,Same Product,Food,Bar,7,1
 `);
@@ -403,8 +584,89 @@ SKU-1,Same Product,Food,Bar,7,1
     expect((state.repo.updateProduct as any).mock.calls).toHaveLength(0);
   });
 
+  it('commits approved location mappings into nested areas and area inventory', async () => {
+    const { result, state } = await runImportWithState(
+      `Entry Type,Entry Name,SID,Primary Folder,Quantity,Location
+Item,Guest Soap,SORT-1,Amenities,8,Bay J - Shelf 4
+`,
+      'sortly-items',
+      undefined,
+      {
+        mapping: {
+          categoryMappings: [
+            { source: 'Amenities', target: 'Amenities / Bath' },
+          ],
+          locationMappings: [
+            {
+              source: 'Bay J - Shelf 4',
+              locationName: 'Bay J',
+              areaPath: 'Shelf 4',
+            },
+          ],
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      categoriesCreated: 2,
+      locationsCreated: 1,
+      areasCreated: 1,
+      productsCreated: 1,
+      inventoryRecordsCreated: 1,
+      rowsSkipped: 0,
+      errors: [],
+    });
+    const location = state.locations[0]!;
+    const area = state.areas[0]!;
+    expect(location).toMatchObject({ name: 'Bay J' });
+    expect(area).toMatchObject({
+      name: 'Shelf 4',
+      location_id: location.id,
+      parent_id: null,
+    });
+    const product = state.productsBySku.get('SORT-1');
+    expect(product).toMatchObject({ name: 'Guest Soap' });
+    expect(
+      state.inventoryByKey.get(
+        state.inventoryKey(product.id, location.id, area.id),
+      ),
+    ).toMatchObject({
+      quantity: 8,
+      area_id: area.id,
+    });
+    expect(
+      state.inventoryByKey.get(state.inventoryKey(product.id, location.id)),
+    ).toBeUndefined();
+  });
+
+  it('reports missing mappings during commit without guessing', async () => {
+    const { result } = await runImportWithState(
+      `Entry Type,Entry Name,SID,Primary Folder,Quantity,Location
+Item,Guest Soap,SORT-1,Amenities,8,Bay J - Shelf 4
+`,
+      'sortly-items',
+      undefined,
+      {
+        mapping: {
+          categoryMappings: [{ source: 'Amenities', target: 'Amenities' }],
+          locationMappings: [],
+        },
+      },
+    );
+
+    expect(result.rowsSkipped).toBe(1);
+    expect(result.productsCreated).toBe(0);
+    expect(result.errors).toEqual([
+      {
+        row: 2,
+        error: 'Missing location mapping for "Bay J - Shelf 4"',
+      },
+    ]);
+  });
+
   it('reports normalized duplicate SKUs with conflicting reorder points', async () => {
-    const result = await runImport(`sku,name,category_path,location,quantity,reorder_point
+    const result =
+      await runImport(`sku,name,category_path,location,quantity,reorder_point
 SKU-1,Same Product,Food,Warehouse,5,1
 SKU-1,Same Product,Food,Bar,7,2
 `);
@@ -454,7 +716,9 @@ SKU-1,Same Product,Food,Warehouse,8
     );
 
     expect(result.inventoryRecordsUpdated).toBe(1);
-    expect(state.inventoryByKey.get('prod-1:loc-1')).toMatchObject({
+    expect(
+      state.inventoryByKey.get(state.inventoryKey('prod-1', 'loc-1')),
+    ).toMatchObject({
       quantity: 8,
       expiry_date: null,
     });
@@ -510,7 +774,9 @@ SKU-1,Changed Product,Drinks,Warehouse,8
       name: 'Same Product',
       category_id: 'cat-1',
     });
-    expect(state.inventoryByKey.get('prod-1:loc-1')).toMatchObject({
+    expect(
+      state.inventoryByKey.get(state.inventoryKey('prod-1', 'loc-1')),
+    ).toMatchObject({
       quantity: 4,
     });
   });

--- a/src/effect/modules/products/import/service.ts
+++ b/src/effect/modules/products/import/service.ts
@@ -1,526 +1,39 @@
 import { Effect } from 'effect';
-import { LocationType } from '@stocket/types/locations';
 import type {
   ImportCaches,
-  ImportAreaRow,
-  ImportCategoryRow,
-  ImportLocationRow,
   ImportProductRow,
   ImportProductsFromCsvOptions,
   NormalizedProductImportRow,
   PreviewProductsFromCsvOptions,
   ProductImportCommitResultDto,
   ProductImportPreviewDto,
-  ProductImportResultDto,
-  ProductImportValues,
 } from './types';
 import {
   applyProductImportMapping,
-  detectProductImportFormat,
   findConflictingDuplicateSkuRows,
   formatImportError,
+  importProductImportRow,
   makeEmptyProductImportCommitResult,
   makeProductImportMappingLookups,
   makeProductImportPreview,
-  normalizeCategoryPath,
   normalizeProductImportRecords,
-  nullableText,
-  parseBoolean,
-  parseCsvContent,
   parseDate,
-  parseInteger,
-  parseProductImportNumber,
-  productValuesMatch,
+  parseProductImportRequest,
   pushRowError,
-  pushWarning,
 } from './utils';
-import {
+import type {
   ProductImportCsvParseFailed,
   ProductImportUnsupportedFormat,
-  ProductsInfrastructureError,
 } from '../products.errors';
 import { ProductImportRepository } from './repository';
-import { PhotosService } from '../../photos/service';
+import { PhotosService as PhotosServiceTag } from '../../photos/service';
 
 export class ProductImportService extends Effect.Service<ProductImportService>()(
   '@stocket/effect/products/ProductImportService',
   {
     effect: Effect.gen(function* () {
       const repository = yield* ProductImportRepository;
-      const photosService = yield* PhotosService;
-
-      const getOrCreateCategoryPath = (
-        categoryPath: string,
-        caches: ImportCaches,
-        result: ProductImportResultDto,
-      ) =>
-        Effect.gen(function* () {
-          const parts = normalizeCategoryPath(categoryPath)
-            .split('/')
-            .map((part) => part.trim())
-            .filter(Boolean);
-
-          if (parts.length === 0) {
-            return yield* Effect.fail(
-              new ProductsInfrastructureError({
-                action: 'resolve import category path',
-                messageKey: 'products.repositoryFailed',
-              }),
-            );
-          }
-
-          let parentId: string | null = null;
-          let categoryId = '';
-
-          for (const part of parts) {
-            const cacheKey = `${parentId ?? 'root'}:${part}`;
-            const cached = caches.categories.get(cacheKey);
-            if (cached) {
-              parentId = cached;
-              categoryId = cached;
-              continue;
-            }
-
-            let category: ImportCategoryRow | null =
-              yield* repository.findCategoryByNameAndParent(part, parentId);
-
-            if (!category) {
-              category = yield* repository.createCategory({
-                name: part,
-                parent_id: parentId,
-                description: 'Imported via product import',
-              });
-              result.categoriesCreated++;
-            }
-
-            caches.categories.set(cacheKey, category.id);
-            parentId = category.id;
-            categoryId = category.id;
-          }
-
-          return categoryId;
-        });
-
-      const getOrCreateLocation = (
-        locationName: string,
-        caches: ImportCaches,
-        result: ProductImportCommitResultDto,
-      ) =>
-        Effect.gen(function* () {
-          const name = locationName.trim();
-          if (name === '') return null;
-
-          const cached = caches.locations.get(name);
-          if (cached) return cached;
-
-          let location: ImportLocationRow | null =
-            yield* repository.findLocationByName(name);
-
-          if (!location) {
-            location = yield* repository.createLocation({
-              name,
-              type: LocationType.WAREHOUSE,
-              address: '',
-              contact_person: '',
-              phone: '',
-              is_active: true,
-            });
-            result.locationsCreated++;
-          }
-
-          caches.locations.set(name, location.id);
-          return location.id;
-        });
-
-      const getOrCreateAreaPath = (
-        locationId: string,
-        areaPath: string,
-        caches: ImportCaches,
-        result: ProductImportCommitResultDto,
-      ) =>
-        Effect.gen(function* () {
-          const parts = areaPath
-            .split('/')
-            .map((part) => part.trim())
-            .filter(Boolean);
-          if (parts.length === 0) return null;
-
-          let parentId: string | null = null;
-          let areaId = '';
-
-          for (const part of parts) {
-            const cacheKey = `${locationId}:${parentId ?? 'root'}:${part}`;
-            const cached = caches.areas.get(cacheKey);
-            if (cached) {
-              parentId = cached;
-              areaId = cached;
-              continue;
-            }
-
-            let area: ImportAreaRow | null =
-              yield* repository.findAreaByNameLocationAndParent(
-                part,
-                locationId,
-                parentId,
-              );
-
-            if (!area) {
-              area = yield* repository.createArea({
-                location_id: locationId,
-                parent_id: parentId,
-                name: part,
-                code: '',
-                description: 'Imported via product import',
-                is_active: true,
-              });
-              result.areasCreated++;
-            }
-
-            caches.areas.set(cacheKey, area.id);
-            parentId = area.id;
-            areaId = area.id;
-          }
-
-          return areaId;
-        });
-
-      const upsertProduct = (
-        row: NormalizedProductImportRow,
-        categoryId: string,
-        caches: ImportCaches,
-        result: ProductImportResultDto,
-        expiryDate: Date | null,
-        userId: string,
-      ) =>
-        Effect.gen(function* () {
-          const updatedBy = userId;
-          const cached = caches.products.get(row.sku);
-          if (cached) return cached;
-
-          const values: ProductImportValues = {
-            name: row.name,
-            description: nullableText(row.description),
-            category_id: categoryId,
-            unit: nullableText(row.unit),
-            barcode: nullableText(row.barcode),
-            standard_price: parseProductImportNumber(row.standard_price),
-            reorder_point: parseInteger(row.reorder_point, 0),
-            is_active: parseBoolean(row.is_active, true),
-            is_perishable: parseBoolean(row.is_perishable, Boolean(expiryDate)),
-            notes: nullableText(row.notes),
-          };
-
-          const existing = yield* repository.findProductBySku(row.sku);
-          if (!existing) {
-            const product = yield* repository.createProduct({
-              sku: row.sku,
-              ...values,
-              created_by: updatedBy,
-              updated_by: updatedBy,
-            });
-            result.productsCreated++;
-            caches.products.set(row.sku, product);
-            return product;
-          }
-
-          if (productValuesMatch(existing, values)) {
-            caches.products.set(row.sku, existing);
-            return existing;
-          }
-
-          const product = yield* repository.updateProduct(existing.id, {
-            ...values,
-            updated_by: updatedBy,
-          });
-          if (!product) {
-            return yield* Effect.fail(
-              new ProductsInfrastructureError({
-                action: 'update import product',
-                messageKey: 'products.repositoryFailed',
-              }),
-            );
-          }
-          result.productsUpdated++;
-          caches.products.set(row.sku, product);
-          return product;
-        });
-
-      const upsertInventory = (
-        product: ImportProductRow,
-        locationId: string | null,
-        areaId: string | null,
-        row: NormalizedProductImportRow,
-        result: ProductImportCommitResultDto,
-        expiryDate: Date | null,
-      ) =>
-        Effect.gen(function* () {
-          if (!locationId) return;
-
-          const existing = yield* repository.findInventoryByProductLocationArea(
-            product.id,
-            locationId,
-            areaId,
-          );
-          const quantity = parseInteger(row.quantity, 0);
-          if (areaId === null) {
-            const hasAreaScopedInventory =
-              yield* repository.hasAreaScopedInventoryForProductAndLocation(
-                product.id,
-                locationId,
-              );
-            if (hasAreaScopedInventory) {
-              return yield* Effect.fail(
-                new ProductsInfrastructureError({
-                  action: 'import root inventory with area-scoped inventory',
-                  messageKey: 'products.importAreaScopedInventoryConflict',
-                }),
-              );
-            }
-          }
-
-          if (!existing) {
-            yield* repository.createInventory({
-              product_id: product.id,
-              location_id: locationId,
-              area_id: areaId,
-              quantity,
-              expiry_date: expiryDate,
-            });
-            result.inventoryRecordsCreated++;
-            return;
-          }
-
-          const inventory = yield* repository.updateInventory(existing.id, {
-            quantity,
-            expiry_date: expiryDate,
-          });
-          if (!inventory) {
-            return yield* Effect.fail(
-              new ProductsInfrastructureError({
-                action: 'update import inventory',
-                messageKey: 'products.repositoryFailed',
-              }),
-            );
-          }
-          result.inventoryRecordsUpdated++;
-        });
-
-      const importPhotosForProduct = (
-        product: ImportProductRow,
-        row: NormalizedProductImportRow,
-        result: ProductImportCommitResultDto,
-        userId: string,
-        importedPhotoProducts: Set<string>,
-      ) =>
-        Effect.gen(function* () {
-          if (
-            row.photo_urls.length === 0 ||
-            importedPhotoProducts.has(product.id)
-          ) {
-            return;
-          }
-          importedPhotoProducts.add(product.id);
-
-          for (const photoUrl of row.photo_urls) {
-            const response = yield* Effect.tryPromise({
-              try: () => fetch(photoUrl),
-              catch: (cause) => cause,
-            }).pipe(
-              Effect.catchAll((cause) =>
-                Effect.sync(() => {
-                  pushWarning(
-                    result,
-                    `Failed to download Sortly photo ${photoUrl}: ${formatImportError(cause)}`,
-                    row.sourceRow,
-                  );
-                  return null;
-                }),
-              ),
-            );
-            if (!response) continue;
-
-            if (!response.ok) {
-              pushWarning(
-                result,
-                `Failed to download Sortly photo ${photoUrl}: HTTP ${response.status}`,
-                row.sourceRow,
-              );
-              continue;
-            }
-
-            const contentType =
-              response.headers.get('content-type') ??
-              'application/octet-stream';
-            const arrayBuffer = yield* Effect.tryPromise({
-              try: () => response.arrayBuffer(),
-              catch: (cause) => cause,
-            }).pipe(
-              Effect.catchAll((cause) =>
-                Effect.sync(() => {
-                  pushWarning(
-                    result,
-                    `Failed to read Sortly photo ${photoUrl}: ${formatImportError(cause)}`,
-                    row.sourceRow,
-                  );
-                  return null;
-                }),
-              ),
-            );
-            if (!arrayBuffer) continue;
-
-            const buffer = Buffer.from(arrayBuffer);
-            const filename =
-              photoUrl.split('/').pop()?.split('?')[0] || 'sortly-photo';
-            yield* photosService
-              .uploadPhoto(
-                product.id,
-                {
-                  originalname: filename,
-                  mimetype: contentType,
-                  size: buffer.length,
-                  buffer,
-                },
-                userId,
-              )
-              .pipe(
-                Effect.match({
-                  onFailure: (error) => {
-                    pushWarning(
-                      result,
-                      `Failed to import Sortly photo ${photoUrl}: ${formatImportError(error)}`,
-                      row.sourceRow,
-                    );
-                  },
-                  onSuccess: () => {
-                    result.photosImported++;
-                  },
-                }),
-              );
-          }
-        });
-
-      const validateRootInventoryImport = (
-        row: NormalizedProductImportRow,
-        caches: ImportCaches,
-      ) =>
-        Effect.gen(function* () {
-          const locationName = row.location.trim();
-          if (locationName === '' || row.area_path.trim() !== '') return;
-
-          const cachedProduct = caches.products.get(row.sku);
-          let product = cachedProduct ?? null;
-          if (!product) {
-            product = yield* repository.findProductBySku(row.sku);
-          }
-          if (!product) return;
-
-          let locationId = caches.locations.get(locationName) ?? null;
-          if (!locationId) {
-            const location = yield* repository.findLocationByName(locationName);
-            locationId = location?.id ?? null;
-          }
-          if (!locationId) return;
-
-          const hasAreaScopedInventory =
-            yield* repository.hasAreaScopedInventoryForProductAndLocation(
-              product.id,
-              locationId,
-            );
-          if (hasAreaScopedInventory) {
-            return yield* Effect.fail(
-              new ProductsInfrastructureError({
-                action: 'import root inventory with area-scoped inventory',
-                messageKey: 'products.importAreaScopedInventoryConflict',
-              }),
-            );
-          }
-        });
-
-      const importRow = (
-        row: NormalizedProductImportRow,
-        caches: ImportCaches,
-        result: ProductImportCommitResultDto,
-        expiryDate: Date | null,
-        userId: string,
-        importedPhotoProducts: Set<string>,
-        importPhotos: boolean,
-      ) =>
-        Effect.gen(function* () {
-          if (row.area_path.trim() !== '' && row.location.trim() === '') {
-            return yield* Effect.fail(
-              new Error('Cannot import area_path without location'),
-            );
-          }
-
-          yield* validateRootInventoryImport(row, caches);
-          const categoryId = yield* getOrCreateCategoryPath(
-            row.category_path,
-            caches,
-            result,
-          );
-          const product = yield* upsertProduct(
-            row,
-            categoryId,
-            caches,
-            result,
-            expiryDate,
-            userId,
-          );
-          const locationId = yield* getOrCreateLocation(
-            row.location,
-            caches,
-            result,
-          );
-          const areaId = locationId
-            ? yield* getOrCreateAreaPath(
-                locationId,
-                row.area_path,
-                caches,
-                result,
-              )
-            : null;
-          yield* upsertInventory(
-            product,
-            locationId,
-            areaId,
-            row,
-            result,
-            expiryDate,
-          );
-          if (importPhotos) {
-            yield* importPhotosForProduct(
-              product,
-              row,
-              result,
-              userId,
-              importedPhotoProducts,
-            );
-          }
-        });
-
-      const parseImportRequest = (
-        content: string,
-        importType: ImportProductsFromCsvOptions['importType'],
-      ) =>
-        Effect.gen(function* () {
-          const parsed = yield* Effect.try({
-            try: () => parseCsvContent(content),
-            catch: (cause) =>
-              new ProductImportCsvParseFailed({
-                cause,
-                messageKey: 'products.importCsvParseFailed',
-              }),
-          });
-          const format = detectProductImportFormat(parsed.headers, importType);
-          if (!format) {
-            return yield* Effect.fail(
-              new ProductImportUnsupportedFormat({
-                messageKey: 'products.importUnsupportedFormat',
-              }),
-            );
-          }
-          return { parsed, format };
-        });
+      const photosService = yield* PhotosServiceTag;
 
       const previewFromCsvContent = ({
         content,
@@ -532,7 +45,7 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
         ProductImportCsvParseFailed | ProductImportUnsupportedFormat
       > =>
         Effect.gen(function* () {
-          const { parsed, format } = yield* parseImportRequest(
+          const { parsed, format } = yield* parseProductImportRequest(
             content,
             importType,
           );
@@ -553,7 +66,7 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
         ProductImportCsvParseFailed | ProductImportUnsupportedFormat
       > =>
         Effect.gen(function* () {
-          const { parsed, format } = yield* parseImportRequest(
+          const { parsed, format } = yield* parseProductImportRequest(
             content,
             importType,
           );
@@ -612,7 +125,9 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
               continue;
             }
 
-            yield* importRow(
+            yield* importProductImportRow({
+              repository,
+              photosService,
               row,
               caches,
               result,
@@ -620,7 +135,7 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
               userId,
               importedPhotoProducts,
               importPhotos,
-            ).pipe(
+            }).pipe(
               Effect.catchAll((error) =>
                 Effect.sync(() => {
                   pushRowError(result, row.sourceRow, formatImportError(error));
@@ -638,6 +153,6 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
         importFromCsvContent,
       };
     }),
-    dependencies: [ProductImportRepository.Default, PhotosService.Default],
+    dependencies: [ProductImportRepository.Default, PhotosServiceTag.Default],
   },
 ) {}

--- a/src/effect/modules/products/import/service.ts
+++ b/src/effect/modules/products/import/service.ts
@@ -2,19 +2,26 @@ import { Effect } from 'effect';
 import { LocationType } from '@stocket/types/locations';
 import type {
   ImportCaches,
+  ImportAreaRow,
   ImportCategoryRow,
   ImportLocationRow,
   ImportProductRow,
   ImportProductsFromCsvOptions,
   NormalizedProductImportRow,
+  PreviewProductsFromCsvOptions,
+  ProductImportCommitResultDto,
+  ProductImportPreviewDto,
   ProductImportResultDto,
   ProductImportValues,
 } from './types';
 import {
+  applyProductImportMapping,
   detectProductImportFormat,
   findConflictingDuplicateSkuRows,
   formatImportError,
-  makeEmptyProductImportResult,
+  makeEmptyProductImportCommitResult,
+  makeProductImportMappingLookups,
+  makeProductImportPreview,
   normalizeCategoryPath,
   normalizeProductImportRecords,
   nullableText,
@@ -25,6 +32,7 @@ import {
   parseProductImportNumber,
   productValuesMatch,
   pushRowError,
+  pushWarning,
 } from './utils';
 import {
   ProductImportCsvParseFailed,
@@ -32,12 +40,14 @@ import {
   ProductsInfrastructureError,
 } from '../products.errors';
 import { ProductImportRepository } from './repository';
+import { PhotosService } from '../../photos/service';
 
 export class ProductImportService extends Effect.Service<ProductImportService>()(
   '@stocket/effect/products/ProductImportService',
   {
     effect: Effect.gen(function* () {
       const repository = yield* ProductImportRepository;
+      const photosService = yield* PhotosService;
 
       const getOrCreateCategoryPath = (
         categoryPath: string,
@@ -94,7 +104,7 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
       const getOrCreateLocation = (
         locationName: string,
         caches: ImportCaches,
-        result: ProductImportResultDto,
+        result: ProductImportCommitResultDto,
       ) =>
         Effect.gen(function* () {
           const name = locationName.trim();
@@ -122,6 +132,58 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
           return location.id;
         });
 
+      const getOrCreateAreaPath = (
+        locationId: string,
+        areaPath: string,
+        caches: ImportCaches,
+        result: ProductImportCommitResultDto,
+      ) =>
+        Effect.gen(function* () {
+          const parts = areaPath
+            .split('/')
+            .map((part) => part.trim())
+            .filter(Boolean);
+          if (parts.length === 0) return null;
+
+          let parentId: string | null = null;
+          let areaId = '';
+
+          for (const part of parts) {
+            const cacheKey = `${locationId}:${parentId ?? 'root'}:${part}`;
+            const cached = caches.areas.get(cacheKey);
+            if (cached) {
+              parentId = cached;
+              areaId = cached;
+              continue;
+            }
+
+            let area: ImportAreaRow | null =
+              yield* repository.findAreaByNameLocationAndParent(
+                part,
+                locationId,
+                parentId,
+              );
+
+            if (!area) {
+              area = yield* repository.createArea({
+                location_id: locationId,
+                parent_id: parentId,
+                name: part,
+                code: '',
+                description: 'Imported via product import',
+                is_active: true,
+              });
+              result.areasCreated++;
+            }
+
+            caches.areas.set(cacheKey, area.id);
+            parentId = area.id;
+            areaId = area.id;
+          }
+
+          return areaId;
+        });
+
       const upsertProduct = (
         row: NormalizedProductImportRow,
         categoryId: string,
@@ -144,10 +206,7 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
             standard_price: parseProductImportNumber(row.standard_price),
             reorder_point: parseInteger(row.reorder_point, 0),
             is_active: parseBoolean(row.is_active, true),
-            is_perishable: parseBoolean(
-              row.is_perishable,
-              Boolean(expiryDate),
-            ),
+            is_perishable: parseBoolean(row.is_perishable, Boolean(expiryDate)),
             notes: nullableText(row.notes),
           };
 
@@ -169,10 +228,10 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
             return existing;
           }
 
-          const product = yield* repository.updateProduct(
-            existing.id,
-            { ...values, updated_by: updatedBy },
-          );
+          const product = yield* repository.updateProduct(existing.id, {
+            ...values,
+            updated_by: updatedBy,
+          });
           if (!product) {
             return yield* Effect.fail(
               new ProductsInfrastructureError({
@@ -189,37 +248,41 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
       const upsertInventory = (
         product: ImportProductRow,
         locationId: string | null,
+        areaId: string | null,
         row: NormalizedProductImportRow,
-        result: ProductImportResultDto,
+        result: ProductImportCommitResultDto,
         expiryDate: Date | null,
       ) =>
         Effect.gen(function* () {
           if (!locationId) return;
 
-          const existing =
-            yield* repository.findRootInventoryByProductAndLocation(
-              product.id,
-              locationId,
-            );
+          const existing = yield* repository.findInventoryByProductLocationArea(
+            product.id,
+            locationId,
+            areaId,
+          );
           const quantity = parseInteger(row.quantity, 0);
-          const hasAreaScopedInventory =
-            yield* repository.hasAreaScopedInventoryForProductAndLocation(
-              product.id,
-              locationId,
-            );
-          if (hasAreaScopedInventory) {
-            return yield* Effect.fail(
-              new ProductsInfrastructureError({
-                action: 'import root inventory with area-scoped inventory',
-                messageKey: 'products.importAreaScopedInventoryConflict',
-              }),
-            );
+          if (areaId === null) {
+            const hasAreaScopedInventory =
+              yield* repository.hasAreaScopedInventoryForProductAndLocation(
+                product.id,
+                locationId,
+              );
+            if (hasAreaScopedInventory) {
+              return yield* Effect.fail(
+                new ProductsInfrastructureError({
+                  action: 'import root inventory with area-scoped inventory',
+                  messageKey: 'products.importAreaScopedInventoryConflict',
+                }),
+              );
+            }
           }
 
           if (!existing) {
             yield* repository.createInventory({
               product_id: product.id,
               location_id: locationId,
+              area_id: areaId,
               quantity,
               expiry_date: expiryDate,
             });
@@ -242,13 +305,107 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
           result.inventoryRecordsUpdated++;
         });
 
+      const importPhotosForProduct = (
+        product: ImportProductRow,
+        row: NormalizedProductImportRow,
+        result: ProductImportCommitResultDto,
+        userId: string,
+        importedPhotoProducts: Set<string>,
+      ) =>
+        Effect.gen(function* () {
+          if (
+            row.photo_urls.length === 0 ||
+            importedPhotoProducts.has(product.id)
+          ) {
+            return;
+          }
+          importedPhotoProducts.add(product.id);
+
+          for (const photoUrl of row.photo_urls) {
+            const response = yield* Effect.tryPromise({
+              try: () => fetch(photoUrl),
+              catch: (cause) => cause,
+            }).pipe(
+              Effect.catchAll((cause) =>
+                Effect.sync(() => {
+                  pushWarning(
+                    result,
+                    `Failed to download Sortly photo ${photoUrl}: ${formatImportError(cause)}`,
+                    row.sourceRow,
+                  );
+                  return null;
+                }),
+              ),
+            );
+            if (!response) continue;
+
+            if (!response.ok) {
+              pushWarning(
+                result,
+                `Failed to download Sortly photo ${photoUrl}: HTTP ${response.status}`,
+                row.sourceRow,
+              );
+              continue;
+            }
+
+            const contentType =
+              response.headers.get('content-type') ??
+              'application/octet-stream';
+            const arrayBuffer = yield* Effect.tryPromise({
+              try: () => response.arrayBuffer(),
+              catch: (cause) => cause,
+            }).pipe(
+              Effect.catchAll((cause) =>
+                Effect.sync(() => {
+                  pushWarning(
+                    result,
+                    `Failed to read Sortly photo ${photoUrl}: ${formatImportError(cause)}`,
+                    row.sourceRow,
+                  );
+                  return null;
+                }),
+              ),
+            );
+            if (!arrayBuffer) continue;
+
+            const buffer = Buffer.from(arrayBuffer);
+            const filename =
+              photoUrl.split('/').pop()?.split('?')[0] || 'sortly-photo';
+            yield* photosService
+              .uploadPhoto(
+                product.id,
+                {
+                  originalname: filename,
+                  mimetype: contentType,
+                  size: buffer.length,
+                  buffer,
+                },
+                userId,
+              )
+              .pipe(
+                Effect.match({
+                  onFailure: (error) => {
+                    pushWarning(
+                      result,
+                      `Failed to import Sortly photo ${photoUrl}: ${formatImportError(error)}`,
+                      row.sourceRow,
+                    );
+                  },
+                  onSuccess: () => {
+                    result.photosImported++;
+                  },
+                }),
+              );
+          }
+        });
+
       const validateRootInventoryImport = (
         row: NormalizedProductImportRow,
         caches: ImportCaches,
       ) =>
         Effect.gen(function* () {
           const locationName = row.location.trim();
-          if (locationName === '') return;
+          if (locationName === '' || row.area_path.trim() !== '') return;
 
           const cachedProduct = caches.products.get(row.sku);
           let product = cachedProduct ?? null;
@@ -282,11 +439,19 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
       const importRow = (
         row: NormalizedProductImportRow,
         caches: ImportCaches,
-        result: ProductImportResultDto,
+        result: ProductImportCommitResultDto,
         expiryDate: Date | null,
         userId: string,
+        importedPhotoProducts: Set<string>,
+        importPhotos: boolean,
       ) =>
         Effect.gen(function* () {
+          if (row.area_path.trim() !== '' && row.location.trim() === '') {
+            return yield* Effect.fail(
+              new Error('Cannot import area_path without location'),
+            );
+          }
+
           yield* validateRootInventoryImport(row, caches);
           const categoryId = yield* getOrCreateCategoryPath(
             row.category_path,
@@ -306,17 +471,37 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
             caches,
             result,
           );
-          yield* upsertInventory(product, locationId, row, result, expiryDate);
+          const areaId = locationId
+            ? yield* getOrCreateAreaPath(
+                locationId,
+                row.area_path,
+                caches,
+                result,
+              )
+            : null;
+          yield* upsertInventory(
+            product,
+            locationId,
+            areaId,
+            row,
+            result,
+            expiryDate,
+          );
+          if (importPhotos) {
+            yield* importPhotosForProduct(
+              product,
+              row,
+              result,
+              userId,
+              importedPhotoProducts,
+            );
+          }
         });
 
-      const importFromCsvContent = ({
-        content,
-        importType = 'auto',
-        userId,
-      }: ImportProductsFromCsvOptions): Effect.Effect<
-        ProductImportResultDto,
-        ProductImportCsvParseFailed | ProductImportUnsupportedFormat
-      > =>
+      const parseImportRequest = (
+        content: string,
+        importType: ImportProductsFromCsvOptions['importType'],
+      ) =>
         Effect.gen(function* () {
           const parsed = yield* Effect.try({
             try: () => parseCsvContent(content),
@@ -334,17 +519,69 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
               }),
             );
           }
+          return { parsed, format };
+        });
 
-          const result = makeEmptyProductImportResult();
-          const rows = normalizeProductImportRecords(parsed.records, format);
+      const previewFromCsvContent = ({
+        content,
+        importType = 'auto',
+        knownLocations = [],
+        useLlm = false,
+      }: PreviewProductsFromCsvOptions): Effect.Effect<
+        ProductImportPreviewDto,
+        ProductImportCsvParseFailed | ProductImportUnsupportedFormat
+      > =>
+        Effect.gen(function* () {
+          const { parsed, format } = yield* parseImportRequest(
+            content,
+            importType,
+          );
+          return makeProductImportPreview(parsed, format, {
+            knownLocations,
+            useLlm,
+          });
+        }).pipe(Effect.withSpan('ProductImportService.previewFromCsvContent'));
+
+      const importFromCsvContent = ({
+        content,
+        importType = 'auto',
+        mapping,
+        importPhotos = false,
+        userId,
+      }: ImportProductsFromCsvOptions): Effect.Effect<
+        ProductImportCommitResultDto,
+        ProductImportCsvParseFailed | ProductImportUnsupportedFormat
+      > =>
+        Effect.gen(function* () {
+          const { parsed, format } = yield* parseImportRequest(
+            content,
+            importType,
+          );
+          const result = makeEmptyProductImportCommitResult();
+          const mappingLookups = makeProductImportMappingLookups(mapping);
+          const rows: NormalizedProductImportRow[] = [];
+          for (const rawRow of normalizeProductImportRecords(
+            parsed.records,
+            format,
+          )) {
+            const mapped = applyProductImportMapping(rawRow, mappingLookups);
+            if (mapped.error) {
+              pushRowError(result, rawRow.sourceRow, mapped.error);
+              continue;
+            }
+            rows.push(mapped.row);
+          }
+
           const duplicateConflictRows = findConflictingDuplicateSkuRows(rows, {
             includeReorderPoint: format === 'normalized-products',
           });
           const caches: ImportCaches = {
+            areas: new Map<string, string>(),
             categories: new Map<string, string>(),
             locations: new Map<string, string>(),
             products: new Map<string, ImportProductRow>(),
           };
+          const importedPhotoProducts = new Set<string>();
 
           for (const row of rows) {
             if (!row.sku || !row.name) {
@@ -375,14 +612,18 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
               continue;
             }
 
-            yield* importRow(row, caches, result, expiryDate, userId).pipe(
+            yield* importRow(
+              row,
+              caches,
+              result,
+              expiryDate,
+              userId,
+              importedPhotoProducts,
+              importPhotos,
+            ).pipe(
               Effect.catchAll((error) =>
                 Effect.sync(() => {
-                  pushRowError(
-                    result,
-                    row.sourceRow,
-                    formatImportError(error),
-                  );
+                  pushRowError(result, row.sourceRow, formatImportError(error));
                 }),
               ),
             );
@@ -392,9 +633,11 @@ export class ProductImportService extends Effect.Service<ProductImportService>()
         }).pipe(Effect.withSpan('ProductImportService.importFromCsvContent'));
 
       return {
+        previewFromCsvContent,
+        commitFromCsvContent: importFromCsvContent,
         importFromCsvContent,
       };
     }),
-    dependencies: [ProductImportRepository.Default],
+    dependencies: [ProductImportRepository.Default, PhotosService.Default],
   },
 ) {}

--- a/src/effect/modules/products/import/types.ts
+++ b/src/effect/modules/products/import/types.ts
@@ -1,11 +1,22 @@
 import type {
+  ProductImportCommitResultDto,
   ProductImportErrorDto,
+  ProductImportMappingDto,
+  ProductImportPreviewDto,
   ProductImportResultDto,
+  ProductImportWarningDto,
 } from '@stocket/types/products';
-import type { categories, locations } from '../../../platform/db/schema';
+import type { areas, categories, locations } from '../../../platform/db/schema';
 import type { ProductRow } from '../products.utils';
 
-export type { ProductImportErrorDto, ProductImportResultDto };
+export type {
+  ProductImportCommitResultDto,
+  ProductImportErrorDto,
+  ProductImportMappingDto,
+  ProductImportPreviewDto,
+  ProductImportResultDto,
+  ProductImportWarningDto,
+};
 
 export const ProductImportTypes = [
   'auto',
@@ -31,6 +42,7 @@ export interface NormalizedProductImportRow {
   readonly reorder_point: string;
   readonly quantity: string;
   readonly location: string;
+  readonly area_path: string;
   readonly unit: string;
   readonly standard_price: string;
   readonly barcode: string;
@@ -39,13 +51,16 @@ export interface NormalizedProductImportRow {
   readonly is_active: string;
   readonly is_perishable: string;
   readonly expiry_date: string;
+  readonly photo_urls: readonly string[];
 }
 
+export type ImportAreaRow = typeof areas.$inferSelect;
 export type ImportCategoryRow = typeof categories.$inferSelect;
 export type ImportLocationRow = typeof locations.$inferSelect;
 export type ImportProductRow = ProductRow;
 
 export interface ImportCaches {
+  readonly areas: Map<string, string>;
   readonly categories: Map<string, string>;
   readonly locations: Map<string, string>;
   readonly products: Map<string, ImportProductRow>;
@@ -54,7 +69,16 @@ export interface ImportCaches {
 export interface ImportProductsFromCsvOptions {
   readonly content: string;
   readonly importType?: ProductImportType;
+  readonly mapping?: ProductImportMappingDto;
+  readonly importPhotos?: boolean;
   readonly userId: string;
+}
+
+export interface PreviewProductsFromCsvOptions {
+  readonly content: string;
+  readonly importType?: ProductImportType;
+  readonly knownLocations?: readonly string[];
+  readonly useLlm?: boolean;
 }
 
 export interface ProductImportValues {

--- a/src/effect/modules/products/import/utils.ts
+++ b/src/effect/modules/products/import/utils.ts
@@ -1,8 +1,22 @@
+import { Effect } from 'effect';
 import { parse } from 'csv-parse/sync';
+import { LocationType } from '@stocket/types/locations';
+import type { PhotosService } from '../../photos/service';
+import {
+  ProductImportCsvParseFailed,
+  ProductImportUnsupportedFormat,
+  ProductsInfrastructureError,
+} from '../products.errors';
+import type { ProductImportRepository } from './repository';
 import type {
   CsvParseResult,
   CsvRecord,
+  ImportAreaRow,
+  ImportCaches,
+  ImportCategoryRow,
+  ImportLocationRow,
   ImportProductRow,
+  ImportProductsFromCsvOptions,
   NormalizedProductImportRow,
   ProductImportCommitResultDto,
   ProductImportErrorDto,
@@ -43,6 +57,31 @@ export const makeEmptyProductImportCommitResult =
     photosImported: 0,
     warnings: [],
   });
+
+export function parseProductImportRequest(
+  content: string,
+  importType: ImportProductsFromCsvOptions['importType'],
+) {
+  return Effect.gen(function* () {
+    const parsed = yield* Effect.try({
+      try: () => parseCsvContent(content),
+      catch: (cause) =>
+        new ProductImportCsvParseFailed({
+          cause,
+          messageKey: 'products.importCsvParseFailed',
+        }),
+    });
+    const format = detectProductImportFormat(parsed.headers, importType);
+    if (!format) {
+      return yield* Effect.fail(
+        new ProductImportUnsupportedFormat({
+          messageKey: 'products.importUnsupportedFormat',
+        }),
+      );
+    }
+    return { parsed, format };
+  });
+}
 
 const hasAllHeaders = (
   headerSet: ReadonlySet<string>,
@@ -499,6 +538,476 @@ export function makeProductImportPreview(
     issues,
     warnings,
   };
+}
+
+const getOrCreateCategoryPath = (
+  repository: ProductImportRepository,
+  categoryPath: string,
+  caches: ImportCaches,
+  result: ProductImportResultDto,
+) =>
+  Effect.gen(function* () {
+    const parts = normalizeCategoryPath(categoryPath)
+      .split('/')
+      .map((part) => part.trim())
+      .filter(Boolean);
+
+    if (parts.length === 0) {
+      return yield* Effect.fail(
+        new ProductsInfrastructureError({
+          action: 'resolve import category path',
+          messageKey: 'products.repositoryFailed',
+        }),
+      );
+    }
+
+    let parentId: string | null = null;
+    let categoryId = '';
+
+    for (const part of parts) {
+      const cacheKey = `${parentId ?? 'root'}:${part}`;
+      const cached = caches.categories.get(cacheKey);
+      if (cached) {
+        parentId = cached;
+        categoryId = cached;
+        continue;
+      }
+
+      let category: ImportCategoryRow | null =
+        yield* repository.findCategoryByNameAndParent(part, parentId);
+
+      if (!category) {
+        category = yield* repository.createCategory({
+          name: part,
+          parent_id: parentId,
+          description: 'Imported via product import',
+        });
+        result.categoriesCreated++;
+      }
+
+      caches.categories.set(cacheKey, category.id);
+      parentId = category.id;
+      categoryId = category.id;
+    }
+
+    return categoryId;
+  });
+
+const getOrCreateLocation = (
+  repository: ProductImportRepository,
+  locationName: string,
+  caches: ImportCaches,
+  result: ProductImportCommitResultDto,
+) =>
+  Effect.gen(function* () {
+    const name = locationName.trim();
+    if (name === '') return null;
+
+    const cached = caches.locations.get(name);
+    if (cached) return cached;
+
+    let location: ImportLocationRow | null =
+      yield* repository.findLocationByName(name);
+
+    if (!location) {
+      location = yield* repository.createLocation({
+        name,
+        type: LocationType.WAREHOUSE,
+        address: '',
+        contact_person: '',
+        phone: '',
+        is_active: true,
+      });
+      result.locationsCreated++;
+    }
+
+    caches.locations.set(name, location.id);
+    return location.id;
+  });
+
+const getOrCreateAreaPath = (
+  repository: ProductImportRepository,
+  locationId: string,
+  areaPath: string,
+  caches: ImportCaches,
+  result: ProductImportCommitResultDto,
+) =>
+  Effect.gen(function* () {
+    const parts = areaPath
+      .split('/')
+      .map((part) => part.trim())
+      .filter(Boolean);
+    if (parts.length === 0) return null;
+
+    let parentId: string | null = null;
+    let areaId = '';
+
+    for (const part of parts) {
+      const cacheKey = `${locationId}:${parentId ?? 'root'}:${part}`;
+      const cached = caches.areas.get(cacheKey);
+      if (cached) {
+        parentId = cached;
+        areaId = cached;
+        continue;
+      }
+
+      let area: ImportAreaRow | null =
+        yield* repository.findAreaByNameLocationAndParent(
+          part,
+          locationId,
+          parentId,
+        );
+
+      if (!area) {
+        area = yield* repository.createArea({
+          location_id: locationId,
+          parent_id: parentId,
+          name: part,
+          code: '',
+          description: 'Imported via product import',
+          is_active: true,
+        });
+        result.areasCreated++;
+      }
+
+      caches.areas.set(cacheKey, area.id);
+      parentId = area.id;
+      areaId = area.id;
+    }
+
+    return areaId;
+  });
+
+const upsertProduct = (
+  repository: ProductImportRepository,
+  row: NormalizedProductImportRow,
+  categoryId: string,
+  caches: ImportCaches,
+  result: ProductImportResultDto,
+  expiryDate: Date | null,
+  userId: string,
+) =>
+  Effect.gen(function* () {
+    const updatedBy = userId;
+    const cached = caches.products.get(row.sku);
+    if (cached) return cached;
+
+    const values: ProductImportValues = {
+      name: row.name,
+      description: nullableText(row.description),
+      category_id: categoryId,
+      unit: nullableText(row.unit),
+      barcode: nullableText(row.barcode),
+      standard_price: parseProductImportNumber(row.standard_price),
+      reorder_point: parseInteger(row.reorder_point, 0),
+      is_active: parseBoolean(row.is_active, true),
+      is_perishable: parseBoolean(row.is_perishable, Boolean(expiryDate)),
+      notes: nullableText(row.notes),
+    };
+
+    const existing = yield* repository.findProductBySku(row.sku);
+    if (!existing) {
+      const product = yield* repository.createProduct({
+        sku: row.sku,
+        ...values,
+        created_by: updatedBy,
+        updated_by: updatedBy,
+      });
+      result.productsCreated++;
+      caches.products.set(row.sku, product);
+      return product;
+    }
+
+    if (productValuesMatch(existing, values)) {
+      caches.products.set(row.sku, existing);
+      return existing;
+    }
+
+    const product = yield* repository.updateProduct(existing.id, {
+      ...values,
+      updated_by: updatedBy,
+    });
+    if (!product) {
+      return yield* Effect.fail(
+        new ProductsInfrastructureError({
+          action: 'update import product',
+          messageKey: 'products.repositoryFailed',
+        }),
+      );
+    }
+    result.productsUpdated++;
+    caches.products.set(row.sku, product);
+    return product;
+  });
+
+const upsertInventory = (
+  repository: ProductImportRepository,
+  product: ImportProductRow,
+  locationId: string | null,
+  areaId: string | null,
+  row: NormalizedProductImportRow,
+  result: ProductImportCommitResultDto,
+  expiryDate: Date | null,
+) =>
+  Effect.gen(function* () {
+    if (!locationId) return;
+
+    const existing = yield* repository.findInventoryByProductLocationArea(
+      product.id,
+      locationId,
+      areaId,
+    );
+    const quantity = parseInteger(row.quantity, 0);
+    if (areaId === null) {
+      const hasAreaScopedInventory =
+        yield* repository.hasAreaScopedInventoryForProductAndLocation(
+          product.id,
+          locationId,
+        );
+      if (hasAreaScopedInventory) {
+        return yield* Effect.fail(
+          new ProductsInfrastructureError({
+            action: 'import root inventory with area-scoped inventory',
+            messageKey: 'products.importAreaScopedInventoryConflict',
+          }),
+        );
+      }
+    }
+
+    if (!existing) {
+      yield* repository.createInventory({
+        product_id: product.id,
+        location_id: locationId,
+        area_id: areaId,
+        quantity,
+        expiry_date: expiryDate,
+      });
+      result.inventoryRecordsCreated++;
+      return;
+    }
+
+    const inventory = yield* repository.updateInventory(existing.id, {
+      quantity,
+      expiry_date: expiryDate,
+    });
+    if (!inventory) {
+      return yield* Effect.fail(
+        new ProductsInfrastructureError({
+          action: 'update import inventory',
+          messageKey: 'products.repositoryFailed',
+        }),
+      );
+    }
+    result.inventoryRecordsUpdated++;
+  });
+
+const importPhotosForProduct = (
+  photosService: PhotosService,
+  product: ImportProductRow,
+  row: NormalizedProductImportRow,
+  result: ProductImportCommitResultDto,
+  userId: string,
+  importedPhotoProducts: Set<string>,
+) =>
+  Effect.gen(function* () {
+    if (row.photo_urls.length === 0 || importedPhotoProducts.has(product.id)) {
+      return;
+    }
+    importedPhotoProducts.add(product.id);
+
+    for (const photoUrl of row.photo_urls) {
+      const response = yield* Effect.tryPromise({
+        try: () => fetch(photoUrl),
+        catch: (cause) => cause,
+      }).pipe(
+        Effect.catchAll((cause) =>
+          Effect.sync(() => {
+            pushWarning(
+              result,
+              `Failed to download Sortly photo ${photoUrl}: ${formatImportError(cause)}`,
+              row.sourceRow,
+            );
+            return null;
+          }),
+        ),
+      );
+      if (!response) continue;
+
+      if (!response.ok) {
+        pushWarning(
+          result,
+          `Failed to download Sortly photo ${photoUrl}: HTTP ${response.status}`,
+          row.sourceRow,
+        );
+        continue;
+      }
+
+      const contentType =
+        response.headers.get('content-type') ?? 'application/octet-stream';
+      const arrayBuffer = yield* Effect.tryPromise({
+        try: () => response.arrayBuffer(),
+        catch: (cause) => cause,
+      }).pipe(
+        Effect.catchAll((cause) =>
+          Effect.sync(() => {
+            pushWarning(
+              result,
+              `Failed to read Sortly photo ${photoUrl}: ${formatImportError(cause)}`,
+              row.sourceRow,
+            );
+            return null;
+          }),
+        ),
+      );
+      if (!arrayBuffer) continue;
+
+      const buffer = Buffer.from(arrayBuffer);
+      const filename = photoUrl.split('/').pop()?.split('?')[0] || 'sortly-photo';
+      yield* photosService
+        .uploadPhoto(
+          product.id,
+          {
+            originalname: filename,
+            mimetype: contentType,
+            size: buffer.length,
+            buffer,
+          },
+          userId,
+        )
+        .pipe(
+          Effect.match({
+            onFailure: (error) => {
+              pushWarning(
+                result,
+                `Failed to import Sortly photo ${photoUrl}: ${formatImportError(error)}`,
+                row.sourceRow,
+              );
+            },
+            onSuccess: () => {
+              result.photosImported++;
+            },
+          }),
+        );
+    }
+  });
+
+const validateRootInventoryImport = (
+  repository: ProductImportRepository,
+  row: NormalizedProductImportRow,
+  caches: ImportCaches,
+) =>
+  Effect.gen(function* () {
+    const locationName = row.location.trim();
+    if (locationName === '' || row.area_path.trim() !== '') return;
+
+    const cachedProduct = caches.products.get(row.sku);
+    let product = cachedProduct ?? null;
+    if (!product) {
+      product = yield* repository.findProductBySku(row.sku);
+    }
+    if (!product) return;
+
+    let locationId = caches.locations.get(locationName) ?? null;
+    if (!locationId) {
+      const location = yield* repository.findLocationByName(locationName);
+      locationId = location?.id ?? null;
+    }
+    if (!locationId) return;
+
+    const hasAreaScopedInventory =
+      yield* repository.hasAreaScopedInventoryForProductAndLocation(
+        product.id,
+        locationId,
+      );
+    if (hasAreaScopedInventory) {
+      return yield* Effect.fail(
+        new ProductsInfrastructureError({
+          action: 'import root inventory with area-scoped inventory',
+          messageKey: 'products.importAreaScopedInventoryConflict',
+        }),
+      );
+    }
+  });
+
+export function importProductImportRow({
+  repository,
+  photosService,
+  row,
+  caches,
+  result,
+  expiryDate,
+  userId,
+  importedPhotoProducts,
+  importPhotos,
+}: {
+  readonly repository: ProductImportRepository;
+  readonly photosService: PhotosService;
+  readonly row: NormalizedProductImportRow;
+  readonly caches: ImportCaches;
+  readonly result: ProductImportCommitResultDto;
+  readonly expiryDate: Date | null;
+  readonly userId: string;
+  readonly importedPhotoProducts: Set<string>;
+  readonly importPhotos: boolean;
+}) {
+  return Effect.gen(function* () {
+    if (row.area_path.trim() !== '' && row.location.trim() === '') {
+      return yield* Effect.fail(
+        new Error('Cannot import area_path without location'),
+      );
+    }
+
+    yield* validateRootInventoryImport(repository, row, caches);
+    const categoryId = yield* getOrCreateCategoryPath(
+      repository,
+      row.category_path,
+      caches,
+      result,
+    );
+    const product = yield* upsertProduct(
+      repository,
+      row,
+      categoryId,
+      caches,
+      result,
+      expiryDate,
+      userId,
+    );
+    const locationId = yield* getOrCreateLocation(
+      repository,
+      row.location,
+      caches,
+      result,
+    );
+    const areaId = locationId
+      ? yield* getOrCreateAreaPath(
+          repository,
+          locationId,
+          row.area_path,
+          caches,
+          result,
+        )
+      : null;
+    yield* upsertInventory(
+      repository,
+      product,
+      locationId,
+      areaId,
+      row,
+      result,
+      expiryDate,
+    );
+    if (importPhotos) {
+      yield* importPhotosForProduct(
+        photosService,
+        product,
+        row,
+        result,
+        userId,
+        importedPhotoProducts,
+      );
+    }
+  });
 }
 
 export function parseDate(value: string): Date | null {

--- a/src/effect/modules/products/import/utils.ts
+++ b/src/effect/modules/products/import/utils.ts
@@ -4,9 +4,13 @@ import type {
   CsvRecord,
   ImportProductRow,
   NormalizedProductImportRow,
+  ProductImportCommitResultDto,
   ProductImportErrorDto,
   ProductImportFormat,
+  ProductImportMappingDto,
+  ProductImportPreviewDto,
   ProductImportResultDto,
+  ProductImportWarningDto,
   ProductImportType,
   ProductImportValues,
 } from './types';
@@ -31,6 +35,14 @@ export const makeEmptyProductImportResult = (): ProductImportResultDto => ({
   rowsSkipped: 0,
   errors: [],
 });
+
+export const makeEmptyProductImportCommitResult =
+  (): ProductImportCommitResultDto => ({
+    ...makeEmptyProductImportResult(),
+    areasCreated: 0,
+    photosImported: 0,
+    warnings: [],
+  });
 
 const hasAllHeaders = (
   headerSet: ReadonlySet<string>,
@@ -113,6 +125,14 @@ export const normalizeCategoryPath = (categoryPath: string): string => {
   return parts.length > 0 ? parts.join(' / ') : 'Uncategorized';
 };
 
+export const normalizeAreaPath = (areaPath: string): string => {
+  const parts = areaPath
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return parts.join(' / ');
+};
+
 const normalizeNormalizedRecord = (
   record: CsvRecord,
   sourceRow: number,
@@ -124,6 +144,7 @@ const normalizeNormalizedRecord = (
   reorder_point: readCell(record, 'reorder_point'),
   quantity: readCell(record, 'quantity'),
   location: readCell(record, 'location'),
+  area_path: normalizeAreaPath(readCell(record, 'area_path')),
   unit: readCell(record, 'unit'),
   standard_price: readCell(record, 'standard_price'),
   barcode: readCell(record, 'barcode'),
@@ -132,7 +153,17 @@ const normalizeNormalizedRecord = (
   is_active: readCell(record, 'is_active'),
   is_perishable: readCell(record, 'is_perishable'),
   expiry_date: readCell(record, 'expiry_date'),
+  photo_urls: [],
 });
+
+const collectSortlyPhotoUrls = (record: CsvRecord): string[] => {
+  const urls: string[] = [];
+  for (let i = 1; i <= 8; i++) {
+    const value = readCell(record, `Photo${i}`);
+    if (value !== '') urls.push(value);
+  }
+  return urls;
+};
 
 const normalizeSortlyRecord = (
   record: CsvRecord,
@@ -154,6 +185,7 @@ const normalizeSortlyRecord = (
     reorder_point: readCell(record, 'Min Level') || '0',
     quantity: readCell(record, 'Quantity') || '0',
     location: readCell(record, 'Location'),
+    area_path: '',
     unit: readCell(record, 'Unit'),
     standard_price: readCell(record, 'Price'),
     barcode: qr1 || qr2,
@@ -162,6 +194,7 @@ const normalizeSortlyRecord = (
     is_active: 'true',
     is_perishable: expiryDate === '' ? 'false' : 'true',
     expiry_date: expiryDate,
+    photo_urls: collectSortlyPhotoUrls(record),
   };
 };
 
@@ -180,6 +213,292 @@ export function normalizeProductImportRecords(
   return records.map((record, index) =>
     normalizeNormalizedRecord(record, index + 2),
   );
+}
+
+const countBy = <T>(values: readonly T[], selector: (value: T) => string) => {
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    const key = selector(value).trim();
+    if (key === '') continue;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => a.value.localeCompare(b.value));
+};
+
+const normalizeKnownLocations = (knownLocations: readonly string[]) =>
+  knownLocations
+    .map((location) => location.trim())
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+
+const removeLeadingLocationSeparator = (value: string): string =>
+  value.replace(/^\s*(?:-|\/|>|:)\s*/, '').trim();
+
+const suggestLocationMapping = (
+  source: string,
+  knownLocations: readonly string[],
+) => {
+  const normalizedSource = source.replace(/\s+/g, ' ').trim();
+  for (const knownLocation of normalizeKnownLocations(knownLocations)) {
+    if (normalizedSource === knownLocation) {
+      return { locationName: knownLocation, areaPath: '' };
+    }
+    if (normalizedSource.startsWith(`${knownLocation} `)) {
+      const areaPath = removeLeadingLocationSeparator(
+        normalizedSource.slice(knownLocation.length),
+      );
+      if (areaPath !== '') {
+        return {
+          locationName: knownLocation,
+          areaPath: normalizeAreaPath(areaPath),
+        };
+      }
+    }
+  }
+
+  const delimiterMatch = normalizedSource.match(/^(.+?)\s+-\s+(.+)$/);
+  if (delimiterMatch) {
+    return {
+      locationName: delimiterMatch[1]!.trim(),
+      areaPath: normalizeAreaPath(delimiterMatch[2]!.trim()),
+    };
+  }
+
+  return { locationName: normalizedSource, areaPath: '' };
+};
+
+export function suggestImportMapping(
+  rows: readonly NormalizedProductImportRow[],
+  knownLocations: readonly string[] = [],
+): ProductImportMappingDto {
+  return {
+    categoryMappings: countBy(rows, (row) => row.category_path).map(
+      ({ value }) => ({ source: value, target: value }),
+    ),
+    locationMappings: countBy(rows, (row) => row.location).map(({ value }) => ({
+      source: value,
+      ...suggestLocationMapping(value, knownLocations),
+    })),
+  };
+}
+
+export interface ProductImportMappingLookups {
+  readonly categoryMappings: ReadonlyMap<string, string>;
+  readonly locationMappings: ReadonlyMap<
+    string,
+    { readonly locationName: string; readonly areaPath: string }
+  >;
+}
+
+export function makeProductImportMappingLookups(
+  mapping: ProductImportMappingDto | undefined,
+): ProductImportMappingLookups | null {
+  if (!mapping) return null;
+
+  return {
+    categoryMappings: new Map(
+      mapping.categoryMappings.map((item) => [
+        item.source.trim(),
+        item.target.trim(),
+      ]),
+    ),
+    locationMappings: new Map(
+      mapping.locationMappings.map((item) => [
+        item.source.trim(),
+        {
+          locationName: item.locationName.trim(),
+          areaPath: normalizeAreaPath(item.areaPath),
+        },
+      ]),
+    ),
+  };
+}
+
+export function applyProductImportMapping(
+  row: NormalizedProductImportRow,
+  lookups: ProductImportMappingLookups | null,
+): { readonly row: NormalizedProductImportRow; readonly error?: string } {
+  if (!lookups) return { row };
+
+  const categoryPath = row.category_path.trim();
+  const mappedCategory = lookups.categoryMappings.get(categoryPath);
+  if (!mappedCategory) {
+    return {
+      row,
+      error: `Missing category mapping for "${categoryPath}"`,
+    };
+  }
+
+  const locationName = row.location.trim();
+  if (locationName === '') {
+    return {
+      row: {
+        ...row,
+        category_path: normalizeCategoryPath(mappedCategory),
+        area_path: '',
+      },
+    };
+  }
+
+  const mappedLocation = lookups.locationMappings.get(locationName);
+  if (!mappedLocation) {
+    return {
+      row,
+      error: `Missing location mapping for "${locationName}"`,
+    };
+  }
+
+  if (mappedLocation.locationName === '') {
+    return {
+      row,
+      error: `Location mapping for "${locationName}" must include a location`,
+    };
+  }
+
+  return {
+    row: {
+      ...row,
+      category_path: normalizeCategoryPath(mappedCategory),
+      location: mappedLocation.locationName,
+      area_path: mappedLocation.areaPath,
+    },
+  };
+}
+
+const isStringRecordArray = (
+  value: unknown,
+  fields: readonly string[],
+): value is Record<string, string>[] =>
+  Array.isArray(value) &&
+  value.every(
+    (item) =>
+      typeof item === 'object' &&
+      item !== null &&
+      fields.every(
+        (field) => typeof (item as Record<string, unknown>)[field] === 'string',
+      ),
+  );
+
+export function parseProductImportMappingJson(
+  value: string,
+): ProductImportMappingDto | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !isStringRecordArray(
+        (parsed as { categoryMappings?: unknown }).categoryMappings,
+        ['source', 'target'],
+      ) ||
+      !isStringRecordArray(
+        (parsed as { locationMappings?: unknown }).locationMappings,
+        ['source', 'locationName', 'areaPath'],
+      )
+    ) {
+      return null;
+    }
+
+    const mapping = parsed as ProductImportMappingDto;
+    return {
+      categoryMappings: mapping.categoryMappings.map((item) => ({
+        source: item.source.trim(),
+        target: normalizeCategoryPath(item.target),
+      })),
+      locationMappings: mapping.locationMappings.map((item) => ({
+        source: item.source.trim(),
+        locationName: item.locationName.trim(),
+        areaPath: normalizeAreaPath(item.areaPath),
+      })),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function makeProductImportPreview(
+  parsed: CsvParseResult,
+  format: ProductImportFormat,
+  options: {
+    readonly knownLocations?: readonly string[];
+    readonly useLlm?: boolean;
+  } = {},
+): ProductImportPreviewDto {
+  const rows = normalizeProductImportRecords(parsed.records, format);
+  const issues: ProductImportErrorDto[] = [];
+  const warnings: ProductImportWarningDto[] = [];
+  const duplicateConflictRows = findConflictingDuplicateSkuRows(rows, {
+    includeReorderPoint: format === 'normalized-products',
+  });
+
+  for (const row of rows) {
+    if (!row.sku || !row.name) {
+      issues.push({
+        row: row.sourceRow,
+        error: 'Cannot import product without sku and name',
+      });
+    }
+
+    if (duplicateConflictRows.has(row.sourceRow)) {
+      issues.push({
+        row: row.sourceRow,
+        error: `Conflicting duplicate SKU "${row.sku}" has different product fields`,
+      });
+    }
+
+    const expiryDate = parseDate(row.expiry_date);
+    if (row.expiry_date.trim() !== '' && expiryDate === null) {
+      issues.push({
+        row: row.sourceRow,
+        error: `Invalid expiry_date "${row.expiry_date}"`,
+      });
+    }
+  }
+
+  if (options.useLlm) {
+    warnings.push({
+      warning:
+        'AI mapping suggestions are not configured in this environment; deterministic suggestions were used.',
+    });
+  }
+
+  const itemRows =
+    format === 'sortly-items'
+      ? parsed.records.filter(
+          (record) => readCell(record, 'Entry Type') === 'Item',
+        ).length
+      : rows.length;
+  const folderRows =
+    format === 'sortly-items'
+      ? parsed.records.filter(
+          (record) => readCell(record, 'Entry Type') === 'Folder',
+        ).length
+      : 0;
+
+  return {
+    detectedFormat: format,
+    stats: {
+      totalRows: parsed.records.length,
+      importableRows: rows.length,
+      itemRows,
+      folderRows,
+      rowsMissingSku: rows.filter((row) => row.sku === '').length,
+      rowsMissingName: rows.filter((row) => row.name === '').length,
+      rowsMissingLocation: rows.filter((row) => row.location === '').length,
+      rowsMissingCategory: rows.filter(
+        (row) => row.category_path === 'Uncategorized',
+      ).length,
+      itemsWithPhotos: rows.filter((row) => row.photo_urls.length > 0).length,
+      itemsWithBarcodes: rows.filter((row) => row.barcode !== '').length,
+    },
+    categories: countBy(rows, (row) => row.category_path),
+    locations: countBy(rows, (row) => row.location),
+    suggestedMapping: suggestImportMapping(rows, options.knownLocations ?? []),
+    issues,
+    warnings,
+  };
 }
 
 export function parseDate(value: string): Date | null {
@@ -362,6 +681,18 @@ export const pushRowError = (
 ) => {
   result.rowsSkipped++;
   result.errors.push({ row, error } satisfies ProductImportErrorDto);
+};
+
+export const pushWarning = (
+  result: { warnings: ProductImportWarningDto[] },
+  warning: string,
+  row?: number,
+) => {
+  result.warnings.push(
+    row === undefined
+      ? { warning }
+      : ({ row, warning } satisfies ProductImportWarningDto),
+  );
 };
 
 export const formatImportError = (error: unknown): string => {

--- a/src/effect/modules/products/products.errors.ts
+++ b/src/effect/modules/products/products.errors.ts
@@ -35,6 +35,12 @@ export class ProductImportCsvParseFailed extends BadRequestError(
   readonly cause?: unknown;
 }> {}
 
+export class ProductImportInvalidMapping extends BadRequestError(
+  'ProductImportInvalidMapping',
+)<{
+  readonly cause?: unknown;
+}> {}
+
 export class ProductsInfrastructureError extends InternalError(
   'ProductInfrastructureError',
 )<{

--- a/src/effect/modules/products/router.ts
+++ b/src/effect/modules/products/router.ts
@@ -17,11 +17,18 @@ import {
 import { requirePermission } from '../../platform/auth/authorization';
 import { respondJson, respondJsonOk } from '../../platform/http/errors';
 import { AuditLogWriter } from '../../platform/audit/index';
-import { getOptionalSession, requireSession } from '../../platform/http/session';
+import {
+  getOptionalSession,
+  requireSession,
+} from '../../platform/http/session';
 import { makeMessageResponse } from '../../platform/observability/messages';
 import { ProductImportService } from './import/service';
 import { ProductImportTypes } from './import/types';
-import { ProductsInfrastructureError } from './products.errors';
+import {
+  ProductImportInvalidMapping,
+  ProductsInfrastructureError,
+} from './products.errors';
+import { parseProductImportMappingJson } from './import/utils';
 import { ProductsService } from './service';
 
 /**
@@ -30,7 +37,13 @@ import { ProductsService } from './service';
  * them even though every field encodes to a string at runtime. This helper hides the cast.
  */
 const searchParams = <A, I, R>(schema: Schema.Schema<A, I, R>) =>
-  HttpServerRequest.schemaSearchParams(schema as unknown as Schema.Schema<A, Record<string, string | ReadonlyArray<string> | undefined>, R>);
+  HttpServerRequest.schemaSearchParams(
+    schema as unknown as Schema.Schema<
+      A,
+      Record<string, string | ReadonlyArray<string> | undefined>,
+      R
+    >,
+  );
 
 const ProductPathParams = Schema.Struct({ id: ProductIdSchema });
 const CategoryPathParams = Schema.Struct({ categoryId: Schema.UUID });
@@ -41,6 +54,69 @@ const ProductImportUploadSchema = Schema.Struct({
     default: () => 'auto' as const,
   }),
 });
+const ProductImportPreviewUploadSchema = Schema.Struct({
+  file: Multipart.SingleFileSchema,
+  import_type: Schema.optionalWith(ProductImportTypeSchema, {
+    default: () => 'auto' as const,
+  }),
+  known_locations: Schema.optionalWith(Schema.String, {
+    default: () => '[]',
+  }),
+  use_llm: Schema.optionalWith(Schema.BooleanFromString, {
+    default: () => false,
+  }),
+});
+const ProductImportCommitUploadSchema = Schema.Struct({
+  file: Multipart.SingleFileSchema,
+  import_type: Schema.optionalWith(ProductImportTypeSchema, {
+    default: () => 'auto' as const,
+  }),
+  mapping: Schema.String,
+  import_photos: Schema.optionalWith(Schema.BooleanFromString, {
+    default: () => false,
+  }),
+});
+
+const readProductImportUpload = (file: { readonly path: string }) =>
+  Effect.tryPromise({
+    try: () => readFile(file.path),
+    catch: (cause) =>
+      new ProductsInfrastructureError({
+        action: 'read uploaded product import file',
+        cause,
+        messageKey: 'products.importReadUploadFailed',
+      }),
+  }).pipe(Effect.map((buffer) => buffer.toString('utf8')));
+
+const parseJsonStringArray = (value: string) =>
+  Effect.try({
+    try: () => {
+      const parsed = JSON.parse(value) as unknown;
+      if (
+        !Array.isArray(parsed) ||
+        !parsed.every((item) => typeof item === 'string')
+      ) {
+        throw new Error('Expected JSON string array');
+      }
+      return parsed.map((item) => item.trim()).filter(Boolean);
+    },
+    catch: (cause) =>
+      new ProductImportInvalidMapping({
+        cause,
+        messageKey: 'products.importInvalidMapping',
+      }),
+  });
+
+const parseImportMapping = (value: string) =>
+  Effect.sync(() => parseProductImportMappingJson(value)).pipe(
+    Effect.filterOrFail(
+      (mapping) => mapping !== null,
+      () =>
+        new ProductImportInvalidMapping({
+          messageKey: 'products.importInvalidMapping',
+        }),
+    ),
+  );
 
 const IncludeDeletedQuery = Schema.Struct({
   include_deleted: Schema.optionalWith(ProductBooleanQuerySchema, {
@@ -76,8 +152,9 @@ export const productsRouter = HttpRouter.empty.pipe(
     '/bulk',
     Effect.gen(function* () {
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-      const dto =
-        yield* HttpServerRequest.schemaBodyJson(BulkCreateProductsSchema);
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        BulkCreateProductsSchema,
+      );
       const session = yield* getOptionalSession;
       const userId = session?.user.id;
       const productsService = yield* ProductsService;
@@ -94,6 +171,52 @@ export const productsRouter = HttpRouter.empty.pipe(
     }),
   ),
   HttpRouter.post(
+    '/import/preview',
+    Effect.gen(function* () {
+      yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
+      const { file, import_type, known_locations, use_llm } =
+        yield* HttpServerRequest.schemaBodyMultipart(
+          ProductImportPreviewUploadSchema,
+        );
+      const content = yield* readProductImportUpload(file);
+      const knownLocations = yield* parseJsonStringArray(known_locations);
+      const productImportService = yield* ProductImportService;
+      const result = yield* productImportService.previewFromCsvContent({
+        content,
+        importType: import_type,
+        knownLocations,
+        useLlm: use_llm,
+      });
+      return yield* respondJsonOk(result);
+    }),
+  ),
+  HttpRouter.post(
+    '/import/commit',
+    Effect.gen(function* () {
+      yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
+      yield* requirePermission(Resource.LOCATIONS, Permission.WRITE);
+      yield* requirePermission(Resource.INVENTORY, Permission.WRITE);
+      const { file, import_type, mapping, import_photos } =
+        yield* HttpServerRequest.schemaBodyMultipart(
+          ProductImportCommitUploadSchema,
+        );
+      const session = yield* requireSession;
+      const userId = session.user.id;
+      const content = yield* readProductImportUpload(file);
+      const importMapping = yield* parseImportMapping(mapping);
+
+      const productImportService = yield* ProductImportService;
+      const result = yield* productImportService.commitFromCsvContent({
+        content,
+        importType: import_type,
+        mapping: importMapping,
+        importPhotos: import_photos,
+        userId,
+      });
+      return yield* respondJsonOk(result);
+    }),
+  ),
+  HttpRouter.post(
     '/import',
     Effect.gen(function* () {
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
@@ -104,19 +227,11 @@ export const productsRouter = HttpRouter.empty.pipe(
       const session = yield* requireSession;
       const userId = session.user.id;
 
-      const buffer = yield* Effect.tryPromise({
-        try: () => readFile(file.path),
-        catch: (cause) =>
-          new ProductsInfrastructureError({
-            action: 'read uploaded product import file',
-            cause,
-            messageKey: 'products.importReadUploadFailed',
-          }),
-      });
+      const content = yield* readProductImportUpload(file);
 
       const productImportService = yield* ProductImportService;
       const result = yield* productImportService.importFromCsvContent({
-        content: buffer.toString('utf8'),
+        content,
         importType: import_type,
         userId,
       });
@@ -130,9 +245,7 @@ export const productsRouter = HttpRouter.empty.pipe(
       const { categoryId } =
         yield* HttpRouter.schemaPathParams(CategoryPathParams);
       const productsService = yield* ProductsService;
-      return yield* respondJson(
-        productsService.findByCategoryTree(categoryId),
-      );
+      return yield* respondJson(productsService.findByCategoryTree(categoryId));
     }),
   ),
   HttpRouter.get(
@@ -149,8 +262,9 @@ export const productsRouter = HttpRouter.empty.pipe(
     '/',
     Effect.gen(function* () {
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-      const dto =
-        yield* HttpServerRequest.schemaBodyJson(CreateProductRequestSchema);
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        CreateProductRequestSchema,
+      );
       const session = yield* getOptionalSession;
       const userId = session?.user.id;
       const productsService = yield* ProductsService;
@@ -168,8 +282,9 @@ export const productsRouter = HttpRouter.empty.pipe(
     '/bulk/status',
     Effect.gen(function* () {
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
-      const dto =
-        yield* HttpServerRequest.schemaBodyJson(BulkUpdateStatusSchema);
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        BulkUpdateStatusSchema,
+      );
       const session = yield* getOptionalSession;
       const userId = session?.user.id;
       const productsService = yield* ProductsService;
@@ -240,8 +355,9 @@ export const productsRouter = HttpRouter.empty.pipe(
     Effect.gen(function* () {
       yield* requirePermission(Resource.PRODUCTS, Permission.WRITE);
       const { id } = yield* HttpRouter.schemaPathParams(ProductPathParams);
-      const dto =
-        yield* HttpServerRequest.schemaBodyJson(UpdateProductRequestSchema);
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        UpdateProductRequestSchema,
+      );
       const session = yield* getOptionalSession;
       const userId = session?.user.id;
       const productsService = yield* ProductsService;

--- a/src/effect/modules/superadmin/repository.integration.spec.ts
+++ b/src/effect/modules/superadmin/repository.integration.spec.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from 'node:crypto';
+import { Effect, Layer } from 'effect';
+import { DEFAULT_FEATURE_STATES, FeatureKey } from '@stocket/types/features';
+import {
+  organizations,
+  tenantDomains,
+  tenantFeatureOverrides,
+} from '../../platform/db/schema';
+import {
+  getTestDb,
+  makeTestDrizzleLayer,
+  withTestDb,
+} from '../../testing/test-harness';
+import { SuperAdminRepository } from './repository';
+
+withTestDb();
+
+const runRepository = <A, E>(
+  effect: Effect.Effect<A, E, SuperAdminRepository>,
+) =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(
+        SuperAdminRepository.Default.pipe(
+          Layer.provide(makeTestDrizzleLayer()),
+        ),
+      ),
+    ),
+  );
+
+describe('SuperAdminRepository tenant features', () => {
+  it('upserts non-default feature overrides and clears default-equivalent values', async () => {
+    const db = getTestDb();
+    const tenantId = randomUUID();
+
+    await db.insert(organizations).values({
+      id: tenantId,
+      name: 'Feature Tenant',
+      slug: `feature-${tenantId.slice(0, 8)}`,
+    });
+    await db.insert(tenantDomains).values({
+      tenant_id: tenantId,
+      hostname: `feature-${tenantId.slice(0, 8)}.localhost:3000`,
+      kind: 'subdomain',
+      is_primary: true,
+      verified_at: new Date(),
+    });
+
+    await runRepository(
+      Effect.flatMap(SuperAdminRepository, (repository) =>
+        repository.updateTenant({
+          tenantId,
+          name: 'Feature Tenant Updated',
+          features: {
+            ...DEFAULT_FEATURE_STATES,
+            [FeatureKey.SMART_IMPORT]: true,
+          },
+          updatedBy: 'superadmin-1',
+        }),
+      ),
+    );
+
+    const enabledOverrides = await db.select().from(tenantFeatureOverrides);
+
+    expect(enabledOverrides).toHaveLength(1);
+    expect(enabledOverrides[0]).toMatchObject({
+      tenant_id: tenantId,
+      feature_key: FeatureKey.SMART_IMPORT,
+      enabled: true,
+      updated_by: 'superadmin-1',
+    });
+
+    await runRepository(
+      Effect.flatMap(SuperAdminRepository, (repository) =>
+        repository.updateTenant({
+          tenantId,
+          name: 'Feature Tenant Updated Again',
+          features: DEFAULT_FEATURE_STATES,
+          updatedBy: 'superadmin-1',
+        }),
+      ),
+    );
+
+    const clearedOverrides = await db.select().from(tenantFeatureOverrides);
+
+    expect(clearedOverrides).toHaveLength(0);
+  });
+});

--- a/src/effect/modules/superadmin/repository.ts
+++ b/src/effect/modules/superadmin/repository.ts
@@ -1,6 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import { Effect } from 'effect';
 import { and, asc, eq, sql } from 'drizzle-orm';
+import {
+  DEFAULT_FEATURE_STATES,
+  type FeatureStates,
+} from '@stocket/types/features';
+import {
+  FEATURE_KEYS,
+  type TenantFeatureOverrideRow,
+} from '../../platform/tenancy/tenant-features';
 import { DrizzleDatabase } from '../../platform/db/drizzle';
 import {
   betterAuthUsers,
@@ -9,6 +17,7 @@ import {
   platformAuditEvents,
   rolePermissions,
   roles,
+  tenantFeatureOverrides,
   tenantDomains,
   userRoles,
 } from '../../platform/db/schema';
@@ -46,6 +55,13 @@ export interface CreateTenantInput {
   readonly adminUserId: string;
 }
 
+export interface UpdateTenantInput {
+  readonly tenantId: string;
+  readonly name: string;
+  readonly features: FeatureStates;
+  readonly updatedBy: string;
+}
+
 export interface PlatformAuditEventInput {
   readonly actorUserId: string;
   readonly action: string;
@@ -66,6 +82,11 @@ export interface CreatedTenantResult {
   readonly admin: {
     readonly id: string;
   };
+}
+
+export interface UpdatedTenantResult {
+  readonly tenant: TenantListRow;
+  readonly overrides: TenantFeatureOverrideRow[];
 }
 
 const rowsOf = <A>(result: unknown): A[] =>
@@ -125,6 +146,30 @@ export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()
             .orderBy(asc(organizations.created_at), asc(organizations.name));
 
           return rows;
+        });
+
+      const findTenantById = (tenantId: string) =>
+        tryAsync('find platform tenant', async () => {
+          const rows = await db
+            .select({
+              id: organizations.id,
+              name: organizations.name,
+              slug: organizations.slug,
+              primaryHostname: tenantDomains.hostname,
+              createdAt: organizations.created_at,
+            })
+            .from(organizations)
+            .leftJoin(
+              tenantDomains,
+              and(
+                eq(tenantDomains.tenant_id, organizations.id),
+                eq(tenantDomains.is_primary, true),
+              ),
+            )
+            .where(eq(organizations.id, tenantId))
+            .limit(1);
+
+          return rows[0] ?? null;
         });
 
       const tenantSlugExists = (slug: string) =>
@@ -206,7 +251,9 @@ export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()
             const adminRoleRows = await tx
               .select({ id: roles.id })
               .from(roles)
-              .where(and(eq(roles.tenant_id, tenantId), eq(roles.name, 'Admin')))
+              .where(
+                and(eq(roles.tenant_id, tenantId), eq(roles.name, 'Admin')),
+              )
               .limit(1);
 
             const adminRoleId = adminRoleRows[0]?.id;
@@ -234,6 +281,100 @@ export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()
           });
         });
 
+      const updateTenant = (input: UpdateTenantInput) =>
+        tryAsync('update tenant', async () =>
+          db.transaction(async (tx) => {
+            const now = new Date();
+            const [tenant] = await tx
+              .update(organizations)
+              .set({ name: input.name })
+              .where(eq(organizations.id, input.tenantId))
+              .returning({
+                id: organizations.id,
+                name: organizations.name,
+                slug: organizations.slug,
+                createdAt: organizations.created_at,
+              });
+
+            if (!tenant) {
+              return null;
+            }
+
+            for (const featureKey of FEATURE_KEYS) {
+              const enabled = input.features[featureKey];
+              const defaultEnabled = DEFAULT_FEATURE_STATES[featureKey];
+
+              if (enabled === defaultEnabled) {
+                await tx
+                  .delete(tenantFeatureOverrides)
+                  .where(
+                    and(
+                      eq(tenantFeatureOverrides.tenant_id, input.tenantId),
+                      eq(tenantFeatureOverrides.feature_key, featureKey),
+                    ),
+                  );
+                continue;
+              }
+
+              await tx
+                .insert(tenantFeatureOverrides)
+                .values({
+                  tenant_id: input.tenantId,
+                  feature_key: featureKey,
+                  enabled,
+                  expires_at: null,
+                  updated_at: now,
+                  updated_by: input.updatedBy,
+                })
+                .onConflictDoUpdate({
+                  target: [
+                    tenantFeatureOverrides.tenant_id,
+                    tenantFeatureOverrides.feature_key,
+                  ],
+                  set: {
+                    enabled,
+                    expires_at: null,
+                    updated_at: now,
+                    updated_by: input.updatedBy,
+                  },
+                });
+            }
+
+            const [primaryDomain] = await tx
+              .select({ hostname: tenantDomains.hostname })
+              .from(tenantDomains)
+              .where(
+                and(
+                  eq(tenantDomains.tenant_id, input.tenantId),
+                  eq(tenantDomains.is_primary, true),
+                ),
+              )
+              .limit(1);
+
+            const overrides = await tx
+              .select({
+                featureKey: tenantFeatureOverrides.feature_key,
+                enabled: tenantFeatureOverrides.enabled,
+                expiresAt: tenantFeatureOverrides.expires_at,
+                updatedAt: tenantFeatureOverrides.updated_at,
+                updatedBy: tenantFeatureOverrides.updated_by,
+              })
+              .from(tenantFeatureOverrides)
+              .where(eq(tenantFeatureOverrides.tenant_id, input.tenantId));
+
+            return {
+              tenant: {
+                id: tenant.id,
+                name: tenant.name,
+                slug: tenant.slug,
+                primaryHostname: primaryDomain?.hostname ?? null,
+                createdAt: tenant.createdAt,
+              },
+              overrides,
+            } satisfies UpdatedTenantResult;
+          }),
+        );
+
       const recordPlatformAuditEvent = (input: PlatformAuditEventInput) =>
         tryAsync('record platform audit event', async () => {
           await db.insert(platformAuditEvents).values({
@@ -251,9 +392,11 @@ export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()
         findSuperAdminUser,
         findBetterAuthUserByLoweredEmail,
         listTenants,
+        findTenantById,
         tenantSlugExists,
         tenantHostnameExists,
         createTenantWithAdmin,
+        updateTenant,
         recordPlatformAuditEvent,
       };
     }),

--- a/src/effect/modules/superadmin/router.ts
+++ b/src/effect/modules/superadmin/router.ts
@@ -1,12 +1,19 @@
 import { HttpRouter, HttpServerRequest } from '@effect/platform';
-import { Effect } from 'effect';
+import { Effect, Schema } from 'effect';
 import { requireSuperAdmin } from '../../platform/auth/authorization';
 import { BetterAuthHeaders } from '../../platform/auth/better-auth';
 import { respondJson } from '../../platform/http/errors';
 import { getRequestHeaders } from '../../platform/http/session';
-import { CreateSuperAdminTenantSchema } from '@stocket/types/superadmin';
+import {
+  CreateSuperAdminTenantSchema,
+  UpdateSuperAdminTenantSchema,
+} from '@stocket/types/superadmin';
 import { getRequestContext } from '../../platform/http/request-context';
 import { SuperAdminService } from './service';
+
+const TenantPathParamsSchema = Schema.Struct({
+  tenantId: Schema.UUID,
+});
 
 export const superAdminRouter = HttpRouter.empty.pipe(
   HttpRouter.get(
@@ -47,6 +54,41 @@ export const superAdminRouter = HttpRouter.empty.pipe(
           })
           .pipe(Effect.provideService(BetterAuthHeaders, requestHeaders)),
         { status: 201 },
+      );
+    }),
+  ),
+  HttpRouter.get(
+    '/tenants/:tenantId/features',
+    Effect.gen(function* () {
+      yield* requireSuperAdmin;
+      const { tenantId } = yield* HttpRouter.schemaPathParams(
+        TenantPathParamsSchema,
+      );
+      const superAdminService = yield* SuperAdminService;
+      return yield* respondJson(superAdminService.getTenantFeatures(tenantId));
+    }),
+  ),
+  HttpRouter.put(
+    '/tenants/:tenantId',
+    Effect.gen(function* () {
+      const session = yield* requireSuperAdmin;
+      const { tenantId } = yield* HttpRouter.schemaPathParams(
+        TenantPathParamsSchema,
+      );
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        UpdateSuperAdminTenantSchema,
+      );
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const requestContext = yield* getRequestContext;
+      const superAdminService = yield* SuperAdminService;
+      const userAgent = request.headers['user-agent'];
+
+      return yield* respondJson(
+        superAdminService.updateTenant(tenantId, dto, {
+          userId: session.user.id,
+          ipAddress: requestContext.ip,
+          userAgent: typeof userAgent === 'string' ? userAgent : null,
+        }),
       );
     }),
   ),

--- a/src/effect/modules/superadmin/service.spec.ts
+++ b/src/effect/modules/superadmin/service.spec.ts
@@ -1,5 +1,12 @@
 import { Effect, Layer } from 'effect';
+import {
+  DEFAULT_FEATURE_STATES,
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
 import { BetterAuth, BetterAuthHeaders } from '../../platform/auth/better-auth';
+import { TenantFeaturesService } from '../../platform/tenancy/tenant-features';
 import { UsersRepository } from '../users/repository';
 import { SuperAdminRepository } from './repository';
 import { SuperAdminService } from './service';
@@ -45,12 +52,33 @@ describe('Effect SuperAdminService', () => {
   const makeRepository = () => ({
     tenantSlugExists: vi.fn().mockReturnValue(Effect.succeed(false)),
     tenantHostnameExists: vi.fn().mockReturnValue(Effect.succeed(false)),
-    findBetterAuthUserByLoweredEmail: vi.fn().mockReturnValue(
-      Effect.succeed(null),
+    findBetterAuthUserByLoweredEmail: vi
+      .fn()
+      .mockReturnValue(Effect.succeed(null)),
+    findTenantById: vi.fn().mockReturnValue(
+      Effect.succeed({
+        id: '00000000-0000-4000-8000-000000000101',
+        name: 'Acme France',
+        slug: 'acme',
+        primaryHostname: 'acme.localhost:3000',
+        createdAt: new Date('2026-06-22T10:00:00.000Z'),
+      }),
     ),
     createTenantWithAdmin: vi
       .fn()
       .mockReturnValue(Effect.succeed(createdTenant)),
+    updateTenant: vi.fn().mockReturnValue(
+      Effect.succeed({
+        tenant: {
+          id: '00000000-0000-4000-8000-000000000101',
+          name: 'Acme Updated',
+          slug: 'acme',
+          primaryHostname: 'acme.localhost:3000',
+          createdAt: new Date('2026-06-22T10:00:00.000Z'),
+        },
+        overrides: [],
+      }),
+    ),
     recordPlatformAuditEvent: vi.fn().mockReturnValue(Effect.void),
   });
 
@@ -67,13 +95,36 @@ describe('Effect SuperAdminService', () => {
     },
   });
 
+  const makeTenantFeatures = () => ({
+    listOverrides: vi.fn().mockReturnValue(Effect.succeed([])),
+    getEffectiveFeatures: vi
+      .fn()
+      .mockReturnValue(Effect.succeed(DEFAULT_FEATURE_STATES)),
+    getTenantFeatures: vi.fn().mockImplementation((tenantId: string) =>
+      Effect.succeed({
+        tenantId,
+        planKey: PlanKey.FREE,
+        source: EntitlementSource.MANUAL,
+        features: {
+          ...DEFAULT_FEATURE_STATES,
+          [FeatureKey.SMART_IMPORT]: true,
+        },
+        overrides: [],
+        updated_at: null,
+        updated_by: null,
+      }),
+    ),
+  });
+
   const makeServiceLayer = ({
     betterAuth,
     repository,
+    tenantFeatures,
     usersRepository,
   }: {
     betterAuth: unknown;
     repository: unknown;
+    tenantFeatures: unknown;
     usersRepository: unknown;
   }) =>
     SuperAdminService.DefaultWithoutDependencies.pipe(
@@ -87,6 +138,10 @@ describe('Effect SuperAdminService', () => {
           Layer.succeed(
             UsersRepository,
             usersRepository as typeof UsersRepository.Service,
+          ),
+          Layer.succeed(
+            TenantFeaturesService,
+            tenantFeatures as typeof TenantFeaturesService.Service,
           ),
         ),
       ),
@@ -119,9 +174,11 @@ describe('Effect SuperAdminService', () => {
     const betterAuth = makeBetterAuth();
     const repository = makeRepository();
     const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
     const layer = makeServiceLayer({
       betterAuth,
       repository,
+      tenantFeatures,
       usersRepository,
     });
 
@@ -153,7 +210,8 @@ describe('Effect SuperAdminService', () => {
     });
 
     await waitForCall(betterAuth.api.requestPasswordReset);
-    const welcomeRequest = betterAuth.api.requestPasswordReset.mock.calls[0]![0];
+    const welcomeRequest =
+      betterAuth.api.requestPasswordReset.mock.calls[0]![0];
     expect(welcomeRequest.body).toEqual({
       email: 'admin@example.com',
       redirectTo: 'https://acme.localhost:3000/reset-password?flow=welcome',
@@ -178,9 +236,11 @@ describe('Effect SuperAdminService', () => {
       }),
     );
     const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
     const layer = makeServiceLayer({
       betterAuth,
       repository,
+      tenantFeatures,
       usersRepository,
     });
 
@@ -197,6 +257,145 @@ describe('Effect SuperAdminService', () => {
       id: 'existing-admin-1',
       email: 'existing@example.com',
       name: 'Existing Admin',
+    });
+  });
+
+  it('returns tenant features for an existing tenant', async () => {
+    const betterAuth = makeBetterAuth();
+    const repository = makeRepository();
+    const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
+    const layer = makeServiceLayer({
+      betterAuth,
+      repository,
+      tenantFeatures,
+      usersRepository,
+    });
+
+    const result = await run(
+      Effect.flatMap(SuperAdminService, (service) =>
+        service.getTenantFeatures('00000000-0000-4000-8000-000000000101'),
+      ),
+      layer,
+    );
+
+    expect(repository.findTenantById).toHaveBeenCalledWith(
+      '00000000-0000-4000-8000-000000000101',
+    );
+    expect(tenantFeatures.getTenantFeatures).toHaveBeenCalledWith(
+      '00000000-0000-4000-8000-000000000101',
+    );
+    expect(result.features[FeatureKey.SMART_IMPORT]).toBe(true);
+  });
+
+  it('fails when reading features for an unknown tenant', async () => {
+    const betterAuth = makeBetterAuth();
+    const repository = makeRepository();
+    repository.findTenantById.mockReturnValue(Effect.succeed(null));
+    const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
+    const layer = makeServiceLayer({
+      betterAuth,
+      repository,
+      tenantFeatures,
+      usersRepository,
+    });
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        Effect.flatMap(SuperAdminService, (service) =>
+          service.getTenantFeatures('00000000-0000-4000-8000-000000000999'),
+        ),
+      ).pipe(Effect.provide(layer)),
+    );
+
+    expect(error).toMatchObject({
+      _tag: 'TenantNotFound',
+      tenantId: '00000000-0000-4000-8000-000000000999',
+      statusCode: 404,
+    });
+  });
+
+  it('updates tenant name and staged feature state atomically through the repository', async () => {
+    const betterAuth = makeBetterAuth();
+    const repository = makeRepository();
+    const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
+    const layer = makeServiceLayer({
+      betterAuth,
+      repository,
+      tenantFeatures,
+      usersRepository,
+    });
+
+    const features = {
+      ...DEFAULT_FEATURE_STATES,
+      [FeatureKey.SMART_IMPORT]: true,
+    };
+
+    const result = await run(
+      Effect.flatMap(SuperAdminService, (service) =>
+        service.updateTenant(
+          '00000000-0000-4000-8000-000000000101',
+          {
+            name: ' Acme Updated ',
+            features,
+          },
+          actor,
+        ),
+      ),
+      layer,
+    );
+
+    expect(repository.updateTenant).toHaveBeenCalledWith({
+      tenantId: '00000000-0000-4000-8000-000000000101',
+      name: 'Acme Updated',
+      features,
+      updatedBy: 'superadmin-1',
+    });
+    expect(result.features[FeatureKey.SMART_IMPORT]).toBe(true);
+
+    await waitForCall(repository.recordPlatformAuditEvent);
+    expect(repository.recordPlatformAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'tenant.update',
+        entityId: '00000000-0000-4000-8000-000000000101',
+      }),
+    );
+  });
+
+  it('fails when updating an unknown tenant', async () => {
+    const betterAuth = makeBetterAuth();
+    const repository = makeRepository();
+    repository.updateTenant.mockReturnValue(Effect.succeed(null));
+    const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
+    const layer = makeServiceLayer({
+      betterAuth,
+      repository,
+      tenantFeatures,
+      usersRepository,
+    });
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        Effect.flatMap(SuperAdminService, (service) =>
+          service.updateTenant(
+            '00000000-0000-4000-8000-000000000999',
+            {
+              name: 'Missing',
+              features: DEFAULT_FEATURE_STATES,
+            },
+            actor,
+          ),
+        ),
+      ).pipe(Effect.provide(layer)),
+    );
+
+    expect(error).toMatchObject({
+      _tag: 'TenantNotFound',
+      tenantId: '00000000-0000-4000-8000-000000000999',
+      statusCode: 404,
     });
   });
 });

--- a/src/effect/modules/superadmin/service.ts
+++ b/src/effect/modules/superadmin/service.ts
@@ -4,27 +4,30 @@ import type {
   SuperAdminCreateTenantResponse,
   SuperAdminMeResponse,
   SuperAdminTenantListResponse,
+  UpdateSuperAdminTenantInput,
 } from '@stocket/types/superadmin';
 import {
   hostnameForTenantSlug,
   isReservedTenantSlug,
   isValidTenantSlug,
 } from '../../platform/tenancy/host';
+import {
+  normalizeFeatureStates,
+  TenantFeaturesService,
+} from '../../platform/tenancy/tenant-features';
 import type { UserSession } from '../../platform/auth/user-session';
 import { makeServiceTracer } from '../../platform/observability/service-tracer';
 import { makeTryAsync } from '../../platform/effect/try-async';
 import { BetterAuth, BetterAuthHeaders } from '../../platform/auth/better-auth';
 import { type LogPayload } from '../../platform/observability/messages';
 import { UsersRepository } from '../users/repository';
-import {
-  tenantWelcomeOrigin,
-  welcomeRedirectUrl,
-} from '../users/users.utils';
+import { tenantWelcomeOrigin, welcomeRedirectUrl } from '../users/users.utils';
 import {
   InvalidTenantSlug,
   ReservedTenantSlug,
   SuperAdminRepositoryError,
   TenantHostnameAlreadyExists,
+  TenantNotFound,
   TenantSlugAlreadyExists,
 } from './superadmin.errors';
 import { SuperAdminRepository } from './repository';
@@ -94,6 +97,7 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
     effect: Effect.gen(function* () {
       const repository = yield* SuperAdminRepository;
       const usersRepository = yield* UsersRepository;
+      const tenantFeaturesService = yield* TenantFeaturesService;
       const betterAuth = yield* BetterAuth;
       const trace = makeServiceTracer({
         serviceName: 'SuperAdminService',
@@ -155,6 +159,78 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
               })),
             }) satisfies SuperAdminTenantListResponse,
         ),
+      );
+
+      const getTenantFeatures = trace.traced(
+        'getTenantFeatures',
+        (tenantId: string) =>
+          Effect.gen(function* () {
+            const tenant = yield* repository.findTenantById(tenantId);
+            if (!tenant) {
+              return yield* Effect.fail(
+                new TenantNotFound({
+                  tenantId,
+                  messageKey: 'superadmin.tenantNotFound',
+                }),
+              );
+            }
+
+            return yield* tenantFeaturesService.getTenantFeatures(tenantId);
+          }),
+        (tenantId) => ({ attributes: { entityId: tenantId } }),
+      );
+
+      const updateTenant = trace.traced(
+        'updateTenant',
+        (
+          tenantId: string,
+          input: UpdateSuperAdminTenantInput,
+          actor: {
+            readonly userId: string;
+            readonly ipAddress?: string | null;
+            readonly userAgent?: string | null;
+          },
+        ) =>
+          Effect.gen(function* () {
+            const name = input.name.trim();
+            const features = normalizeFeatureStates(input.features);
+            const updated = yield* repository.updateTenant({
+              tenantId,
+              name,
+              features,
+              updatedBy: actor.userId,
+            });
+
+            if (!updated) {
+              return yield* Effect.fail(
+                new TenantNotFound({
+                  tenantId,
+                  messageKey: 'superadmin.tenantNotFound',
+                }),
+              );
+            }
+
+            yield* Effect.forkDaemon(
+              repository
+                .recordPlatformAuditEvent({
+                  actorUserId: actor.userId,
+                  action: 'tenant.update',
+                  entityType: 'tenant',
+                  entityId: tenantId,
+                  metadata: {
+                    name: updated.tenant.name,
+                    slug: updated.tenant.slug,
+                    features,
+                  },
+                  ipAddress: actor.ipAddress ?? null,
+                  userAgent: actor.userAgent ?? null,
+                })
+                .pipe(Effect.ignore),
+            );
+
+            return yield* tenantFeaturesService.getTenantFeatures(tenantId);
+          }),
+        (tenantId) => ({ attributes: { entityId: tenantId } }),
       );
 
       const createTenant = trace.traced(
@@ -299,9 +375,15 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
       return {
         me,
         listTenants,
+        getTenantFeatures,
+        updateTenant,
         createTenant,
       };
     }),
-    dependencies: [SuperAdminRepository.Default, UsersRepository.Default],
+    dependencies: [
+      SuperAdminRepository.Default,
+      UsersRepository.Default,
+      TenantFeaturesService.Default,
+    ],
   },
 ) {}

--- a/src/effect/modules/superadmin/superadmin.errors.ts
+++ b/src/effect/modules/superadmin/superadmin.errors.ts
@@ -2,6 +2,7 @@ import {
   BadRequestError,
   ConflictError,
   InternalError,
+  NotFoundError,
 } from '../../platform/effect/domain-errors';
 
 export class InvalidTenantSlug extends BadRequestError('InvalidTenantSlug')<{
@@ -22,6 +23,10 @@ export class TenantHostnameAlreadyExists extends ConflictError(
   'TenantHostnameAlreadyExists',
 )<{
   readonly hostname: string;
+}> {}
+
+export class TenantNotFound extends NotFoundError('TenantNotFound')<{
+  readonly tenantId: string;
 }> {}
 
 export class SuperAdminRepositoryError extends InternalError(

--- a/src/effect/platform/catalogs/de.ts
+++ b/src/effect/platform/catalogs/de.ts
@@ -133,6 +133,8 @@ export const deCatalog: Record<MessageKey, string> = {
     'Standortbestand kann nicht importiert werden, solange fuer dieses Produkt und diesen Standort bereichsbezogener Bestand existiert.',
   'products.importCsvParseFailed':
     'Die hochgeladene CSV-Datei konnte nicht geparst werden.',
+  'products.importInvalidMapping':
+    'Die Zuordnung fuer den Produktimport ist ungueltig.',
   'products.importReadUploadFailed':
     'Die hochgeladene Produktimportdatei konnte nicht gelesen werden.',
   'products.importUnsupportedFormat':

--- a/src/effect/platform/catalogs/de.ts
+++ b/src/effect/platform/catalogs/de.ts
@@ -21,6 +21,8 @@ export const deCatalog: Record<MessageKey, string> = {
     'Die Anforderung der Willkommens-E-Mail ist fehlgeschlagen.',
   'tenant.membershipRejected':
     'Der aktive Tenant ist fuer diesen Benutzer nicht verfuegbar.',
+  'tenantFeatures.repositoryFailed':
+    'Der Tenant-Feature-Vorgang ist fehlgeschlagen.',
   'tenant.notResolved':
     'Fuer diese Anfrage konnte kein aktiver Tenant ermittelt werden.',
   'tenant.hostNotFound': 'Tenant-Host nicht gefunden.',
@@ -162,6 +164,7 @@ export const deCatalog: Record<MessageKey, string> = {
     'Die Superadmin-Autorisierung ist fehlgeschlagen.',
   'superadmin.repositoryFailed': 'Der Superadmin-Vorgang ist fehlgeschlagen.',
   'superadmin.reservedTenantSlug': 'Der Tenant-Slug ist reserviert.',
+  'superadmin.tenantNotFound': 'Tenant nicht gefunden.',
   'superadmin.tenantHostnameAlreadyExists':
     'Ein Tenant mit diesem Hostnamen existiert bereits.',
   'superadmin.tenantSlugAlreadyExists':

--- a/src/effect/platform/catalogs/en.ts
+++ b/src/effect/platform/catalogs/en.ts
@@ -109,10 +109,10 @@ export const enCatalog = {
   'products.importAreaScopedInventoryConflict':
     'Cannot import location-level inventory while area-scoped inventory exists for this product and location.',
   'products.importCsvParseFailed': 'Could not parse the uploaded CSV file.',
+  'products.importInvalidMapping': 'Invalid product import mapping payload.',
   'products.importReadUploadFailed':
     'Failed to read the uploaded product import file.',
-  'products.importUnsupportedFormat':
-    'Unsupported product import CSV headers.',
+  'products.importUnsupportedFormat': 'Unsupported product import CSV headers.',
   'products.infrastructureFailed': 'Product operation failed.',
   'products.notDeleted': 'Product is not deleted.',
   'products.notFound': 'Product not found.',

--- a/src/effect/platform/catalogs/en.ts
+++ b/src/effect/platform/catalogs/en.ts
@@ -18,6 +18,7 @@ export const enCatalog = {
   'email.welcomeRequestFailed': 'Failed to request the welcome email.',
   'tenant.membershipRejected':
     'The active tenant is not available for this user.',
+  'tenantFeatures.repositoryFailed': 'Tenant feature operation failed.',
   'tenant.notResolved': 'No active tenant could be resolved for this request.',
   'tenant.hostNotFound': 'Tenant host not found.',
   'branding.repositoryFailed': 'Branding operation failed.',
@@ -132,6 +133,7 @@ export const enCatalog = {
   'superadmin.infrastructureFailed': 'Superadmin authorization failed.',
   'superadmin.repositoryFailed': 'Superadmin operation failed.',
   'superadmin.reservedTenantSlug': 'Tenant slug is reserved.',
+  'superadmin.tenantNotFound': 'Tenant not found.',
   'superadmin.tenantHostnameAlreadyExists':
     'A tenant with this hostname already exists.',
   'superadmin.tenantSlugAlreadyExists':

--- a/src/effect/platform/catalogs/fr.ts
+++ b/src/effect/platform/catalogs/fr.ts
@@ -17,8 +17,7 @@ export const frCatalog: Record<MessageKey, string> = {
   'auth.permissionDenied': 'Permissions insuffisantes.',
   'auth.unauthorized': 'Non autorise.',
   'email.sendFailed': "L'envoi de l'e-mail a echoue.",
-  'email.welcomeRequestFailed':
-    "La demande d'e-mail de bienvenue a echoue.",
+  'email.welcomeRequestFailed': "La demande d'e-mail de bienvenue a echoue.",
   'tenant.membershipRejected':
     "Le tenant actif n'est pas disponible pour cet utilisateur.",
   'tenant.notResolved':
@@ -126,6 +125,7 @@ export const frCatalog: Record<MessageKey, string> = {
     "Impossible d'importer un stock au niveau emplacement lorsqu'un stock par zone existe deja pour ce produit et cet emplacement.",
   'products.importCsvParseFailed':
     "Impossible d'analyser le fichier CSV televerse.",
+  'products.importInvalidMapping': "Le mapping d'import produits est invalide.",
   'products.importReadUploadFailed':
     "La lecture du fichier d'import produits televerse a echoue.",
   'products.importUnsupportedFormat':

--- a/src/effect/platform/catalogs/fr.ts
+++ b/src/effect/platform/catalogs/fr.ts
@@ -20,6 +20,8 @@ export const frCatalog: Record<MessageKey, string> = {
   'email.welcomeRequestFailed': "La demande d'e-mail de bienvenue a echoue.",
   'tenant.membershipRejected':
     "Le tenant actif n'est pas disponible pour cet utilisateur.",
+  'tenantFeatures.repositoryFailed':
+    "L'operation sur les fonctionnalites du tenant a echoue.",
   'tenant.notResolved':
     'Aucun tenant actif na pu etre resolu pour cette requete.',
   'tenant.hostNotFound': 'Hote tenant introuvable.',
@@ -151,6 +153,7 @@ export const frCatalog: Record<MessageKey, string> = {
   'superadmin.infrastructureFailed': "L'autorisation superadmin a echoue.",
   'superadmin.repositoryFailed': "L'operation superadmin a echoue.",
   'superadmin.reservedTenantSlug': 'Le slug tenant est reserve.',
+  'superadmin.tenantNotFound': 'Tenant introuvable.',
   'superadmin.tenantHostnameAlreadyExists':
     'Un tenant avec cet hote existe deja.',
   'superadmin.tenantSlugAlreadyExists': 'Un tenant avec ce slug existe deja.',

--- a/src/effect/platform/db/schema.ts
+++ b/src/effect/platform/db/schema.ts
@@ -107,7 +107,9 @@ export const betterAuthUsers = pgTable(
   {
     // Better Auth still generates UUID values, but the app stores user ids as
     // text because local RBAC tables and audit logs use opaque auth ids.
-    id: text('id').primaryKey().default(sql`gen_random_uuid()`),
+    id: text('id')
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
     name: text('name').notNull(),
     email: text('email').notNull(),
     email_verified: boolean('email_verified').notNull().default(false),
@@ -252,6 +254,29 @@ export const superAdmins = pgTable('super_admins', {
     .notNull()
     .defaultNow(),
 });
+
+export const tenantFeatureOverrides = pgTable(
+  'tenant_feature_overrides',
+  {
+    tenant_id: uuid('tenant_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    feature_key: varchar('feature_key', { length: 100 }).notNull(),
+    enabled: boolean('enabled').notNull(),
+    expires_at: timestamp('expires_at', { withTimezone: true }),
+    updated_at: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updated_by: text('updated_by'),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.tenant_id, table.feature_key],
+      name: 'tenant_feature_overrides_tenant_id_feature_key_pk',
+    }),
+    index('tenant_feature_overrides_tenant_id_idx').on(table.tenant_id),
+  ],
+);
 
 export const platformAuditEvents = pgTable(
   'platform_audit_events',

--- a/src/effect/platform/tenancy/tenant-features.ts
+++ b/src/effect/platform/tenancy/tenant-features.ts
@@ -1,0 +1,148 @@
+import { Effect } from 'effect';
+import { desc, eq } from 'drizzle-orm';
+import {
+  DEFAULT_FEATURE_STATES,
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+  type FeatureStates,
+  type TenantFeatureOverrideResponseDto,
+  type TenantFeaturesResponseDto,
+} from '@stocket/types/features';
+import { DrizzleDatabase } from '../db/drizzle';
+import { tenantFeatureOverrides } from '../db/schema';
+import { InternalError } from '../effect/domain-errors';
+
+export class TenantFeaturesRepositoryError extends InternalError(
+  'TenantFeaturesRepositoryError',
+)<{
+  readonly action: string;
+  readonly cause?: unknown;
+}> {}
+
+export interface TenantFeatureOverrideRow {
+  readonly featureKey: string;
+  readonly enabled: boolean;
+  readonly expiresAt: Date | null;
+  readonly updatedAt: Date;
+  readonly updatedBy: string | null;
+}
+
+export const FEATURE_KEYS = Object.values(FeatureKey) as FeatureKey[];
+
+const isFeatureKey = (value: string): value is FeatureKey =>
+  FEATURE_KEYS.includes(value as FeatureKey);
+
+export const normalizeFeatureStates = (
+  features: Partial<FeatureStates> | null | undefined,
+): FeatureStates => ({
+  ...DEFAULT_FEATURE_STATES,
+  ...(features ?? {}),
+});
+
+export const resolveFeatureStates = (
+  overrides: ReadonlyArray<TenantFeatureOverrideRow>,
+  now = new Date(),
+): FeatureStates => {
+  const features = normalizeFeatureStates(undefined);
+
+  for (const override of overrides) {
+    if (!isFeatureKey(override.featureKey)) {
+      continue;
+    }
+    if (override.expiresAt && override.expiresAt <= now) {
+      continue;
+    }
+    features[override.featureKey] = override.enabled;
+  }
+
+  return features;
+};
+
+const toOverrideDto = (
+  row: TenantFeatureOverrideRow,
+): TenantFeatureOverrideResponseDto => ({
+  featureKey: row.featureKey as FeatureKey,
+  enabled: row.enabled,
+  reason: null,
+  expires_at: row.expiresAt,
+  updated_at: row.updatedAt,
+  updated_by: row.updatedBy,
+});
+
+const latestOverride = (
+  overrides: ReadonlyArray<TenantFeatureOverrideRow>,
+): TenantFeatureOverrideRow | null =>
+  overrides.reduce<TenantFeatureOverrideRow | null>(
+    (latest, override) =>
+      latest === null || override.updatedAt > latest.updatedAt
+        ? override
+        : latest,
+    null,
+  );
+
+export class TenantFeaturesService extends Effect.Service<TenantFeaturesService>()(
+  '@stocket/effect/tenancy/TenantFeaturesService',
+  {
+    effect: Effect.gen(function* () {
+      const db = yield* DrizzleDatabase;
+
+      const listOverrides = (tenantId: string) =>
+        Effect.tryPromise({
+          try: async () =>
+            await db
+              .select({
+                featureKey: tenantFeatureOverrides.feature_key,
+                enabled: tenantFeatureOverrides.enabled,
+                expiresAt: tenantFeatureOverrides.expires_at,
+                updatedAt: tenantFeatureOverrides.updated_at,
+                updatedBy: tenantFeatureOverrides.updated_by,
+              })
+              .from(tenantFeatureOverrides)
+              .where(eq(tenantFeatureOverrides.tenant_id, tenantId))
+              .orderBy(desc(tenantFeatureOverrides.updated_at)),
+          catch: (cause) =>
+            new TenantFeaturesRepositoryError({
+              action: 'list tenant feature overrides',
+              cause,
+              messageKey: 'tenantFeatures.repositoryFailed',
+            }),
+        });
+
+      const getEffectiveFeatures = (tenantId: string) =>
+        Effect.map(listOverrides(tenantId), (rows) =>
+          resolveFeatureStates(rows),
+        );
+
+      const getTenantFeatures = (tenantId: string) =>
+        Effect.map(listOverrides(tenantId), (rows) => {
+          const now = new Date();
+          const latest = latestOverride(rows);
+          const activeOverrides = rows.filter(
+            (row) => !row.expiresAt || row.expiresAt > now,
+          );
+
+          return {
+            tenantId,
+            planKey: PlanKey.FREE,
+            source:
+              activeOverrides.length > 0
+                ? EntitlementSource.MANUAL
+                : EntitlementSource.SYSTEM,
+            features: resolveFeatureStates(rows, now),
+            overrides: rows
+              .filter((row) => isFeatureKey(row.featureKey))
+              .map(toOverrideDto),
+            updated_at: latest?.updatedAt ?? null,
+            updated_by: latest?.updatedBy ?? null,
+          } satisfies TenantFeaturesResponseDto;
+        });
+
+      return {
+        listOverrides,
+        getEffectiveFeatures,
+        getTenantFeatures,
+      };
+    }),
+  },
+) {}

--- a/src/effect/platform/testing/tenant-features.spec.ts
+++ b/src/effect/platform/testing/tenant-features.spec.ts
@@ -1,0 +1,42 @@
+import { DEFAULT_FEATURE_STATES, FeatureKey } from '@stocket/types/features';
+import { resolveFeatureStates } from '../tenancy/tenant-features';
+
+describe('tenant feature resolution', () => {
+  it('returns shared defaults with no overrides', () => {
+    expect(resolveFeatureStates([])).toEqual(DEFAULT_FEATURE_STATES);
+  });
+
+  it('applies active overrides by feature key', () => {
+    expect(
+      resolveFeatureStates([
+        {
+          featureKey: FeatureKey.SMART_IMPORT,
+          enabled: true,
+          expiresAt: null,
+          updatedAt: new Date('2026-06-22T10:00:00.000Z'),
+          updatedBy: 'superadmin-1',
+        },
+      ]),
+    ).toEqual({
+      ...DEFAULT_FEATURE_STATES,
+      [FeatureKey.SMART_IMPORT]: true,
+    });
+  });
+
+  it('ignores expired overrides', () => {
+    expect(
+      resolveFeatureStates(
+        [
+          {
+            featureKey: FeatureKey.ORDERS,
+            enabled: false,
+            expiresAt: new Date('2026-06-21T10:00:00.000Z'),
+            updatedAt: new Date('2026-06-20T10:00:00.000Z'),
+            updatedBy: 'superadmin-1',
+          },
+        ],
+        new Date('2026-06-22T10:00:00.000Z'),
+      ),
+    ).toEqual(DEFAULT_FEATURE_STATES);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the reviewed Sortly onboarding import backend flow:

- `POST /products/import/preview` to parse CSVs, summarize rows, expose raw Sortly category/location values, and return deterministic mapping suggestions
- `POST /products/import/commit` to apply approved mappings and create/update categories, products, locations, nested areas, inventory, and optional photos
- `area_path` support so inventory can be attached to nested areas under a top-level location
- warnings for non-blocking AI/photo issues, while keeping the existing `POST /products/import` behavior compatible

## Dependencies

Depends on stocketfr/packages#21 for the shared import preview/mapping/commit DTOs.

## Validation

- `node_modules/.bin/tsc --noEmit --pretty false --project tsconfig.json`
- `node_modules/.bin/vitest run src/effect/modules/products/import/service.spec.ts src/effect/modules/products/router.spec.ts`
- `node_modules/.bin/vitest --config vitest.integration.config.ts run src/effect/modules/products/import/import.integration.spec.ts`
- `node_modules/.bin/oxlint src/effect/modules/products/import/import.integration.spec.ts src/effect/modules/products/import/repository.ts src/effect/modules/products/import/service.spec.ts src/effect/modules/products/import/service.ts src/effect/modules/products/import/types.ts src/effect/modules/products/import/utils.ts src/effect/modules/products/products.errors.ts src/effect/modules/products/router.ts src/effect/platform/catalogs/de.ts src/effect/platform/catalogs/en.ts src/effect/platform/catalogs/fr.ts`

## Notes

The `use_llm` preview flag is wired through the API, but a real provider is not configured in this change. The backend currently returns deterministic suggestions and a warning when AI suggestions are requested.
