### PR TITLE
[codex] Add tenant feature toggle APIs

### DIFF
--- a/drizzle/0006_tenant_feature_overrides.sql
+++ b/drizzle/0006_tenant_feature_overrides.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS "tenant_feature_overrides" (
+  "tenant_id" uuid NOT NULL,
+  "feature_key" varchar(100) NOT NULL,
+  "enabled" boolean NOT NULL,
+  "expires_at" timestamp with time zone,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_by" text,
+  CONSTRAINT "tenant_feature_overrides_tenant_id_feature_key_pk" PRIMARY KEY("tenant_id","feature_key")
+);
+
+DO $$ BEGIN
+ ALTER TABLE "tenant_feature_overrides"
+ ADD CONSTRAINT "tenant_feature_overrides_tenant_id_organization_id_fk"
+ FOREIGN KEY ("tenant_id") REFERENCES "public"."organization"("id")
+ ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "tenant_feature_overrides_tenant_id_idx"
+ON "tenant_feature_overrides" USING btree ("tenant_id");

--- a/src/effect/modules/auth/mappers.spec.ts
+++ b/src/effect/modules/auth/mappers.spec.ts
@@ -3,6 +3,7 @@ import {
   toProfileResponse,
   toSessionClaimsResponse,
 } from './mappers';
+import { DEFAULT_FEATURE_STATES, PlanKey } from '@stocket/types/features';
 
 describe('auth mappers', () => {
   const session = {
@@ -37,6 +38,10 @@ describe('auth mappers', () => {
           tenantName: 'Stocket',
           tenantSlug: 'stocket',
         },
+        {
+          planKey: PlanKey.FREE,
+          features: DEFAULT_FEATURE_STATES,
+        },
       ),
     ).toEqual({
       id: 'user-1',
@@ -46,6 +51,8 @@ describe('auth mappers', () => {
       tenantId: '00000000-0000-4000-8000-000000000001',
       tenantName: 'Stocket',
       tenantSlug: 'stocket',
+      planKey: PlanKey.FREE,
+      features: DEFAULT_FEATURE_STATES,
       roles: ['Admin'],
       permissions: {
         roles: ['read', 'write'],

--- a/src/effect/modules/auth/mappers.ts
+++ b/src/effect/modules/auth/mappers.ts
@@ -3,6 +3,7 @@ import type {
   ProfileResponseDto,
   SessionClaimsResponseDto,
 } from '@stocket/types/auth';
+import type { FeatureStates, PlanKey } from '@stocket/types/features';
 import type { UserSession } from '../../platform/auth/user-session';
 import {
   getSessionIdFromSession,
@@ -16,6 +17,10 @@ export const toCurrentUserResponse = (
   session: UserSession,
   userPermissions: UserPermissions,
   tenant: TenantContext,
+  entitlements: {
+    readonly planKey: PlanKey;
+    readonly features: FeatureStates;
+  },
 ): CurrentUserResponseDto => {
   const { id, name, email, image } = session.user;
 
@@ -27,6 +32,8 @@ export const toCurrentUserResponse = (
     tenantId: tenant.tenantId,
     tenantName: tenant.tenantName,
     tenantSlug: tenant.tenantSlug,
+    planKey: entitlements.planKey,
+    features: entitlements.features,
     roles: userPermissions.roleNames,
     permissions: userPermissions.permissions,
   };

--- a/src/effect/modules/auth/service.integration.spec.ts
+++ b/src/effect/modules/auth/service.integration.spec.ts
@@ -22,10 +22,20 @@
 import { HttpServerRequest } from '@effect/platform';
 import { Effect, Layer, ManagedRuntime } from 'effect';
 import { Permission, Resource } from '@stocket/types/auth';
+import {
+  DEFAULT_FEATURE_STATES,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import type { BetterAuthService } from '../../platform/auth/better-auth';
 import type { DrizzleDb } from '../../platform/db/drizzle';
-import { rolePermissions } from '../../platform/db/schema';
+import {
+  rolePermissions,
+  tenantFeatureOverrides,
+} from '../../platform/db/schema';
+import { DEFAULT_TENANT_ID } from '../../platform/tenancy/tenant-constants';
+import { TenantFeaturesService } from '../../platform/tenancy/tenant-features';
 import {
   makeBetterAuthTestLayer,
   makeFakeBetterAuthUser,
@@ -208,6 +218,12 @@ describe('AuthService Integration', () => {
             { resource: Resource.DASHBOARD, permission: Permission.READ },
           ],
         });
+        await db.insert(tenantFeatureOverrides).values({
+          tenant_id: DEFAULT_TENANT_ID,
+          feature_key: FeatureKey.SMART_IMPORT,
+          enabled: true,
+          updated_by: 'superadmin-1',
+        });
 
         const layer = buildAuthServiceLayer(TEST_USER_ID);
         const result = await run(
@@ -218,6 +234,11 @@ describe('AuthService Integration', () => {
         expect(result.id).toBe(TEST_USER_ID);
         expect(result.name).toBe('Integration Test User');
         expect(result.email).toBe('integration@example.com');
+        expect(result.planKey).toBe(PlanKey.FREE);
+        expect(result.features).toEqual({
+          ...DEFAULT_FEATURE_STATES,
+          [FeatureKey.SMART_IMPORT]: true,
+        });
         expect(result.roles).toEqual(['Integration Admin']);
         expect(result.permissions[Resource.ROLES]).toEqual(
           expect.arrayContaining([Permission.READ, Permission.WRITE]),
@@ -347,6 +368,7 @@ describe('AuthService Integration', () => {
             Layer.mergeAll(
               dbLayer,
               buildRolesServiceLayer(),
+              TenantFeaturesService.Default.pipe(Layer.provide(dbLayer)),
               buildBetterAuthLayer(TEST_USER_ID),
               makeRequestLayer(),
             ),

--- a/src/effect/modules/auth/service.spec.ts
+++ b/src/effect/modules/auth/service.spec.ts
@@ -10,7 +10,14 @@
 import { describe, expect, it } from '@effect/vitest';
 import { Effect, Layer } from 'effect';
 import { Permission, Resource } from '@stocket/types/auth';
+import {
+  DEFAULT_FEATURE_STATES,
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
 import { makeTestLayer } from '../../testing/test-harness';
+import { TenantFeaturesService } from '../../platform/tenancy/tenant-features';
 import { RolesService, type UserPermissions } from '../roles/service';
 import { AuthService } from './service';
 
@@ -70,12 +77,32 @@ const rolesLayer = (overrides: Partial<RolesService> = {}) =>
     ...overrides,
   });
 
-const serviceLayer = (roles = rolesLayer()) =>
-  AuthService.DefaultWithoutDependencies.pipe(Layer.provide(roles));
+const tenantFeaturesLayer = (overrides: Partial<TenantFeaturesService> = {}) =>
+  makeTestLayer(TenantFeaturesService)({
+    listOverrides: () => Effect.succeed([]),
+    getEffectiveFeatures: () => Effect.succeed(DEFAULT_FEATURE_STATES),
+    getTenantFeatures: () =>
+      Effect.succeed({
+        tenantId: '00000000-0000-4000-8000-000000000001',
+        planKey: PlanKey.FREE,
+        source: EntitlementSource.SYSTEM,
+        features: DEFAULT_FEATURE_STATES,
+        overrides: [],
+        updated_at: null,
+        updated_by: null,
+      }),
+    ...overrides,
+  });
+
+const serviceLayer = (roles = rolesLayer(), features = tenantFeaturesLayer()) =>
+  AuthService.DefaultWithoutDependencies.pipe(
+    Layer.provide(Layer.mergeAll(roles, features)),
+  );
 
 const withService = <A, E, R>(
   body: (svc: AuthService) => Effect.Effect<A, E, R>,
   rolesOverrides?: Partial<RolesService>,
+  featuresOverrides?: Partial<TenantFeaturesService>,
 ): Effect.Effect<A, E, never> =>
   // `requireSession` is replaced by the `vi.mock` above, so its residual
   // `BetterAuthService | HttpServerRequest` requirements are discharged at
@@ -85,7 +112,12 @@ const withService = <A, E, R>(
     const svc = yield* AuthService;
     return yield* body(svc);
   }).pipe(
-    Effect.provide(serviceLayer(rolesLayer(rolesOverrides))),
+    Effect.provide(
+      serviceLayer(
+        rolesLayer(rolesOverrides),
+        tenantFeaturesLayer(featuresOverrides),
+      ),
+    ),
   ) as unknown as Effect.Effect<A, E, never>;
 
 // ---------------------------------------------------------------------------
@@ -113,6 +145,8 @@ describe('AuthService', () => {
               tenantId: '00000000-0000-4000-8000-000000000001',
               tenantName: 'Stocket',
               tenantSlug: 'stocket',
+              planKey: PlanKey.FREE,
+              features: DEFAULT_FEATURE_STATES,
               roles: ['Admin'],
               permissions: {
                 [Resource.ROLES]: [Permission.READ, Permission.WRITE],
@@ -210,6 +244,31 @@ describe('AuthService', () => {
         );
       },
     );
+
+    it.effect('returns effective features from TenantFeaturesService', () => {
+      mockRequireSession.mockReturnValue(Effect.succeed(makeSession()));
+      const features = {
+        ...DEFAULT_FEATURE_STATES,
+        [FeatureKey.SMART_IMPORT]: true,
+      };
+      const getEffectiveFeatures = vi
+        .fn()
+        .mockReturnValue(Effect.succeed(features));
+
+      return withService(
+        (svc) =>
+          Effect.gen(function* () {
+            const result = yield* svc.me();
+
+            expect(getEffectiveFeatures).toHaveBeenCalledWith(
+              '00000000-0000-4000-8000-000000000001',
+            );
+            expect(result.features).toEqual(features);
+          }),
+        undefined,
+        { getEffectiveFeatures },
+      );
+    });
   });
 
   describe('profile', () => {

--- a/src/effect/modules/auth/service.ts
+++ b/src/effect/modules/auth/service.ts
@@ -1,7 +1,9 @@
 import { Effect } from 'effect';
+import { PlanKey } from '@stocket/types/features';
 import { requireSession } from '../../platform/http/session';
 import { makeServiceTracer } from '../../platform/observability/service-tracer';
 import { resolveTenantForSession } from '../../platform/tenancy/tenant-context';
+import { TenantFeaturesService } from '../../platform/tenancy/tenant-features';
 import { RolesService } from '../roles/service';
 import {
   toCurrentUserResponse,
@@ -14,6 +16,7 @@ export class AuthService extends Effect.Service<AuthService>()(
   {
     effect: Effect.gen(function* () {
       const rolesService = yield* RolesService;
+      const tenantFeaturesService = yield* TenantFeaturesService;
       const trace = makeServiceTracer({
         serviceName: 'AuthService',
         module: 'auth',
@@ -30,7 +33,13 @@ export class AuthService extends Effect.Service<AuthService>()(
             session.user.id,
             tenant.tenantId,
           );
-          return toCurrentUserResponse(session, userPermissions, tenant);
+          const features = yield* tenantFeaturesService.getEffectiveFeatures(
+            tenant.tenantId,
+          );
+          return toCurrentUserResponse(session, userPermissions, tenant, {
+            planKey: PlanKey.FREE,
+            features,
+          });
         }),
       );
 
@@ -56,6 +65,6 @@ export class AuthService extends Effect.Service<AuthService>()(
         sessionClaims,
       };
     }),
-    dependencies: [RolesService.Default],
+    dependencies: [RolesService.Default, TenantFeaturesService.Default],
   },
 ) {}

--- a/src/effect/modules/superadmin/repository.integration.spec.ts
+++ b/src/effect/modules/superadmin/repository.integration.spec.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from 'node:crypto';
+import { Effect, Layer } from 'effect';
+import { DEFAULT_FEATURE_STATES, FeatureKey } from '@stocket/types/features';
+import {
+  organizations,
+  tenantDomains,
+  tenantFeatureOverrides,
+} from '../../platform/db/schema';
+import {
+  getTestDb,
+  makeTestDrizzleLayer,
+  withTestDb,
+} from '../../testing/test-harness';
+import { SuperAdminRepository } from './repository';
+
+withTestDb();
+
+const runRepository = <A, E>(
+  effect: Effect.Effect<A, E, SuperAdminRepository>,
+) =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(
+        SuperAdminRepository.Default.pipe(
+          Layer.provide(makeTestDrizzleLayer()),
+        ),
+      ),
+    ),
+  );
+
+describe('SuperAdminRepository tenant features', () => {
+  it('upserts non-default feature overrides and clears default-equivalent values', async () => {
+    const db = getTestDb();
+    const tenantId = randomUUID();
+
+    await db.insert(organizations).values({
+      id: tenantId,
+      name: 'Feature Tenant',
+      slug: `feature-${tenantId.slice(0, 8)}`,
+    });
+    await db.insert(tenantDomains).values({
+      tenant_id: tenantId,
+      hostname: `feature-${tenantId.slice(0, 8)}.localhost:3000`,
+      kind: 'subdomain',
+      is_primary: true,
+      verified_at: new Date(),
+    });
+
+    await runRepository(
+      Effect.flatMap(SuperAdminRepository, (repository) =>
+        repository.updateTenant({
+          tenantId,
+          name: 'Feature Tenant Updated',
+          features: {
+            ...DEFAULT_FEATURE_STATES,
+            [FeatureKey.SMART_IMPORT]: true,
+          },
+          updatedBy: 'superadmin-1',
+        }),
+      ),
+    );
+
+    const enabledOverrides = await db.select().from(tenantFeatureOverrides);
+
+    expect(enabledOverrides).toHaveLength(1);
+    expect(enabledOverrides[0]).toMatchObject({
+      tenant_id: tenantId,
+      feature_key: FeatureKey.SMART_IMPORT,
+      enabled: true,
+      updated_by: 'superadmin-1',
+    });
+
+    await runRepository(
+      Effect.flatMap(SuperAdminRepository, (repository) =>
+        repository.updateTenant({
+          tenantId,
+          name: 'Feature Tenant Updated Again',
+          features: DEFAULT_FEATURE_STATES,
+          updatedBy: 'superadmin-1',
+        }),
+      ),
+    );
+
+    const clearedOverrides = await db.select().from(tenantFeatureOverrides);
+
+    expect(clearedOverrides).toHaveLength(0);
+  });
+});

--- a/src/effect/modules/superadmin/repository.ts
+++ b/src/effect/modules/superadmin/repository.ts
@@ -1,6 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import { Effect } from 'effect';
 import { and, asc, eq, sql } from 'drizzle-orm';
+import {
+  DEFAULT_FEATURE_STATES,
+  type FeatureStates,
+} from '@stocket/types/features';
+import {
+  FEATURE_KEYS,
+  type TenantFeatureOverrideRow,
+} from '../../platform/tenancy/tenant-features';
 import { DrizzleDatabase } from '../../platform/db/drizzle';
 import {
   betterAuthUsers,
@@ -9,6 +17,7 @@ import {
   platformAuditEvents,
   rolePermissions,
   roles,
+  tenantFeatureOverrides,
   tenantDomains,
   userRoles,
 } from '../../platform/db/schema';
@@ -46,6 +55,13 @@ export interface CreateTenantInput {
   readonly adminUserId: string;
 }
 
+export interface UpdateTenantInput {
+  readonly tenantId: string;
+  readonly name: string;
+  readonly features: FeatureStates;
+  readonly updatedBy: string;
+}
+
 export interface PlatformAuditEventInput {
   readonly actorUserId: string;
   readonly action: string;
@@ -66,6 +82,11 @@ export interface CreatedTenantResult {
   readonly admin: {
     readonly id: string;
   };
+}
+
+export interface UpdatedTenantResult {
+  readonly tenant: TenantListRow;
+  readonly overrides: TenantFeatureOverrideRow[];
 }
 
 const rowsOf = <A>(result: unknown): A[] =>
@@ -125,6 +146,30 @@ export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()
             .orderBy(asc(organizations.created_at), asc(organizations.name));
 
           return rows;
+        });
+
+      const findTenantById = (tenantId: string) =>
+        tryAsync('find platform tenant', async () => {
+          const rows = await db
+            .select({
+              id: organizations.id,
+              name: organizations.name,
+              slug: organizations.slug,
+              primaryHostname: tenantDomains.hostname,
+              createdAt: organizations.created_at,
+            })
+            .from(organizations)
+            .leftJoin(
+              tenantDomains,
+              and(
+                eq(tenantDomains.tenant_id, organizations.id),
+                eq(tenantDomains.is_primary, true),
+              ),
+            )
+            .where(eq(organizations.id, tenantId))
+            .limit(1);
+
+          return rows[0] ?? null;
         });
 
       const tenantSlugExists = (slug: string) =>
@@ -206,7 +251,9 @@ export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()
             const adminRoleRows = await tx
               .select({ id: roles.id })
               .from(roles)
-              .where(and(eq(roles.tenant_id, tenantId), eq(roles.name, 'Admin')))
+              .where(
+                and(eq(roles.tenant_id, tenantId), eq(roles.name, 'Admin')),
+              )
               .limit(1);
 
             const adminRoleId = adminRoleRows[0]?.id;
@@ -234,6 +281,100 @@ export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()
           });
         });
 
+      const updateTenant = (input: UpdateTenantInput) =>
+        tryAsync('update tenant', async () =>
+          db.transaction(async (tx) => {
+            const now = new Date();
+            const [tenant] = await tx
+              .update(organizations)
+              .set({ name: input.name })
+              .where(eq(organizations.id, input.tenantId))
+              .returning({
+                id: organizations.id,
+                name: organizations.name,
+                slug: organizations.slug,
+                createdAt: organizations.created_at,
+              });
+
+            if (!tenant) {
+              return null;
+            }
+
+            for (const featureKey of FEATURE_KEYS) {
+              const enabled = input.features[featureKey];
+              const defaultEnabled = DEFAULT_FEATURE_STATES[featureKey];
+
+              if (enabled === defaultEnabled) {
+                await tx
+                  .delete(tenantFeatureOverrides)
+                  .where(
+                    and(
+                      eq(tenantFeatureOverrides.tenant_id, input.tenantId),
+                      eq(tenantFeatureOverrides.feature_key, featureKey),
+                    ),
+                  );
+                continue;
+              }
+
+              await tx
+                .insert(tenantFeatureOverrides)
+                .values({
+                  tenant_id: input.tenantId,
+                  feature_key: featureKey,
+                  enabled,
+                  expires_at: null,
+                  updated_at: now,
+                  updated_by: input.updatedBy,
+                })
+                .onConflictDoUpdate({
+                  target: [
+                    tenantFeatureOverrides.tenant_id,
+                    tenantFeatureOverrides.feature_key,
+                  ],
+                  set: {
+                    enabled,
+                    expires_at: null,
+                    updated_at: now,
+                    updated_by: input.updatedBy,
+                  },
+                });
+            }
+
+            const [primaryDomain] = await tx
+              .select({ hostname: tenantDomains.hostname })
+              .from(tenantDomains)
+              .where(
+                and(
+                  eq(tenantDomains.tenant_id, input.tenantId),
+                  eq(tenantDomains.is_primary, true),
+                ),
+              )
+              .limit(1);
+
+            const overrides = await tx
+              .select({
+                featureKey: tenantFeatureOverrides.feature_key,
+                enabled: tenantFeatureOverrides.enabled,
+                expiresAt: tenantFeatureOverrides.expires_at,
+                updatedAt: tenantFeatureOverrides.updated_at,
+                updatedBy: tenantFeatureOverrides.updated_by,
+              })
+              .from(tenantFeatureOverrides)
+              .where(eq(tenantFeatureOverrides.tenant_id, input.tenantId));
+
+            return {
+              tenant: {
+                id: tenant.id,
+                name: tenant.name,
+                slug: tenant.slug,
+                primaryHostname: primaryDomain?.hostname ?? null,
+                createdAt: tenant.createdAt,
+              },
+              overrides,
+            } satisfies UpdatedTenantResult;
+          }),
+        );
+
       const recordPlatformAuditEvent = (input: PlatformAuditEventInput) =>
         tryAsync('record platform audit event', async () => {
           await db.insert(platformAuditEvents).values({
@@ -251,9 +392,11 @@ export class SuperAdminRepository extends Effect.Service<SuperAdminRepository>()
         findSuperAdminUser,
         findBetterAuthUserByLoweredEmail,
         listTenants,
+        findTenantById,
         tenantSlugExists,
         tenantHostnameExists,
         createTenantWithAdmin,
+        updateTenant,
         recordPlatformAuditEvent,
       };
     }),

--- a/src/effect/modules/superadmin/router.ts
+++ b/src/effect/modules/superadmin/router.ts
@@ -1,12 +1,19 @@
 import { HttpRouter, HttpServerRequest } from '@effect/platform';
-import { Effect } from 'effect';
+import { Effect, Schema } from 'effect';
 import { requireSuperAdmin } from '../../platform/auth/authorization';
 import { BetterAuthHeaders } from '../../platform/auth/better-auth';
 import { respondJson } from '../../platform/http/errors';
 import { getRequestHeaders } from '../../platform/http/session';
-import { CreateSuperAdminTenantSchema } from '@stocket/types/superadmin';
+import {
+  CreateSuperAdminTenantSchema,
+  UpdateSuperAdminTenantSchema,
+} from '@stocket/types/superadmin';
 import { getRequestContext } from '../../platform/http/request-context';
 import { SuperAdminService } from './service';
+
+const TenantPathParamsSchema = Schema.Struct({
+  tenantId: Schema.UUID,
+});
 
 export const superAdminRouter = HttpRouter.empty.pipe(
   HttpRouter.get(
@@ -47,6 +54,41 @@ export const superAdminRouter = HttpRouter.empty.pipe(
           })
           .pipe(Effect.provideService(BetterAuthHeaders, requestHeaders)),
         { status: 201 },
+      );
+    }),
+  ),
+  HttpRouter.get(
+    '/tenants/:tenantId/features',
+    Effect.gen(function* () {
+      yield* requireSuperAdmin;
+      const { tenantId } = yield* HttpRouter.schemaPathParams(
+        TenantPathParamsSchema,
+      );
+      const superAdminService = yield* SuperAdminService;
+      return yield* respondJson(superAdminService.getTenantFeatures(tenantId));
+    }),
+  ),
+  HttpRouter.put(
+    '/tenants/:tenantId',
+    Effect.gen(function* () {
+      const session = yield* requireSuperAdmin;
+      const { tenantId } = yield* HttpRouter.schemaPathParams(
+        TenantPathParamsSchema,
+      );
+      const dto = yield* HttpServerRequest.schemaBodyJson(
+        UpdateSuperAdminTenantSchema,
+      );
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const requestContext = yield* getRequestContext;
+      const superAdminService = yield* SuperAdminService;
+      const userAgent = request.headers['user-agent'];
+
+      return yield* respondJson(
+        superAdminService.updateTenant(tenantId, dto, {
+          userId: session.user.id,
+          ipAddress: requestContext.ip,
+          userAgent: typeof userAgent === 'string' ? userAgent : null,
+        }),
       );
     }),
   ),

--- a/src/effect/modules/superadmin/service.spec.ts
+++ b/src/effect/modules/superadmin/service.spec.ts
@@ -1,5 +1,12 @@
 import { Effect, Layer } from 'effect';
+import {
+  DEFAULT_FEATURE_STATES,
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+} from '@stocket/types/features';
 import { BetterAuth, BetterAuthHeaders } from '../../platform/auth/better-auth';
+import { TenantFeaturesService } from '../../platform/tenancy/tenant-features';
 import { UsersRepository } from '../users/repository';
 import { SuperAdminRepository } from './repository';
 import { SuperAdminService } from './service';
@@ -45,12 +52,33 @@ describe('Effect SuperAdminService', () => {
   const makeRepository = () => ({
     tenantSlugExists: vi.fn().mockReturnValue(Effect.succeed(false)),
     tenantHostnameExists: vi.fn().mockReturnValue(Effect.succeed(false)),
-    findBetterAuthUserByLoweredEmail: vi.fn().mockReturnValue(
-      Effect.succeed(null),
+    findBetterAuthUserByLoweredEmail: vi
+      .fn()
+      .mockReturnValue(Effect.succeed(null)),
+    findTenantById: vi.fn().mockReturnValue(
+      Effect.succeed({
+        id: '00000000-0000-4000-8000-000000000101',
+        name: 'Acme France',
+        slug: 'acme',
+        primaryHostname: 'acme.localhost:3000',
+        createdAt: new Date('2026-06-22T10:00:00.000Z'),
+      }),
     ),
     createTenantWithAdmin: vi
       .fn()
       .mockReturnValue(Effect.succeed(createdTenant)),
+    updateTenant: vi.fn().mockReturnValue(
+      Effect.succeed({
+        tenant: {
+          id: '00000000-0000-4000-8000-000000000101',
+          name: 'Acme Updated',
+          slug: 'acme',
+          primaryHostname: 'acme.localhost:3000',
+          createdAt: new Date('2026-06-22T10:00:00.000Z'),
+        },
+        overrides: [],
+      }),
+    ),
     recordPlatformAuditEvent: vi.fn().mockReturnValue(Effect.void),
   });
 
@@ -67,13 +95,36 @@ describe('Effect SuperAdminService', () => {
     },
   });
 
+  const makeTenantFeatures = () => ({
+    listOverrides: vi.fn().mockReturnValue(Effect.succeed([])),
+    getEffectiveFeatures: vi
+      .fn()
+      .mockReturnValue(Effect.succeed(DEFAULT_FEATURE_STATES)),
+    getTenantFeatures: vi.fn().mockImplementation((tenantId: string) =>
+      Effect.succeed({
+        tenantId,
+        planKey: PlanKey.FREE,
+        source: EntitlementSource.MANUAL,
+        features: {
+          ...DEFAULT_FEATURE_STATES,
+          [FeatureKey.SMART_IMPORT]: true,
+        },
+        overrides: [],
+        updated_at: null,
+        updated_by: null,
+      }),
+    ),
+  });
+
   const makeServiceLayer = ({
     betterAuth,
     repository,
+    tenantFeatures,
     usersRepository,
   }: {
     betterAuth: unknown;
     repository: unknown;
+    tenantFeatures: unknown;
     usersRepository: unknown;
   }) =>
     SuperAdminService.DefaultWithoutDependencies.pipe(
@@ -87,6 +138,10 @@ describe('Effect SuperAdminService', () => {
           Layer.succeed(
             UsersRepository,
             usersRepository as typeof UsersRepository.Service,
+          ),
+          Layer.succeed(
+            TenantFeaturesService,
+            tenantFeatures as typeof TenantFeaturesService.Service,
           ),
         ),
       ),
@@ -119,9 +174,11 @@ describe('Effect SuperAdminService', () => {
     const betterAuth = makeBetterAuth();
     const repository = makeRepository();
     const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
     const layer = makeServiceLayer({
       betterAuth,
       repository,
+      tenantFeatures,
       usersRepository,
     });
 
@@ -153,7 +210,8 @@ describe('Effect SuperAdminService', () => {
     });
 
     await waitForCall(betterAuth.api.requestPasswordReset);
-    const welcomeRequest = betterAuth.api.requestPasswordReset.mock.calls[0]![0];
+    const welcomeRequest =
+      betterAuth.api.requestPasswordReset.mock.calls[0]![0];
     expect(welcomeRequest.body).toEqual({
       email: 'admin@example.com',
       redirectTo: 'https://acme.localhost:3000/reset-password?flow=welcome',
@@ -178,9 +236,11 @@ describe('Effect SuperAdminService', () => {
       }),
     );
     const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
     const layer = makeServiceLayer({
       betterAuth,
       repository,
+      tenantFeatures,
       usersRepository,
     });
 
@@ -197,6 +257,145 @@ describe('Effect SuperAdminService', () => {
       id: 'existing-admin-1',
       email: 'existing@example.com',
       name: 'Existing Admin',
+    });
+  });
+
+  it('returns tenant features for an existing tenant', async () => {
+    const betterAuth = makeBetterAuth();
+    const repository = makeRepository();
+    const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
+    const layer = makeServiceLayer({
+      betterAuth,
+      repository,
+      tenantFeatures,
+      usersRepository,
+    });
+
+    const result = await run(
+      Effect.flatMap(SuperAdminService, (service) =>
+        service.getTenantFeatures('00000000-0000-4000-8000-000000000101'),
+      ),
+      layer,
+    );
+
+    expect(repository.findTenantById).toHaveBeenCalledWith(
+      '00000000-0000-4000-8000-000000000101',
+    );
+    expect(tenantFeatures.getTenantFeatures).toHaveBeenCalledWith(
+      '00000000-0000-4000-8000-000000000101',
+    );
+    expect(result.features[FeatureKey.SMART_IMPORT]).toBe(true);
+  });
+
+  it('fails when reading features for an unknown tenant', async () => {
+    const betterAuth = makeBetterAuth();
+    const repository = makeRepository();
+    repository.findTenantById.mockReturnValue(Effect.succeed(null));
+    const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
+    const layer = makeServiceLayer({
+      betterAuth,
+      repository,
+      tenantFeatures,
+      usersRepository,
+    });
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        Effect.flatMap(SuperAdminService, (service) =>
+          service.getTenantFeatures('00000000-0000-4000-8000-000000000999'),
+        ),
+      ).pipe(Effect.provide(layer)),
+    );
+
+    expect(error).toMatchObject({
+      _tag: 'TenantNotFound',
+      tenantId: '00000000-0000-4000-8000-000000000999',
+      statusCode: 404,
+    });
+  });
+
+  it('updates tenant name and staged feature state atomically through the repository', async () => {
+    const betterAuth = makeBetterAuth();
+    const repository = makeRepository();
+    const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
+    const layer = makeServiceLayer({
+      betterAuth,
+      repository,
+      tenantFeatures,
+      usersRepository,
+    });
+
+    const features = {
+      ...DEFAULT_FEATURE_STATES,
+      [FeatureKey.SMART_IMPORT]: true,
+    };
+
+    const result = await run(
+      Effect.flatMap(SuperAdminService, (service) =>
+        service.updateTenant(
+          '00000000-0000-4000-8000-000000000101',
+          {
+            name: ' Acme Updated ',
+            features,
+          },
+          actor,
+        ),
+      ),
+      layer,
+    );
+
+    expect(repository.updateTenant).toHaveBeenCalledWith({
+      tenantId: '00000000-0000-4000-8000-000000000101',
+      name: 'Acme Updated',
+      features,
+      updatedBy: 'superadmin-1',
+    });
+    expect(result.features[FeatureKey.SMART_IMPORT]).toBe(true);
+
+    await waitForCall(repository.recordPlatformAuditEvent);
+    expect(repository.recordPlatformAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'tenant.update',
+        entityId: '00000000-0000-4000-8000-000000000101',
+      }),
+    );
+  });
+
+  it('fails when updating an unknown tenant', async () => {
+    const betterAuth = makeBetterAuth();
+    const repository = makeRepository();
+    repository.updateTenant.mockReturnValue(Effect.succeed(null));
+    const usersRepository = makeUsersRepository();
+    const tenantFeatures = makeTenantFeatures();
+    const layer = makeServiceLayer({
+      betterAuth,
+      repository,
+      tenantFeatures,
+      usersRepository,
+    });
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        Effect.flatMap(SuperAdminService, (service) =>
+          service.updateTenant(
+            '00000000-0000-4000-8000-000000000999',
+            {
+              name: 'Missing',
+              features: DEFAULT_FEATURE_STATES,
+            },
+            actor,
+          ),
+        ),
+      ).pipe(Effect.provide(layer)),
+    );
+
+    expect(error).toMatchObject({
+      _tag: 'TenantNotFound',
+      tenantId: '00000000-0000-4000-8000-000000000999',
+      statusCode: 404,
     });
   });
 });

--- a/src/effect/modules/superadmin/service.ts
+++ b/src/effect/modules/superadmin/service.ts
@@ -4,27 +4,30 @@ import type {
   SuperAdminCreateTenantResponse,
   SuperAdminMeResponse,
   SuperAdminTenantListResponse,
+  UpdateSuperAdminTenantInput,
 } from '@stocket/types/superadmin';
 import {
   hostnameForTenantSlug,
   isReservedTenantSlug,
   isValidTenantSlug,
 } from '../../platform/tenancy/host';
+import {
+  normalizeFeatureStates,
+  TenantFeaturesService,
+} from '../../platform/tenancy/tenant-features';
 import type { UserSession } from '../../platform/auth/user-session';
 import { makeServiceTracer } from '../../platform/observability/service-tracer';
 import { makeTryAsync } from '../../platform/effect/try-async';
 import { BetterAuth, BetterAuthHeaders } from '../../platform/auth/better-auth';
 import { type LogPayload } from '../../platform/observability/messages';
 import { UsersRepository } from '../users/repository';
-import {
-  tenantWelcomeOrigin,
-  welcomeRedirectUrl,
-} from '../users/users.utils';
+import { tenantWelcomeOrigin, welcomeRedirectUrl } from '../users/users.utils';
 import {
   InvalidTenantSlug,
   ReservedTenantSlug,
   SuperAdminRepositoryError,
   TenantHostnameAlreadyExists,
+  TenantNotFound,
   TenantSlugAlreadyExists,
 } from './superadmin.errors';
 import { SuperAdminRepository } from './repository';
@@ -94,6 +97,7 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
     effect: Effect.gen(function* () {
       const repository = yield* SuperAdminRepository;
       const usersRepository = yield* UsersRepository;
+      const tenantFeaturesService = yield* TenantFeaturesService;
       const betterAuth = yield* BetterAuth;
       const trace = makeServiceTracer({
         serviceName: 'SuperAdminService',
@@ -155,6 +159,78 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
               })),
             }) satisfies SuperAdminTenantListResponse,
         ),
+      );
+
+      const getTenantFeatures = trace.traced(
+        'getTenantFeatures',
+        (tenantId: string) =>
+          Effect.gen(function* () {
+            const tenant = yield* repository.findTenantById(tenantId);
+            if (!tenant) {
+              return yield* Effect.fail(
+                new TenantNotFound({
+                  tenantId,
+                  messageKey: 'superadmin.tenantNotFound',
+                }),
+              );
+            }
+
+            return yield* tenantFeaturesService.getTenantFeatures(tenantId);
+          }),
+        (tenantId) => ({ attributes: { entityId: tenantId } }),
+      );
+
+      const updateTenant = trace.traced(
+        'updateTenant',
+        (
+          tenantId: string,
+          input: UpdateSuperAdminTenantInput,
+          actor: {
+            readonly userId: string;
+            readonly ipAddress?: string | null;
+            readonly userAgent?: string | null;
+          },
+        ) =>
+          Effect.gen(function* () {
+            const name = input.name.trim();
+            const features = normalizeFeatureStates(input.features);
+            const updated = yield* repository.updateTenant({
+              tenantId,
+              name,
+              features,
+              updatedBy: actor.userId,
+            });
+
+            if (!updated) {
+              return yield* Effect.fail(
+                new TenantNotFound({
+                  tenantId,
+                  messageKey: 'superadmin.tenantNotFound',
+                }),
+              );
+            }
+
+            yield* Effect.forkDaemon(
+              repository
+                .recordPlatformAuditEvent({
+                  actorUserId: actor.userId,
+                  action: 'tenant.update',
+                  entityType: 'tenant',
+                  entityId: tenantId,
+                  metadata: {
+                    name: updated.tenant.name,
+                    slug: updated.tenant.slug,
+                    features,
+                  },
+                  ipAddress: actor.ipAddress ?? null,
+                  userAgent: actor.userAgent ?? null,
+                })
+                .pipe(Effect.ignore),
+            );
+
+            return yield* tenantFeaturesService.getTenantFeatures(tenantId);
+          }),
+        (tenantId) => ({ attributes: { entityId: tenantId } }),
       );
 
       const createTenant = trace.traced(
@@ -299,9 +375,15 @@ export class SuperAdminService extends Effect.Service<SuperAdminService>()(
       return {
         me,
         listTenants,
+        getTenantFeatures,
+        updateTenant,
         createTenant,
       };
     }),
-    dependencies: [SuperAdminRepository.Default, UsersRepository.Default],
+    dependencies: [
+      SuperAdminRepository.Default,
+      UsersRepository.Default,
+      TenantFeaturesService.Default,
+    ],
   },
 ) {}

--- a/src/effect/modules/superadmin/superadmin.errors.ts
+++ b/src/effect/modules/superadmin/superadmin.errors.ts
@@ -2,6 +2,7 @@ import {
   BadRequestError,
   ConflictError,
   InternalError,
+  NotFoundError,
 } from '../../platform/effect/domain-errors';
 
 export class InvalidTenantSlug extends BadRequestError('InvalidTenantSlug')<{
@@ -22,6 +23,10 @@ export class TenantHostnameAlreadyExists extends ConflictError(
   'TenantHostnameAlreadyExists',
 )<{
   readonly hostname: string;
+}> {}
+
+export class TenantNotFound extends NotFoundError('TenantNotFound')<{
+  readonly tenantId: string;
 }> {}
 
 export class SuperAdminRepositoryError extends InternalError(

--- a/src/effect/platform/catalogs/de.ts
+++ b/src/effect/platform/catalogs/de.ts
@@ -21,6 +21,8 @@ export const deCatalog: Record<MessageKey, string> = {
     'Die Anforderung der Willkommens-E-Mail ist fehlgeschlagen.',
   'tenant.membershipRejected':
     'Der aktive Tenant ist fuer diesen Benutzer nicht verfuegbar.',
+  'tenantFeatures.repositoryFailed':
+    'Der Tenant-Feature-Vorgang ist fehlgeschlagen.',
   'tenant.notResolved':
     'Fuer diese Anfrage konnte kein aktiver Tenant ermittelt werden.',
   'tenant.hostNotFound': 'Tenant-Host nicht gefunden.',
@@ -162,6 +164,7 @@ export const deCatalog: Record<MessageKey, string> = {
     'Die Superadmin-Autorisierung ist fehlgeschlagen.',
   'superadmin.repositoryFailed': 'Der Superadmin-Vorgang ist fehlgeschlagen.',
   'superadmin.reservedTenantSlug': 'Der Tenant-Slug ist reserviert.',
+  'superadmin.tenantNotFound': 'Tenant nicht gefunden.',
   'superadmin.tenantHostnameAlreadyExists':
     'Ein Tenant mit diesem Hostnamen existiert bereits.',
   'superadmin.tenantSlugAlreadyExists':

--- a/src/effect/platform/catalogs/en.ts
+++ b/src/effect/platform/catalogs/en.ts
@@ -18,6 +18,7 @@ export const enCatalog = {
   'email.welcomeRequestFailed': 'Failed to request the welcome email.',
   'tenant.membershipRejected':
     'The active tenant is not available for this user.',
+  'tenantFeatures.repositoryFailed': 'Tenant feature operation failed.',
   'tenant.notResolved': 'No active tenant could be resolved for this request.',
   'tenant.hostNotFound': 'Tenant host not found.',
   'branding.repositoryFailed': 'Branding operation failed.',
@@ -132,6 +133,7 @@ export const enCatalog = {
   'superadmin.infrastructureFailed': 'Superadmin authorization failed.',
   'superadmin.repositoryFailed': 'Superadmin operation failed.',
   'superadmin.reservedTenantSlug': 'Tenant slug is reserved.',
+  'superadmin.tenantNotFound': 'Tenant not found.',
   'superadmin.tenantHostnameAlreadyExists':
     'A tenant with this hostname already exists.',
   'superadmin.tenantSlugAlreadyExists':

--- a/src/effect/platform/catalogs/fr.ts
+++ b/src/effect/platform/catalogs/fr.ts
@@ -20,6 +20,8 @@ export const frCatalog: Record<MessageKey, string> = {
   'email.welcomeRequestFailed': "La demande d'e-mail de bienvenue a echoue.",
   'tenant.membershipRejected':
     "Le tenant actif n'est pas disponible pour cet utilisateur.",
+  'tenantFeatures.repositoryFailed':
+    "L'operation sur les fonctionnalites du tenant a echoue.",
   'tenant.notResolved':
     'Aucun tenant actif na pu etre resolu pour cette requete.',
   'tenant.hostNotFound': 'Hote tenant introuvable.',
@@ -151,6 +153,7 @@ export const frCatalog: Record<MessageKey, string> = {
   'superadmin.infrastructureFailed': "L'autorisation superadmin a echoue.",
   'superadmin.repositoryFailed': "L'operation superadmin a echoue.",
   'superadmin.reservedTenantSlug': 'Le slug tenant est reserve.',
+  'superadmin.tenantNotFound': 'Tenant introuvable.',
   'superadmin.tenantHostnameAlreadyExists':
     'Un tenant avec cet hote existe deja.',
   'superadmin.tenantSlugAlreadyExists': 'Un tenant avec ce slug existe deja.',

--- a/src/effect/platform/db/schema.ts
+++ b/src/effect/platform/db/schema.ts
@@ -107,7 +107,9 @@ export const betterAuthUsers = pgTable(
   {
     // Better Auth still generates UUID values, but the app stores user ids as
     // text because local RBAC tables and audit logs use opaque auth ids.
-    id: text('id').primaryKey().default(sql`gen_random_uuid()`),
+    id: text('id')
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
     name: text('name').notNull(),
     email: text('email').notNull(),
     email_verified: boolean('email_verified').notNull().default(false),
@@ -252,6 +254,29 @@ export const superAdmins = pgTable('super_admins', {
     .notNull()
     .defaultNow(),
 });
+
+export const tenantFeatureOverrides = pgTable(
+  'tenant_feature_overrides',
+  {
+    tenant_id: uuid('tenant_id')
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    feature_key: varchar('feature_key', { length: 100 }).notNull(),
+    enabled: boolean('enabled').notNull(),
+    expires_at: timestamp('expires_at', { withTimezone: true }),
+    updated_at: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updated_by: text('updated_by'),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.tenant_id, table.feature_key],
+      name: 'tenant_feature_overrides_tenant_id_feature_key_pk',
+    }),
+    index('tenant_feature_overrides_tenant_id_idx').on(table.tenant_id),
+  ],
+);
 
 export const platformAuditEvents = pgTable(
   'platform_audit_events',

--- a/src/effect/platform/tenancy/tenant-features.ts
+++ b/src/effect/platform/tenancy/tenant-features.ts
@@ -1,0 +1,148 @@
+import { Effect } from 'effect';
+import { desc, eq } from 'drizzle-orm';
+import {
+  DEFAULT_FEATURE_STATES,
+  EntitlementSource,
+  FeatureKey,
+  PlanKey,
+  type FeatureStates,
+  type TenantFeatureOverrideResponseDto,
+  type TenantFeaturesResponseDto,
+} from '@stocket/types/features';
+import { DrizzleDatabase } from '../db/drizzle';
+import { tenantFeatureOverrides } from '../db/schema';
+import { InternalError } from '../effect/domain-errors';
+
+export class TenantFeaturesRepositoryError extends InternalError(
+  'TenantFeaturesRepositoryError',
+)<{
+  readonly action: string;
+  readonly cause?: unknown;
+}> {}
+
+export interface TenantFeatureOverrideRow {
+  readonly featureKey: string;
+  readonly enabled: boolean;
+  readonly expiresAt: Date | null;
+  readonly updatedAt: Date;
+  readonly updatedBy: string | null;
+}
+
+export const FEATURE_KEYS = Object.values(FeatureKey) as FeatureKey[];
+
+const isFeatureKey = (value: string): value is FeatureKey =>
+  FEATURE_KEYS.includes(value as FeatureKey);
+
+export const normalizeFeatureStates = (
+  features: Partial<FeatureStates> | null | undefined,
+): FeatureStates => ({
+  ...DEFAULT_FEATURE_STATES,
+  ...(features ?? {}),
+});
+
+export const resolveFeatureStates = (
+  overrides: ReadonlyArray<TenantFeatureOverrideRow>,
+  now = new Date(),
+): FeatureStates => {
+  const features = normalizeFeatureStates(undefined);
+
+  for (const override of overrides) {
+    if (!isFeatureKey(override.featureKey)) {
+      continue;
+    }
+    if (override.expiresAt && override.expiresAt <= now) {
+      continue;
+    }
+    features[override.featureKey] = override.enabled;
+  }
+
+  return features;
+};
+
+const toOverrideDto = (
+  row: TenantFeatureOverrideRow,
+): TenantFeatureOverrideResponseDto => ({
+  featureKey: row.featureKey as FeatureKey,
+  enabled: row.enabled,
+  reason: null,
+  expires_at: row.expiresAt,
+  updated_at: row.updatedAt,
+  updated_by: row.updatedBy,
+});
+
+const latestOverride = (
+  overrides: ReadonlyArray<TenantFeatureOverrideRow>,
+): TenantFeatureOverrideRow | null =>
+  overrides.reduce<TenantFeatureOverrideRow | null>(
+    (latest, override) =>
+      latest === null || override.updatedAt > latest.updatedAt
+        ? override
+        : latest,
+    null,
+  );
+
+export class TenantFeaturesService extends Effect.Service<TenantFeaturesService>()(
+  '@stocket/effect/tenancy/TenantFeaturesService',
+  {
+    effect: Effect.gen(function* () {
+      const db = yield* DrizzleDatabase;
+
+      const listOverrides = (tenantId: string) =>
+        Effect.tryPromise({
+          try: async () =>
+            await db
+              .select({
+                featureKey: tenantFeatureOverrides.feature_key,
+                enabled: tenantFeatureOverrides.enabled,
+                expiresAt: tenantFeatureOverrides.expires_at,
+                updatedAt: tenantFeatureOverrides.updated_at,
+                updatedBy: tenantFeatureOverrides.updated_by,
+              })
+              .from(tenantFeatureOverrides)
+              .where(eq(tenantFeatureOverrides.tenant_id, tenantId))
+              .orderBy(desc(tenantFeatureOverrides.updated_at)),
+          catch: (cause) =>
+            new TenantFeaturesRepositoryError({
+              action: 'list tenant feature overrides',
+              cause,
+              messageKey: 'tenantFeatures.repositoryFailed',
+            }),
+        });
+
+      const getEffectiveFeatures = (tenantId: string) =>
+        Effect.map(listOverrides(tenantId), (rows) =>
+          resolveFeatureStates(rows),
+        );
+
+      const getTenantFeatures = (tenantId: string) =>
+        Effect.map(listOverrides(tenantId), (rows) => {
+          const now = new Date();
+          const latest = latestOverride(rows);
+          const activeOverrides = rows.filter(
+            (row) => !row.expiresAt || row.expiresAt > now,
+          );
+
+          return {
+            tenantId,
+            planKey: PlanKey.FREE,
+            source:
+              activeOverrides.length > 0
+                ? EntitlementSource.MANUAL
+                : EntitlementSource.SYSTEM,
+            features: resolveFeatureStates(rows, now),
+            overrides: rows
+              .filter((row) => isFeatureKey(row.featureKey))
+              .map(toOverrideDto),
+            updated_at: latest?.updatedAt ?? null,
+            updated_by: latest?.updatedBy ?? null,
+          } satisfies TenantFeaturesResponseDto;
+        });
+
+      return {
+        listOverrides,
+        getEffectiveFeatures,
+        getTenantFeatures,
+      };
+    }),
+  },
+) {}

--- a/src/effect/platform/testing/tenant-features.spec.ts
+++ b/src/effect/platform/testing/tenant-features.spec.ts
@@ -1,0 +1,42 @@
+import { DEFAULT_FEATURE_STATES, FeatureKey } from '@stocket/types/features';
+import { resolveFeatureStates } from '../tenancy/tenant-features';
+
+describe('tenant feature resolution', () => {
+  it('returns shared defaults with no overrides', () => {
+    expect(resolveFeatureStates([])).toEqual(DEFAULT_FEATURE_STATES);
+  });
+
+  it('applies active overrides by feature key', () => {
+    expect(
+      resolveFeatureStates([
+        {
+          featureKey: FeatureKey.SMART_IMPORT,
+          enabled: true,
+          expiresAt: null,
+          updatedAt: new Date('2026-06-22T10:00:00.000Z'),
+          updatedBy: 'superadmin-1',
+        },
+      ]),
+    ).toEqual({
+      ...DEFAULT_FEATURE_STATES,
+      [FeatureKey.SMART_IMPORT]: true,
+    });
+  });
+
+  it('ignores expired overrides', () => {
+    expect(
+      resolveFeatureStates(
+        [
+          {
+            featureKey: FeatureKey.ORDERS,
+            enabled: false,
+            expiresAt: new Date('2026-06-21T10:00:00.000Z'),
+            updatedAt: new Date('2026-06-20T10:00:00.000Z'),
+            updatedBy: 'superadmin-1',
+          },
+        ],
+        new Date('2026-06-22T10:00:00.000Z'),
+      ),
+    ).toEqual(DEFAULT_FEATURE_STATES);
+  });
+});


### PR DESCRIPTION
## What changed

- Added `tenant_feature_overrides` persistence keyed by `(tenant_id, feature_key)`.
- Added a tenant feature resolver service that applies shared defaults plus active manual overrides.
- Added superadmin endpoints for fetching tenant features and saving staged tenant name/features in one transaction.
- Updated `/auth/me` to include `planKey: FREE` and effective tenant `features`.
- Added backend coverage for the resolver, auth mapper/service output, superadmin service flow, and transactional override reconciliation.

## Why

Feature access needs to be managed per tenant from the platform superadmin flow, while keeping billing/plan logic out of v1.

## Stack

This PR is part of the tenant feature toggles slice and targets `codex/sortly-onboarding-import`.

Related PRs:

- Shared types: https://github.com/stocketfr/packages/pull/22
- Frontend: https://github.com/stocketfr/frontend/pull/43

## Validation

- `./node_modules/.bin/vitest run src/effect/platform/testing/tenant-features.spec.ts src/effect/modules/auth/mappers.spec.ts src/effect/modules/auth/service.spec.ts src/effect/modules/superadmin/service.spec.ts`
- `./node_modules/.bin/vitest run --config vitest.integration.config.ts src/effect/modules/superadmin/repository.integration.spec.ts`
- `./node_modules/.bin/vitest run --config vitest.integration.config.ts src/effect/modules/auth/service.integration.spec.ts`
- `./node_modules/.bin/tsc --noEmit`
